### PR TITLE
Add popup notifications for group invites

### DIFF
--- a/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.html
+++ b/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.html
@@ -1,6 +1,6 @@
 <div class="notification-popup" [@fadeInOut]="isActive" (click)="clickNotification()">
   <div *ngIf="notification && notification.message">
-    <div class="friendavatar" [ngStyle]="{ 'background-image': 'url(' + notification.player.avatar + ')' }"></div>
+    <div *ngIf="notification.player && notification.player.avatar" class="friendavatar" [ngStyle]="{ 'background-image': 'url(' + notification.player.avatar + ')' }"></div>
     <div *ngIf="isConnected" class="friendstatus" [class.online]="notification.player && notification.player!.online"></div>
     <div class="text-connection-popup">{{notification.message}}</div>
   </div>

--- a/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.ts
+++ b/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.ts
@@ -58,16 +58,11 @@ export class NotificationPopupComponent implements OnInit {
   private activate(event: KeyboardEvent): void {
     // Just for deskop
     if (!environment.game) {
-      this.notification = {
-        message: 'test notif',
-        player: new Player({
-          name: 'Dumbeldor',
-          online: true,
-          avatar: 'https://skyrim-together.com/images/float/avatars/random3.jpg',
-        }),
-        type: NotificationType.Connection,
-      };
-      this.isActive = !this.isActive;
+      this.popupNotificationService.setMessage('test notif', NotificationType.Connection, new Player({
+        name: 'Dumbeldor',
+        online: true,
+        avatar: 'https://avatars.dicebear.com/api/adventurer/john-skyrim.svg',
+      }));
     }
   }
 

--- a/Code/skyrim_ui/src/app/services/player-list.service.ts
+++ b/Code/skyrim_ui/src/app/services/player-list.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { Player } from '../models/player';
 import { PlayerList } from '../models/player-list';
-import { NotificationType } from '../models/popup-notification';
 import { ClientService } from './client.service';
 import { PopupNotificationService } from './popup-notification.service';
 
@@ -119,7 +118,7 @@ export class PlayerListService {
         const invitingPlayer = this.getPlayerById(inviterId)
         invitingPlayer.hasInvitedLocalPlayer = true;
         
-        this.notificationService.setMessage(`${invitingPlayer.name} has invited you to a party.`, NotificationType.Invitation, invitingPlayer)
+        this.notificationService.setPartyInviteMessage(invitingPlayer);
 
         this.playerList.next(playerList);
       }

--- a/Code/skyrim_ui/src/app/services/player-list.service.ts
+++ b/Code/skyrim_ui/src/app/services/player-list.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { Player } from '../models/player';
 import { PlayerList } from '../models/player-list';
+import { NotificationType } from '../models/popup-notification';
 import { ClientService } from './client.service';
+import { PopupNotificationService } from './popup-notification.service';
 
 
 @Injectable({
@@ -24,6 +26,7 @@ export class PlayerListService {
 
   constructor(
     private clientService: ClientService,
+    private notificationService: PopupNotificationService
   ) {
     this.onDebug();
     this.onConnectionStateChanged();
@@ -109,11 +112,14 @@ export class PlayerListService {
   }
 
   private onPartyInviteReceived() {
-    this.partyInviteReceivedSubscription = this.clientService.partyInviteReceivedChange.subscribe((inviterId: number) => {
+   this.partyInviteReceivedSubscription = this.clientService.partyInviteReceivedChange.subscribe((inviterId: number) => {
       const playerList = this.getPlayerList();
 
       if (playerList) {
-        this.getPlayerById(inviterId).hasInvitedLocalPlayer = true;
+        const invitingPlayer = this.getPlayerById(inviterId)
+        invitingPlayer.hasInvitedLocalPlayer = true;
+        
+        this.notificationService.setMessage(`${invitingPlayer.name} has invited you to a party.`, NotificationType.Invitation, invitingPlayer)
 
         this.playerList.next(playerList);
       }

--- a/Code/skyrim_ui/src/app/services/popup-notification.service.ts
+++ b/Code/skyrim_ui/src/app/services/popup-notification.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Observable, Subject, Subscription, timer } from 'rxjs';
+import { TranslocoService } from '@ngneat/transloco';
+import { firstValueFrom, Observable, Subject, Subscription, timer } from 'rxjs';
 import { Player } from '../models/player';
 import { NotificationType, PopupNotification } from '../models/popup-notification';
 import { Sound, SoundService } from './sound.service';
@@ -15,6 +16,7 @@ export class PopupNotificationService implements OnDestroy {
 
   constructor(
     private readonly soundService: SoundService,
+    private readonly translocoService: TranslocoService
   ) {
   }
 
@@ -26,6 +28,14 @@ export class PopupNotificationService implements OnDestroy {
 
   public get message(): Observable<PopupNotification> {
     return this.messageSubject.asObservable();
+  }
+
+  public async setPartyInviteMessage(invitingPlayer: Player) {
+    const msg = await firstValueFrom(
+      this.translocoService.selectTranslate<string>('COMPONENT.NOTIFICATIONS.INVITE', 
+      { name: invitingPlayer.name}),
+    );
+    this.setMessage(msg, NotificationType.Invitation, invitingPlayer);
   }
 
   public setMessage(msg: string, typeNotification: NotificationType, player?: Player) {

--- a/Code/skyrim_ui/src/app/services/popup-notification.service.ts
+++ b/Code/skyrim_ui/src/app/services/popup-notification.service.ts
@@ -40,12 +40,12 @@ export class PopupNotificationService implements OnDestroy {
     const source = timer(3000);
 
     this.timerSubscription = source.subscribe(() => {
-      this.messageSubject.next({ message: '', type: NotificationType.Connection, player: undefined });
+      this.clearMessage();
     });
   }
 
   public clearMessage() {
-    this.messageSubject.next({ message: '' });
+    this.messageSubject.next({ message: '', type: NotificationType.Connection, player: undefined });
   }
 
 }

--- a/Code/skyrim_ui/src/assets/i18n/en.json
+++ b/Code/skyrim_ui/src/assets/i18n/en.json
@@ -38,7 +38,8 @@
       "OK": "Ok"
     },
     "NOTIFICATIONS": {
-      "MESSAGE_FROM": "Message from"
+      "MESSAGE_FROM": "Message from",
+      "INVITE": "{{name}} has invited you to a party"
     },
     "PARTY_MENU": {
       "ACCEPT_INVITE": "Accept invite from {{name}}",


### PR DESCRIPTION
When you are invited to a party, a notification will now appear to the bottom right. Most of the functionality behind already existed in the code but it's now been enabled. The text can be translated.

Clicking on the notification will accept the party invite. This was already implemented to I left it as is. Could be improved with an "Accept" and a "Decline" button.

As requested by issue #281 