### PR TITLE
Scroll through sent chat messages with the arrow keys

### DIFF
--- a/Code/skyrim_ui/src/app/components/chat/chat.component.ts
+++ b/Code/skyrim_ui/src/app/components/chat/chat.component.ts
@@ -5,7 +5,7 @@ import { environment } from '../../../environments/environment';
 import { ClientService, Message } from '../../services/client.service';
 import { DestroyService } from '../../services/destroy.service';
 import { Sound, SoundService } from '../../services/sound.service';
-
+import { MessageHistory } from './message-history';
 
 interface ChatMessage extends Message {
   date: number;
@@ -31,8 +31,7 @@ export class ChatComponent implements AfterViewChecked {
 
   private scrollBack = 0;
 
-  private history: string[] = [];
-  private currentHistoryIndex = 0;
+  private history = new MessageHistory();
 
   private get maxScroll(): number {
     return this.logRef.nativeElement.scrollHeight - this.logRef.nativeElement.clientHeight;
@@ -117,10 +116,7 @@ export class ChatComponent implements AfterViewChecked {
       this.client.sendMessage(this.message);
       this.sound.play(Sound.Focus);
 
-      if (this.message !== this.history[this.currentHistoryIndex]) {
-        this.history.push(this.message);
-        this.currentHistoryIndex += 1;
-      }
+      this.history.push(this.message)
 
       this.message = '';
     }
@@ -153,10 +149,7 @@ export class ChatComponent implements AfterViewChecked {
     event.preventDefault();
     event.stopPropagation();
 
-    if (this.currentHistoryIndex !== 0) {
-      this.currentHistoryIndex -= 1;
-      this.message = this.history[this.currentHistoryIndex];
-    }   
+    this.message = this.history.prev(this.message)
   }
 
   @HostListener('keydown.ArrowDown', ['$event'])
@@ -164,13 +157,7 @@ export class ChatComponent implements AfterViewChecked {
     event.preventDefault();
     event.stopPropagation();
 
-    if (this.currentHistoryIndex === this.history.length) {
-      this.message = ''
-      
-    } else if (this.currentHistoryIndex <= this.history.length) {
-      this.currentHistoryIndex += 1;
-      this.message = this.history[this.currentHistoryIndex];
-    }
+    this.message = this.history.next()
   }
 
 }

--- a/Code/skyrim_ui/src/app/components/chat/chat.component.ts
+++ b/Code/skyrim_ui/src/app/components/chat/chat.component.ts
@@ -31,7 +31,7 @@ export class ChatComponent implements AfterViewChecked {
 
   private scrollBack = 0;
 
-  private history = new MessageHistory();
+  private history = new MessageHistory({maxHistoryLength: 50});
 
   private get maxScroll(): number {
     return this.logRef.nativeElement.scrollHeight - this.logRef.nativeElement.clientHeight;

--- a/Code/skyrim_ui/src/app/components/chat/message-history.ts
+++ b/Code/skyrim_ui/src/app/components/chat/message-history.ts
@@ -11,9 +11,7 @@ export class MessageHistory {
   }
 
   public push(newMsg: string) {
-    const isNewMessageDifferent = newMsg != this.stack[this.offset];
-
-    if (isNewMessageDifferent) {
+    if (newMsg != this.stack[this.offset]) {
       const stackExceedsMaxLength = this.stack.length > this.maxHistoryLength;
       if (stackExceedsMaxLength) {
         this.stack.shift();

--- a/Code/skyrim_ui/src/app/components/chat/message-history.ts
+++ b/Code/skyrim_ui/src/app/components/chat/message-history.ts
@@ -3,15 +3,23 @@ export class MessageHistory {
   
   private stack: string[] = [];
   private offset = 0;
+  /** When the history exeeds this number, the first item will be removed */
+  private maxHistoryLength: number;
 
-  constructor() {
+  constructor({maxHistoryLength}) {
+    this.maxHistoryLength = maxHistoryLength;
   }
 
   public push(newMsg: string) {
     const isNewMessageDifferent = newMsg != this.stack[this.offset];
 
     if (isNewMessageDifferent) {
-      this.stack.push(newMsg);  
+      const stackExceedsMaxLength = this.stack.length > this.maxHistoryLength;
+      if (stackExceedsMaxLength) {
+        this.stack.shift();
+      }
+
+      this.stack.push(newMsg);
     }
 
     this.offset = this.stack.length;

--- a/Code/skyrim_ui/src/app/components/chat/message-history.ts
+++ b/Code/skyrim_ui/src/app/components/chat/message-history.ts
@@ -1,0 +1,52 @@
+/** Helper for storing sent message history */
+export class MessageHistory {
+  
+  private stack: string[] = [];
+  private offset = 0;
+
+  constructor() {
+  }
+
+  public push(newMsg: string) {
+    const isNewMessageDifferent = newMsg != this.stack[this.offset];
+
+    if (isNewMessageDifferent) {
+      this.stack.push(newMsg);  
+    }
+
+    this.offset = this.stack.length;
+  }
+
+  /**
+   * @param fallback used if there is no history yet
+   */
+  public prev(fallback: string): string {
+    this.offset -= 1;
+
+    const isHistotyEmpty = this.stack.length === 0;
+    if(isHistotyEmpty) {
+      this.offset = 0;
+      return fallback;
+    }
+
+    const isOffsetTooLow = this.offset < 0;
+    if(isOffsetTooLow) {
+      this.offset = 0;
+      return this.stack[this.offset];
+    }
+
+    return this.stack[this.offset];
+  }
+
+  public next(): string {
+    this.offset += 1;
+
+    const isOffsetTooHigh = this.offset > this.stack.length - 1;
+    if (isOffsetTooHigh) {
+      this.offset = this.stack.length;
+      return '';
+    }
+
+    return this.stack[this.offset];
+  }
+}


### PR DESCRIPTION
Use the up and down arrows to scroll through your sent chat messages/commands so you can easily repeat them. Inspired by the functionality in CMD and BASH.

example:
- type in and send message "/tp player"
- hit the up arrow key and enter to send the same command again.

Needs cleaning before it's merged, but I'd like to check in if anyone is working on something similar or for comments before spending too much time on it.