### PR TITLE
Potential fix for actors not dying

### DIFF
--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -538,9 +538,14 @@ void Actor::Kill() noexcept
     if (pExtension->IsPlayer())
         return;
 
-    PAPYRUS_FUNCTION(void, Actor, Kill, void*);
+    // TODO: these args are kind of bogus of course
+    KillImpl(nullptr, 100.f, true, true);
 
+    // Papyrus kill will not go through if it is queued by a kill move
+    /*
+    PAPYRUS_FUNCTION(void, Actor, Kill, void*);
     s_pKill(this, NULL);
+    */
 }
 
 void Actor::Reset() noexcept

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -146,7 +146,7 @@ struct Actor : TESObjectREFR
     virtual void sub_10B();
     virtual void sub_10C();
     virtual void sub_10D();
-    virtual void sub_10E();
+    virtual void KillImpl(Actor* apAttacker, float aDamage, bool aSendEvent, bool aRagdollInstant);
     virtual void sub_10F();
     virtual void sub_110();
     virtual void sub_111();


### PR DESCRIPTION
This should get closer to the problem. This code bypasses the queued kill that seems to happen whenever a killcam is involved, and just forcefully kills the actor. Needs to be tested, will do with the internal test team.