### PR TITLE
feat: Teleport chat command

### DIFF
--- a/Code/skyrim_ui/src/app/services/player-list.service.ts
+++ b/Code/skyrim_ui/src/app/services/player-list.service.ts
@@ -173,6 +173,12 @@ export class PlayerListService {
     return this.getPlayerList().players.find(player => player.id === playerId);
   }
 
+  public getPlayerByName(playerName: string): Player | undefined {
+    // will match a player named "stål" if you type "stal".
+    const isNameSimilar = (name: string) => playerName.localeCompare(name, "en", {sensitivity: "base"}) === 0
+    return this.getPlayerList().players.find((player) => isNameSimilar(player.name))
+  }
+
   public resetHasBeenInvitedFlags() {
     const playerList = this.getPlayerList();
 


### PR DESCRIPTION
Lets you use `/teleport PLAYER_NAME` in chat to teleport to a player. Player name is case-insensitive and only compares base letters, e.g. typing in "jorgen" will match a player named "Jørgen". Also supports spaces.

Planning to implement rest the chat features requested in Issue #110 at a later date.