### PR TITLE
Let UI handle connect/disconnect messages

### DIFF
--- a/Code/client/Services/Generic/OverlayService.cpp
+++ b/Code/client/Services/Generic/OverlayService.cpp
@@ -283,7 +283,6 @@ void OverlayService::OnUpdate(const UpdateEvent&) noexcept
 void OverlayService::OnConnectedEvent(const ConnectedEvent& acEvent) noexcept
 {
     m_pOverlay->ExecuteAsync("connect");
-    SendSystemMessage("Successfully connected to server");
 
     auto pArguments = CefListValue::Create();
     pArguments->SetInt(0, acEvent.PlayerId);
@@ -293,7 +292,6 @@ void OverlayService::OnConnectedEvent(const ConnectedEvent& acEvent) noexcept
 void OverlayService::OnDisconnectedEvent(const DisconnectedEvent&) noexcept
 {
     m_pOverlay->ExecuteAsync("disconnect");
-    SendSystemMessage("Disconnected from server");
 }
 
 void OverlayService::OnWaitingFor3DRemoved(entt::registry& aRegistry, entt::entity aEntity) const noexcept

--- a/Code/skyrim_ui/src/app/services/client.service.ts
+++ b/Code/skyrim_ui/src/app/services/client.service.ts
@@ -439,10 +439,17 @@ export class ClientService implements OnDestroy {
    * Called when a connection is made.
    */
   private onConnect(): void {
-    this.zone.run(() => {
+    this.zone.run(async () => {
       this._remainingReconnectionAttempt = environment.nbReconnectionAttempts;
       this.isConnectionInProgressChange.next(false);
       this.connectionStateChange.next(true);
+
+      const content = await firstValueFrom(
+        this.translocoService.selectTranslate<string>(
+          'SERVICE.CLIENT.CONNECTED'
+        )
+      );
+      this.messageReception.next({ content });
     });
   }
 
@@ -465,6 +472,13 @@ export class ClientService implements OnDestroy {
         );
         this.messageReception.next({ content });
         this.connect(this._host, this._port, this._password);
+      } else {
+        const content = await firstValueFrom(
+          this.translocoService.selectTranslate<string>(
+            'SERVICE.CLIENT.DISCONNECTED'
+          )
+        );
+        this.messageReception.next({ content });
       }
     });
   }

--- a/Code/skyrim_ui/src/assets/i18n/en.json
+++ b/Code/skyrim_ui/src/assets/i18n/en.json
@@ -126,7 +126,9 @@
   },
   "SERVICE": {
     "CLIENT": {
-      "CONNECTION_LOST": "Connection lost, trying to reconnect. {{remainingReconnectionAttempt } attempts left."
+      "CONNECTION_LOST": "Connection lost, trying to reconnect. {{remainingReconnectionAttempt } attempts left.",
+      "CONNECTED": "Successfully connected to server.",
+      "DISCONNECTED": "Disconnected from server."
     },
     "GROUP": {
       "LEVEL_UP": "{{name}} has reached level {{level}}.",


### PR DESCRIPTION
Currently the Client sends a system message with  "successfully connnected/disconnected" whenever you connect to or disconnect from a server. These strings are hardcoded in the Client and cannot be translated. Displaying information should left to the UI, not the client.  This also makes it easy for the UI to later change how the messages should look, such as using a popup notification.