### PR TITLE
Fix: Health Bar Overflow

### DIFF
--- a/Code/client/Services/Generic/OverlayService.cpp
+++ b/Code/client/Services/Generic/OverlayService.cpp
@@ -102,6 +102,8 @@ float CalculateHealthPercentage(Actor* apActor) noexcept
     float percentage = health / maxHealth * 100.f;
     if (percentage < 0.f)
         percentage = 0.f;
+	if (percentage > 100.f)
+		percentage = 100.f;
 
     return percentage;
 }


### PR DESCRIPTION
Fix for health bars overflowing past the UI.
This simply clamps the value to 100% so that it does not overflow. Numbers over 100% are ignored and treated as 100%
If max health is 100
Player has 150 health this will read 100% until player is under 100 (max health)
Player has 35 health this will read 35%

2nd time's the charm...?