### PR TITLE
Reduced player Health and Magicka on Respawn

### DIFF
--- a/Code/client/Services/Generic/PlayerService.cpp
+++ b/Code/client/Services/Generic/PlayerService.cpp
@@ -235,6 +235,15 @@ void PlayerService::RunPostDeathUpdates(const double acDeltaTime) noexcept
         {
             PlayerCharacter::SetGodMode(false);
 
+            PlayerCharacter* pPlayer = PlayerCharacter::Get();
+            
+            // A little punishment for dying to prevent respawn rushing
+            // Should this multiplier be a server var?
+            float spawnHealth = pPlayer->GetActorPermanentValue(ActorValueInfo::kHealth) * 0.1f;
+            float spawnMagicka = pPlayer->GetActorPermanentValue(ActorValueInfo::kMagicka) * 0.1f;
+            pPlayer->ForceActorValue(ActorValueOwner::ForceMode::DAMAGE, ActorValueInfo::kHealth, spawnHealth);
+            pPlayer->ForceActorValue(ActorValueOwner::ForceMode::DAMAGE, ActorValueInfo::kMagicka, spawnMagicka);
+
             godmodeStart = false;
         }
     }

--- a/Code/client/Services/Generic/PlayerService.cpp
+++ b/Code/client/Services/Generic/PlayerService.cpp
@@ -238,11 +238,11 @@ void PlayerService::RunPostDeathUpdates(const double acDeltaTime) noexcept
             PlayerCharacter* pPlayer = PlayerCharacter::Get();
             
             // A little punishment for dying to prevent respawn rushing
-            // Should this multiplier be a server var?
-            float spawnHealth = pPlayer->GetActorPermanentValue(ActorValueInfo::kHealth) * 0.1f;
-            float spawnMagicka = pPlayer->GetActorPermanentValue(ActorValueInfo::kMagicka) * 0.1f;
-            pPlayer->ForceActorValue(ActorValueOwner::ForceMode::DAMAGE, ActorValueInfo::kHealth, spawnHealth);
-            pPlayer->ForceActorValue(ActorValueOwner::ForceMode::DAMAGE, ActorValueInfo::kMagicka, spawnMagicka);
+            float respawnFactor = World::Get().GetServerSettings().HealthAndMagickaOnRespawnFactor;
+            float health = pPlayer->GetActorPermanentValue(ActorValueInfo::kHealth) * respawnFactor;
+            float magicka = pPlayer->GetActorPermanentValue(ActorValueInfo::kMagicka) * respawnFactor;
+            pPlayer->ForceActorValue(ActorValueOwner::ForceMode::DAMAGE, ActorValueInfo::kHealth, health);
+            pPlayer->ForceActorValue(ActorValueOwner::ForceMode::DAMAGE, ActorValueInfo::kMagicka, magicka);
 
             godmodeStart = false;
         }

--- a/Code/encoding/Structs/ServerSettings.cpp
+++ b/Code/encoding/Structs/ServerSettings.cpp
@@ -18,6 +18,7 @@ void ServerSettings::Serialize(TiltedPhoques::Buffer::Writer& aWriter) const noe
     Serialization::WriteVarInt(aWriter, Difficulty);
     Serialization::WriteBool(aWriter, GreetingsEnabled);
     Serialization::WriteBool(aWriter, PvpEnabled);
+    Serialization::WriteFloat(aWriter, HealthAndMagickaOnRespawnFactor);
 }
 
 void ServerSettings::Deserialize(TiltedPhoques::Buffer::Reader& aReader) noexcept
@@ -25,5 +26,6 @@ void ServerSettings::Deserialize(TiltedPhoques::Buffer::Reader& aReader) noexcep
     Difficulty = Serialization::ReadVarInt(aReader) & 0xFFFFFFFF;
     GreetingsEnabled = Serialization::ReadBool(aReader);
     PvpEnabled = Serialization::ReadBool(aReader);
+    HealthAndMagickaOnRespawnFactor = Serialization::ReadFloat(aReader);
 }
 

--- a/Code/encoding/Structs/ServerSettings.h
+++ b/Code/encoding/Structs/ServerSettings.h
@@ -15,4 +15,5 @@ struct ServerSettings
     uint32_t Difficulty{};
     bool GreetingsEnabled{};
     bool PvpEnabled{};
+    float HealthAndMagickaOnRespawnFactor{};
 };

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -116,7 +116,7 @@ GameServer::GameServer(Console::ConsoleRegistry& aConsole) noexcept
         spdlog::warn("Health and Magicka respawn factor is invalid (should be from 0.1 to 1, current value is {}), setting to {}.",
                      healthAndMagickaOnRespawnFactor, newFactor);
 
-        fHealthAndMagickaOnRespawnFactor = healthAndMagickaOnRespawnFactor;
+        fHealthAndMagickaOnRespawnFactor = newFactor;
     }
 
     m_isPasswordProtected = strcmp(sPassword.value(), "") != 0;


### PR DESCRIPTION
Drops the player down to 10% health and magicka after exiting god mode during respawn.
Could help reduce respawn zerg rushing somewhat and get players to retreat and regroup instead.

Is this worth making into a server variable?  