### PR TITLE
Add config option for player home / NoCellReset sync

### DIFF
--- a/Code/client/Services/Generic/ObjectService.cpp
+++ b/Code/client/Services/Generic/ObjectService.cpp
@@ -96,7 +96,7 @@ void ObjectService::OnCellChange(const CellChangeEvent& acEvent) noexcept
 
     // Player homes should not be synced, so that chest contents,
     // which are often used as storage, are never accidentally wiped.
-    if (IsPlayerHome(pCell) && !World::Get().GetServerSettings().SyncPlayerHomes)
+    if (!World::Get().GetServerSettings().SyncPlayerHomes && IsPlayerHome(pCell))
         return;
 
     GameId cellId{};

--- a/Code/client/Services/Generic/ObjectService.cpp
+++ b/Code/client/Services/Generic/ObjectService.cpp
@@ -96,7 +96,7 @@ void ObjectService::OnCellChange(const CellChangeEvent& acEvent) noexcept
 
     // Player homes should not be synced, so that chest contents,
     // which are often used as storage, are never accidentally wiped.
-    if (IsPlayerHome(pCell))
+    if (IsPlayerHome(pCell) && !World::Get().GetServerSettings().SyncPlayerHomes)
         return;
 
     GameId cellId{};

--- a/Code/encoding/Structs/ServerSettings.cpp
+++ b/Code/encoding/Structs/ServerSettings.cpp
@@ -18,6 +18,7 @@ void ServerSettings::Serialize(TiltedPhoques::Buffer::Writer& aWriter) const noe
     Serialization::WriteVarInt(aWriter, Difficulty);
     Serialization::WriteBool(aWriter, GreetingsEnabled);
     Serialization::WriteBool(aWriter, PvpEnabled);
+    Serialization::WriteBool(aWriter, SyncPlayerHomes);
 }
 
 void ServerSettings::Deserialize(TiltedPhoques::Buffer::Reader& aReader) noexcept
@@ -25,5 +26,6 @@ void ServerSettings::Deserialize(TiltedPhoques::Buffer::Reader& aReader) noexcep
     Difficulty = Serialization::ReadVarInt(aReader) & 0xFFFFFFFF;
     GreetingsEnabled = Serialization::ReadBool(aReader);
     PvpEnabled = Serialization::ReadBool(aReader);
+    SyncPlayerHomes = Serialization::ReadBool(aReader);
 }
 

--- a/Code/encoding/Structs/ServerSettings.h
+++ b/Code/encoding/Structs/ServerSettings.h
@@ -15,4 +15,5 @@ struct ServerSettings
     uint32_t Difficulty{};
     bool GreetingsEnabled{};
     bool PvpEnabled{};
+    bool SyncPlayerHomes{};
 };

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -37,7 +37,7 @@ Console::StringSetting sPassword{"GameServer:sPassword", "Server password", ""};
 Console::Setting uDifficulty{"Gameplay:uDifficulty", "In game difficulty (0 to 5)", 4u};
 Console::Setting bEnableGreetings{"Gameplay:bEnableGreetings", "Enables NPC greetings (disabled by default since they can be spammy with dialogue sync)", false};
 Console::Setting bEnablePvp{"Gameplay:bEnablePvp", "Enables pvp", false};
-Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes", "Sync player homes and other NoResetZones", false};
+Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes", "Sync chests and displays in player homes and other NoResetZones", false};
 
 // ModPolicy Stuff
 Console::Setting bEnableModCheck{"ModPolicy:bEnableModCheck", "Bypass the checking of mods on the server", false,

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -37,7 +37,7 @@ Console::StringSetting sPassword{"GameServer:sPassword", "Server password", ""};
 Console::Setting uDifficulty{"Gameplay:uDifficulty", "In game difficulty (0 to 5)", 4u};
 Console::Setting bEnableGreetings{"Gameplay:bEnableGreetings", "Enables NPC greetings (disabled by default since they can be spammy with dialogue sync)", false};
 Console::Setting bEnablePvp{"Gameplay:bEnablePvp", "Enables pvp", false};
-Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes", "Sync player homes and other NoResetZones", false};
+Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes", "Sync player homes and other NoResetZones", true};
 
 // ModPolicy Stuff
 Console::Setting bEnableModCheck{"ModPolicy:bEnableModCheck", "Bypass the checking of mods on the server", false,

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -26,6 +26,7 @@ namespace
 // -- Cvars --
 Console::Setting uServerPort{"GameServer:uPort", "Which port to host the server on", 10578u};
 Console::Setting bPremiumTickrate{"GameServer:bPremiumMode", "Use premium tick rate", true};
+
 Console::StringSetting sServerName{"GameServer:sServerName", "Name that shows up in the server list",
                                    "Dedicated Together Server"};
 //Console::StringSetting sAdminPassword{"GameServer:sAdminPassword", "Admin authentication password", ""};
@@ -36,6 +37,7 @@ Console::StringSetting sPassword{"GameServer:sPassword", "Server password", ""};
 Console::Setting uDifficulty{"Gameplay:uDifficulty", "In game difficulty (0 to 5)", 4u};
 Console::Setting bEnableGreetings{"Gameplay:bEnableGreetings", "Enables NPC greetings (disabled by default since they can be spammy with dialogue sync)", false};
 Console::Setting bEnablePvp{"Gameplay:bEnablePvp", "Enables pvp", false};
+Console::Setting bSyncPlayerHomes{"GameServer:bSyncPlayerHomes", "Sync player homes and other NoResetZones", false};
 
 // ModPolicy Stuff
 Console::Setting bEnableModCheck{"ModPolicy:bEnableModCheck", "Bypass the checking of mods on the server", false,
@@ -626,6 +628,7 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
         serverResponse.Settings.Difficulty = uDifficulty.value_as<uint8_t>();
         serverResponse.Settings.GreetingsEnabled = bEnableGreetings;
         serverResponse.Settings.PvpEnabled = bEnablePvp;
+        serverResponse.Settings.SyncPlayerHomes = bSyncPlayerHomes;
 
         serverResponse.Type = AuthenticationResponse::ResponseType::kAccepted;
         Send(aConnectionId, serverResponse);

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -37,7 +37,7 @@ Console::StringSetting sPassword{"GameServer:sPassword", "Server password", ""};
 Console::Setting uDifficulty{"Gameplay:uDifficulty", "In game difficulty (0 to 5)", 4u};
 Console::Setting bEnableGreetings{"Gameplay:bEnableGreetings", "Enables NPC greetings (disabled by default since they can be spammy with dialogue sync)", false};
 Console::Setting bEnablePvp{"Gameplay:bEnablePvp", "Enables pvp", false};
-Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes", "Sync player homes and other NoResetZones", true};
+Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes", "Sync player homes and other NoResetZones", false};
 
 // ModPolicy Stuff
 Console::Setting bEnableModCheck{"ModPolicy:bEnableModCheck", "Bypass the checking of mods on the server", false,

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -37,7 +37,7 @@ Console::StringSetting sPassword{"GameServer:sPassword", "Server password", ""};
 Console::Setting uDifficulty{"Gameplay:uDifficulty", "In game difficulty (0 to 5)", 4u};
 Console::Setting bEnableGreetings{"Gameplay:bEnableGreetings", "Enables NPC greetings (disabled by default since they can be spammy with dialogue sync)", false};
 Console::Setting bEnablePvp{"Gameplay:bEnablePvp", "Enables pvp", false};
-Console::Setting bSyncPlayerHomes{"GameServer:bSyncPlayerHomes", "Sync player homes and other NoResetZones", false};
+Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes", "Sync player homes and other NoResetZones", false};
 
 // ModPolicy Stuff
 Console::Setting bEnableModCheck{"ModPolicy:bEnableModCheck", "Bypass the checking of mods on the server", false,


### PR DESCRIPTION
For most players, leaving player home sync disabled is fine. However, some players might prefer to have their home base synced for various reasons. 

This adds a new config variable, `bSyncPlayerHomes`, defaulting to `false`, which toggles whether player homes are synced.

Legacy of the Dragonborn is one such example - it has it's own player home, but contains functionality that depends on the contents of several chests within the home. As such, a player might want to re-enable sync if they want to play with it.

This fixes #308!