### PR TITLE
Fix healing hands not working

### DIFF
--- a/Code/client/Services/Generic/MagicService.cpp
+++ b/Code/client/Services/Generic/MagicService.cpp
@@ -71,7 +71,8 @@ void MagicService::OnSpellCastEvent(const SpellCastEvent& acEvent) const noexcep
     // only sync concentration spells through spell cast sync, the rest through projectile sync for accuracy
     if (SpellItem* pSpell = Cast<SpellItem>(TESForm::GetById(acEvent.SpellId)))
     {
-        if (pSpell->eCastingType != MagicSystem::CastingType::CONCENTRATION &&
+        if ((pSpell->eCastingType != MagicSystem::CastingType::CONCENTRATION ||
+             pSpell->IsHealingSpell()) &&
             !pSpell->IsWardSpell() &&
             !pSpell->IsInvisibilitySpell())
         {
@@ -313,7 +314,8 @@ void MagicService::OnAddTargetEvent(const AddTargetEvent& acEvent) noexcept
     // These effects are applied through spell cast sync
     if (SpellItem* pSpellItem = Cast<SpellItem>(TESForm::GetById(acEvent.SpellID)))
     {
-        if (pSpellItem->eCastingType == MagicSystem::CastingType::CONCENTRATION || 
+        if ((pSpellItem->eCastingType == MagicSystem::CastingType::CONCENTRATION && 
+             !pSpellItem->IsHealingSpell()) || 
             pSpellItem->IsWardSpell() ||
             pSpellItem->IsInvisibilitySpell())
         {


### PR DESCRIPTION
Related to issue #225 . Healing hands is a concentration spell, which were all cancelled through magic effect sync. This should in theory fix it. Has to be tested still, but if it doesn't work, these changes are harmless, so it can be merged.