### PR TITLE
Fix beastform

### DIFF
--- a/Code/client/Games/Misc/BSScript.cpp
+++ b/Code/client/Games/Misc/BSScript.cpp
@@ -26,6 +26,8 @@ void TP_MAKE_THISCALL(HookRegisterPapyrusFunction, BSScript::IVirtualMachine, Na
     ThisCall(RealRegisterPapyrusFunction, apThis, apFunction);
 }
 
+// This is a neat hack, but it has been disabled since it messes up other things like beastform.
+// These kinds of issues should be solved with custom scripts now that we have SkyrimTogether.esp anyway.
 int64_t TP_MAKE_THISCALL(HookCompareVariables, void, BSScript::Variable* apVar1, BSScript::Variable* apVar2)
 {
     BSScript::Object* pObject1 = apVar1->GetObject();
@@ -77,11 +79,11 @@ static TiltedPhoques::Initializer s_vmHooks([]()
     POINTER_SKYRIMSE(TRegisterPapyrusFunction, s_registerPapyrusFunction, 104788);
     POINTER_FALLOUT4(TRegisterPapyrusFunction, s_registerPapyrusFunction, 0x1427338A0 - 0x140000000);
 
-    POINTER_SKYRIMSE(TCompareVariables, s_compareVariables, 105220);
+    //POINTER_SKYRIMSE(TCompareVariables, s_compareVariables, 105220);
 
     RealRegisterPapyrusFunction = s_registerPapyrusFunction.Get();
-    RealCompareVariables = s_compareVariables.Get();
+    //RealCompareVariables = s_compareVariables.Get();
 
     TP_HOOK(&RealRegisterPapyrusFunction, HookRegisterPapyrusFunction);
-    TP_HOOK(&RealCompareVariables, HookCompareVariables);
+    //TP_HOOK(&RealCompareVariables, HookCompareVariables);
 });


### PR DESCRIPTION
Other players in the area should now not transform when one player transforms into a werewolf or vampire lord. Certain things may break now, like the dragon claw door, but it is a relatively small trade off, and this door script should be modified through SkyrimTogether.esp anyway.