### PR TITLE
Fix: duplicated loot

### DIFF
--- a/Code/client/Services/Generic/ActorValueService.cpp
+++ b/Code/client/Services/Generic/ActorValueService.cpp
@@ -299,7 +299,7 @@ void ActorValueService::OnHealthChangeBroadcast(const NotifyHealthChangeBroadcas
     pActor->ForceActorValue(ActorValueOwner::ForceMode::DAMAGE, ActorValueInfo::kHealth, newHealth);
 
     const float health = pActor->GetActorValue(ActorValueInfo::kHealth);
-    if (health <= 0.f)
+    if (!pActor->IsDead() && health <= 0.f)
     {
         ActorExtension* pExtension = pActor->GetExtension();
         // Players should never be killed


### PR DESCRIPTION
This should fix the issue where enemies had way too much loot on their bodies, like a dragon having 300 dragon bones. The Kill() function was called every time the health decreased below 0, which it keeps doing even when it dies. When Kill() is called, it generates loot. This was especially noticeable with spells like Flames, where there were a lot of damage decreases. Should fix #233 .