### PR TITLE
Fix: Health Overflow Proper

### DIFF
--- a/Code/client/Services/Generic/OverlayService.cpp
+++ b/Code/client/Services/Generic/OverlayService.cpp
@@ -102,8 +102,6 @@ float CalculateHealthPercentage(Actor* apActor) noexcept
     float percentage = health / maxHealth * 100.f;
     if (percentage < 0.f)
         percentage = 0.f;
-	if (percentage > 100.f)
-		percentage = 100.f;
 
     return percentage;
 }

--- a/Code/client/Services/Generic/OverlayService.cpp
+++ b/Code/client/Services/Generic/OverlayService.cpp
@@ -94,12 +94,13 @@ String GetCellName(const GameId& aWorldSpaceId, const GameId& aCellId) noexcept
 float CalculateHealthPercentage(Actor* apActor) noexcept
 {
     const float maxHealth = apActor->GetActorPermanentValue(ActorValueInfo::kHealth);
+    const float tempModHealth = apActor->healthModifiers.temporaryModifier;
+
     if (maxHealth == 0.f)
         return 0.f;
-
     const float health = apActor->GetActorValue(ActorValueInfo::kHealth);
 
-    float percentage = health / maxHealth * 100.f;
+    float percentage = health / (maxHealth + tempModHealth) * 100.f;
     if (percentage < 0.f)
         percentage = 0.f;
 

--- a/Code/client/Services/Generic/OverlayService.cpp
+++ b/Code/client/Services/Generic/OverlayService.cpp
@@ -102,6 +102,8 @@ float CalculateHealthPercentage(Actor* apActor) noexcept
     float percentage = health / maxHealth * 100.f;
     if (percentage < 0.f)
         percentage = 0.f;
+	if (percentage > 100.f)
+		percentage = 100.f;
 
     return percentage;
 }


### PR DESCRIPTION
This is an actual fix for the overflowing of health in the health bar.
This fixes the overflow of health on the health bar caused by temporary boosts to health