### PR TITLE
Fix for hotkeys in favorites menu not working

### DIFF
--- a/Code/client/Games/Skyrim/Interface/UI.cpp
+++ b/Code/client/Games/Skyrim/Interface/UI.cpp
@@ -132,6 +132,11 @@ static TiltedPhoques::Initializer s_s([]() {
     VersionDbPtr<uint8_t> MainInit(36548);
     TiltedPhoques::Put<uint8_t>(MainInit.Get() + 0xFE, 0xEB);
 
+    // Credits to Skyrim Souls RE for this fix.
+    // Allows the favorites menu to be numbered during connect.
+    VersionDbPtr<uint8_t> FavoritesCanProcess(51538);
+    TiltedPhoques::Put<uint16_t>(FavoritesCanProcess.Get() + 0x15, 0x9090);
+
     // Some experiments:
     // POINTER_SKYRIMSE(TCallback, s_start, 13631);
     // UIMessageQueue__AddMessage_Real = s_start.Get();


### PR DESCRIPTION
Can't take credit for this fix, pretty much entirely taken from Skyrim Soulse RE: https://github.com/Vermunds/SkyrimSoulsRE/blob/master/src/Menus/FavoritesMenuEx.cpp#L42