### PR TITLE
Sync random encounters

### DIFF
--- a/Code/client/Games/Skyrim/Forms/TESNPC.h
+++ b/Code/client/Games/Skyrim/Forms/TESNPC.h
@@ -20,6 +20,16 @@ struct TESNPC : TESActorBase
 
     static TESNPC* Create(const String& acBuffer, uint32_t aChangeFlags) noexcept;
 
+    TESNPC* GetTemplateBase() const noexcept
+    {
+        TESNPC* pTemplate = npcTemplate;
+
+        while (pTemplate && pTemplate->IsTemporary())
+            pTemplate = pTemplate->npcTemplate;
+
+        return pTemplate;
+    }
+
     struct FaceMorphs
     {
         float option[19];

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -209,30 +209,10 @@ void DebugService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
             if (pActor)
             {
                 TESNPC* pBase = Cast<TESNPC>(pActor->baseForm);
-                TESNPC* pTemplate = pBase->npcTemplate;
-                while (pTemplate && pTemplate->IsTemporary())
-                {
-                    //spdlog::info("Template: {:X}", pTemplate->formID);
-                    pTemplate = pTemplate->npcTemplate;
-                }
-
-                TESNPC* pNpc = Cast<TESNPC>(pTemplate);
-                auto pNewActor = Actor::Create(pNpc);
+                TESNPC* pTemplate = pBase->GetTemplateBase();
+                auto pNewActor = Actor::Create(pTemplate);
                 pNewActor->SetActorInventory(pActor->GetActorInventory());
             }
-
-            /*
-            auto pArguments = CefListValue::Create();
-
-            auto pPlayerIds = CefListValue::Create();
-            for (int i = 0; i < 5; i++)
-                pPlayerIds->SetInt(i, i);
-            pPlayerIds->SetString(5, "hello");
-
-            pArguments->SetList(0, pPlayerIds);
-
-            m_world.GetOverlayService().GetOverlayApp()->ExecuteAsync("dummyData", pArguments);
-            */
         }
     }
     else

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -205,6 +205,22 @@ void DebugService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
 
             m_world.GetOverlayService().Reload();
 
