### PR TITLE
Quest item re-appearing in inventory after dropping it

### DIFF
--- a/Code/client/Games/Skyrim/TESObjectREFR.cpp
+++ b/Code/client/Games/Skyrim/TESObjectREFR.cpp
@@ -481,11 +481,11 @@ void TESObjectREFR::SetInventory(const Inventory& aInventory) noexcept
     for (const Inventory::Entry& entry : aInventory.Entries)
     {
         if (entry.Count != 0)
-            AddOrRemoveItem(entry);
+            AddOrRemoveItem(entry, true);
     }
 }
 
-void TESObjectREFR::AddOrRemoveItem(const Inventory::Entry& arEntry) noexcept
+void TESObjectREFR::AddOrRemoveItem(const Inventory::Entry& arEntry, bool aIsSettingInventory) noexcept
 {
     ModSystem& modSystem = World::Get().GetModSystem();
 
@@ -526,7 +526,7 @@ void TESObjectREFR::AddOrRemoveItem(const Inventory::Entry& arEntry) noexcept
 
     // TODO(cosideci): this is still flawed. Adding the refr to the quest leader is hard.
     // It is still recommended that the quest leader loots all quest items.
-    if (arEntry.IsQuestItem && arEntry.Count > 0)
+    if (arEntry.IsQuestItem && arEntry.Count > 0 && !aIsSettingInventory)
     {
         PlayerCharacter* pPlayer = PlayerCharacter::Get();
 

--- a/Code/client/Games/Skyrim/TESObjectREFR.h
+++ b/Code/client/Games/Skyrim/TESObjectREFR.h
@@ -199,7 +199,7 @@ struct TESObjectREFR : TESForm
     bool IsItemInInventory(uint32_t aFormID) const noexcept;
 
     void SetInventory(const Inventory& acContainer) noexcept;
-    void AddOrRemoveItem(const Inventory::Entry& arEntry) noexcept;
+    void AddOrRemoveItem(const Inventory::Entry& arEntry, bool aIsSettingInventory = false) noexcept;
     void UpdateItemList(TESForm* pUnkForm) noexcept;
 
     BSHandleRefObject handleRefObject;


### PR DESCRIPTION
When dropping a duped quest item, and the party leader joined your cell again, the SetInventory() function would re-add the quest item. This PR contains a check that only adds a quest item if that person were present to receive it at the time of the party leader looting it.