### PR TITLE
feat: add password field to server list

### DIFF
--- a/Code/server/Services/ServerListService.h
+++ b/Code/server/Services/ServerListService.h
@@ -34,7 +34,8 @@ private:
         uint16_t aPlayerCount, 
         uint16_t aPlayerMaxCount, 
         String acTagList,
-        bool aPublic) noexcept;
+        bool aPublic,
+        bool aPassword) noexcept;
 
     World& m_world;
 


### PR DESCRIPTION
This PR fixes password protected not announcing their status to the server list and not able to get listed.

- [x] Server list "pass" added to post /announce and to the json list.
- [x] Game server fills the "pass" field when posting.  
- [ ] Client UI reflecting the change to do.
- [ ] Server list service needs to be updated on kubernetes.