+            Actor* pActor = Cast<Actor>(TESForm::GetById(m_formId));
+            if (pActor)
+            {
+                TESNPC* pBase = Cast<TESNPC>(pActor->baseForm);
+                TESNPC* pTemplate = pBase->npcTemplate;
+                while (pTemplate && pTemplate->IsTemporary())
+                {
+                    //spdlog::info("Template: {:X}", pTemplate->formID);
+                    pTemplate = pTemplate->npcTemplate;
+                }
+
+                TESNPC* pNpc = Cast<TESNPC>(pTemplate);
+                auto pNewActor = Actor::Create(pNpc);
+                pNewActor->SetActorInventory(pActor->GetActorInventory());
+            }
+
             /*
             auto pArguments = CefListValue::Create();
 

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -204,15 +204,6 @@ void DebugService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
             s_f8Pressed = true;
 
             m_world.GetOverlayService().Reload();
-
-            Actor* pActor = Cast<Actor>(TESForm::GetById(m_formId));
-            if (pActor)
-            {
-                TESNPC* pBase = Cast<TESNPC>(pActor->baseForm);
-                TESNPC* pTemplate = pBase->GetTemplateBase();
-                auto pNewActor = Actor::Create(pTemplate);
-                pNewActor->SetActorInventory(pActor->GetActorInventory());
-            }
         }
     }
     else

--- a/Code/client/Services/Generic/PartyService.cpp
+++ b/Code/client/Services/Generic/PartyService.cpp
@@ -151,10 +151,10 @@ void PartyService::OnPartyLeft(const NotifyPartyLeft& acPartyLeft) noexcept
     spdlog::debug("[PartyService]: Left party");
 
     // TODO: this can be done a bit prettier
-    if (!World::Get().GetTransport().IsConnected())
+    if (World::Get().GetTransport().IsConnected())
     {
         TESGlobal* pWorldEncountersEnabled = Cast<TESGlobal>(TESForm::GetById(0xB8EC1));
-        pWorldEncountersEnabled->f = 1.f;
+        pWorldEncountersEnabled->f = 0.f;
     }
 
     m_world.GetOverlayService().GetOverlayApp()->ExecuteAsync("partyLeft");

--- a/Code/client/Services/Generic/PartyService.cpp
+++ b/Code/client/Services/Generic/PartyService.cpp
@@ -19,6 +19,8 @@
 
 #include <OverlayApp.hpp>
 
+#include <Forms/TESGlobal.h>
+
 PartyService::PartyService(World& aWorld, entt::dispatcher& aDispatcher, TransportService& aTransportService) noexcept
     : m_world(aWorld), m_transport(aTransportService)
 {
@@ -113,6 +115,13 @@ void PartyService::OnPartyInfo(const NotifyPartyInfo& acPartyInfo) noexcept
         m_leaderPlayerId = acPartyInfo.LeaderPlayerId;
         m_partyMembers = acPartyInfo.PlayerIds;
 
+        // TODO: this can be done a bit prettier
+        if (m_isLeader)
+        {
+            TESGlobal* pWorldEncountersEnabled = Cast<TESGlobal>(TESForm::GetById(0xB8EC1));
+            pWorldEncountersEnabled->f = 1.f;
+        }
+
         auto pArguments = CefListValue::Create();
 
         auto pPlayerIds = CefListValue::Create();
@@ -141,6 +150,13 @@ void PartyService::OnPartyLeft(const NotifyPartyLeft& acPartyLeft) noexcept
 {
     spdlog::debug("[PartyService]: Left party");
 
+    // TODO: this can be done a bit prettier
+    if (!World::Get().GetTransport().IsConnected())
+    {
+        TESGlobal* pWorldEncountersEnabled = Cast<TESGlobal>(TESForm::GetById(0xB8EC1));
+        pWorldEncountersEnabled->f = 1.f;
+    }
+
     m_world.GetOverlayService().GetOverlayApp()->ExecuteAsync("partyLeft");
 
     DestroyParty();
@@ -154,6 +170,13 @@ void PartyService::OnPartyJoined(const NotifyPartyJoined& acPartyJoined) noexcep
     m_isLeader = acPartyJoined.IsLeader;
     m_leaderPlayerId = acPartyJoined.LeaderPlayerId;
     m_partyMembers = acPartyJoined.PlayerIds;
+
+    // TODO: this can be done a bit prettier
+    if (m_isLeader)
+    {
+        TESGlobal* pWorldEncountersEnabled = Cast<TESGlobal>(TESForm::GetById(0xB8EC1));
+        pWorldEncountersEnabled->f = 1.f;
+    }
 
     // Takes ownership of all actors
     if (m_isLeader)

--- a/Code/client/Services/Generic/PlayerService.cpp
+++ b/Code/client/Services/Generic/PlayerService.cpp
@@ -60,6 +60,9 @@ void PlayerService::OnConnected(const ConnectedEvent& acEvent) noexcept
     // TODO: SkyrimTogether.esm
     TESGlobal* pKillMove = Cast<TESGlobal>(TESForm::GetById(0x100F19));
     pKillMove->f = 0.f;
+
+    TESGlobal* pWorldEncountersEnabled = Cast<TESGlobal>(TESForm::GetById(0xB8EC1));
+    pWorldEncountersEnabled->f = 0.f;
 }
 
 void PlayerService::OnDisconnected(const DisconnectedEvent& acEvent) noexcept
@@ -73,6 +76,9 @@ void PlayerService::OnDisconnected(const DisconnectedEvent& acEvent) noexcept
 
     TESGlobal* pKillMove = Cast<TESGlobal>(TESForm::GetById(0x100F19));
     pKillMove->f = 1.f;
+
+    TESGlobal* pWorldEncountersEnabled = Cast<TESGlobal>(TESForm::GetById(0xB8EC1));
+    pWorldEncountersEnabled->f = 1.f;
 }
 
 void PlayerService::OnServerSettingsReceived(const ServerSettings& acSettings) noexcept


### PR DESCRIPTION
Random encounters that were previously invisible, should now be visible. They also won't duplicate. You must be in a party to get random encounters. The client of the party leader spawns the encounters in. Some random encounters might still occasionally have differences in the type of npc, like seeing an orc woman instead of a human man, or a skeever instead of a wolf. Regardless, they should at least spawn now.