### PR TITLE
CI: Add automatic docker builds

### DIFF
--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -1,0 +1,42 @@
+name: Build docker builder
+
+on: workflow_dispatch
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            tiltedphoques/builder
+          tags: |
+            type=raw,value=latest
+            type=ref,event=branch
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push 
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile.builder
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,97 @@
+name: Build docker
+
+on:
+  push:
+    branches:
+      - "master"
+      - "dev"
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        targets:
+          [
+            { arch: "x86_64", platform: "linux/amd64", build_dir: "x86_64" },
+            { arch: "aarch64", platform: "linux/arm64", build_dir: "arm64-v8a" },
+          ]
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            tiltedphoques/st-reborn-server
+          flavor: |
+            suffix=-${{ matrix.targets.arch }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.targets.platform }}
+        uses: docker/build-push-action@v3
+        with:
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
+            arch=${{ matrix.targets.arch }}
+            build_dir=${{ matrix.targets.build_dir }}
+          platforms: ${{ matrix.targets.platform }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  manifest:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            tiltedphoques/st-reborn-server
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          set -x
+          tags="${{ steps.meta.outputs.tags }}"
+          tags="${tags//$'\n'/' '}"
+          for tag in $tags;
+          do
+            amd_tag=$tag-x86_64
+            arm_tag=$tag-aarch64
+            docker manifest create $tag \
+              $amd_tag \
+              $arm_tag
+            docker manifest push $tag
+          done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,9 +26,9 @@ jobs:
           images: |
             tiltedphoques/st-reborn-server
           flavor: |
+            latest=false
             suffix=-${{ matrix.targets.arch }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=semver,pattern={{version}}
 
@@ -70,8 +70,9 @@ jobs:
         with:
           images: |
             tiltedphoques/st-reborn-server
+          flavor: |
+            latest=false
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=semver,pattern={{version}}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,12 @@
 ARG arch=x86_64
+ARG build_dir=x86_64
 
-FROM tiltedphoques/builder:${arch} AS builder
+FROM tiltedphoques/builder AS builder
 
 ARG arch
+ARG build_dir
 
 WORKDIR /home/server
-
-RUN apt update && \
-apt install cmake -y
-
-RUN apt install -y sudo
-
-# switch to ruki user
-RUN groupadd -r ruki && useradd -r -g ruki ruki
-RUN mkdir /home/ruki
-RUN chown -R ruki:ruki /home
-RUN echo "root:0000" | chpasswd
-RUN echo "ruki:0000" | chpasswd
-RUN echo "ruki ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-USER ruki
-
-# install xmake
-RUN cd /tmp/ && git clone --depth=1 "https://github.com/xmake-io/xmake.git" --recursive xmake && cd xmake && ./scripts/get.sh __local__
-RUN rm -rf /tmp/xmake
 
 COPY ./modules ./modules
 COPY ./Libraries ./Libraries
@@ -33,27 +17,26 @@ COPY ./Code ./Code
 RUN ~/.local/bin/xmake f -y -vD
 RUN ~/.local/bin/xmake -j`nproc` -vD
 
-RUN objcopy --only-keep-debug /home/server/build/linux/${arch}/release/SkyrimTogetherServer /home/server/build/linux/${arch}/release/SkyrimTogetherServer.debug
-RUN objcopy --only-keep-debug /home/server/build/linux/${arch}/release/libSTServer.so /home/server/build/linux/${arch}/release/libSTServer.debug
+RUN objcopy --only-keep-debug /home/server/build/linux/${build_dir}/release/SkyrimTogetherServer /home/server/build/linux/${build_dir}/release/SkyrimTogetherServer.debug
+RUN objcopy --only-keep-debug /home/server/build/linux/${build_dir}/release/libSTServer.so /home/server/build/linux/${build_dir}/release/libSTServer.debug
 
 RUN ~/.local/bin/xmake install -o package
 
 FROM ubuntu:20.04 AS skyrim
 
 ARG arch
+ARG build_dir
 
 RUN apt update && apt install libssl1.1
 
-# We copy it twice since we can't really tell the arch from Dockerfile :(
-COPY --from=builder /usr/local/lib64/libstdc++.so.6.0.30 /lib/x86_64-linux-gnu/libstdc++.so.6
-COPY --from=builder /usr/local/lib64/libstdc++.so.6.0.30 /lib/aarch64-linux-gnu/libstdc++.so.6
+COPY --from=builder /usr/local/lib64/libstdc++.so.6.0.30 /lib/${arch}-linux-gnu/libstdc++.so.6
 
 # Now copy the actual bins
 COPY --from=builder /home/server/package/lib/libSTServer.so /home/server/libSTServer.so
 COPY --from=builder /home/server/package/bin/SkyrimTogetherServer /home/server/SkyrimTogetherServer
 COPY --from=builder /home/server/package/bin/crashpad_handler /home/server/crashpad_handler
-COPY --from=builder /home/server/build/linux/${arch}/release/libSTServer.debug /home/server/libSTServer.debug
-COPY --from=builder /home/server/build/linux/${arch}/release/SkyrimTogetherServer.debug /home/server/SkyrimTogetherServer.debug
+COPY --from=builder /home/server/build/linux/${build_dir}/release/libSTServer.debug /home/server/libSTServer.debug
+COPY --from=builder /home/server/build/linux/${build_dir}/release/SkyrimTogetherServer.debug /home/server/SkyrimTogetherServer.debug
 WORKDIR /home/server
 ENTRYPOINT ["./SkyrimTogetherServer"]
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,20 +1,20 @@
-FROM ubuntu:20.04 AS builder
+FROM gcc:12.1.0
 
-RUN apt update && \
-    apt install software-properties-common -y && \
-    add-apt-repository universe -y && \
-    apt update && \
-    apt install libssl-dev curl p7zip-full p7zip-rar zip unzip zlib1g-dev wget -y && \
-    curl -fsSL https://xmake.io/shget.text > getxmake.sh && chmod +x getxmake.sh && ./getxmake.sh && \
-    wget ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-12.1.0/gcc-12.1.0.tar.xz && \
-    tar xf gcc-12.1.0.tar.xz && \
-    rm -f gcc-12.1.0.tar.xz && \
-    cd gcc-12.1.0 && \
-    contrib/download_prerequisites && \
-    mkdir -p obj && \
-    cd obj && \
-    ../configure --enable-languages=c,c++ --disable-multilib && \
-    make -j 4 && \
-    make install && \
-    cd ../.. && \
-    rm -rf gcc-12.1.0
+# install packages
+RUN \
+    apt update \
+    && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+        cmake \
+        sudo
+
+# switch to ruki user
+RUN groupadd -r ruki && useradd -m -r -g ruki ruki
+RUN chown -R ruki:ruki /home
+RUN echo "root:0000" | chpasswd
+RUN echo "ruki:0000" | chpasswd
+RUN echo "ruki ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+USER ruki
+
+# install xmake
+RUN cd /tmp/ && git clone --depth=1 "https://github.com/xmake-io/xmake.git" --recursive xmake && cd xmake && ./scripts/get.sh __local__
+RUN rm -rf /tmp/xmake


### PR DESCRIPTION
This adds automatic docker image build using Github actions based on git events.

- all images are OCI compliants
- all images are multi arch (amd64 and arm64 for now, pretty much any arch can be added through QEMU)
- images can still be built independently of the GA environment with basic docker commands

This simplify the release/testing process and now we are not reliant anymore on anyone available time and hardware 😉  

### Builder image
The builder base image is now the official [gcc:12.1.0](https://hub.docker.com/_/gcc) image, it contains the setup of cmake/xmake. The build can be run manually through Github action panel, and pushes a single multi arch `latest` image (see [example here](https://hub.docker.com/r/a1ex4/st-builder/tags), [build logs here](https://github.com/a1ex4/TiltedEvolution/runs/7428348411?check_suite_focus=true)):
![image](https://user-images.githubusercontent.com/12754559/180645553-ddaae5d0-3640-443f-b490-9658fe0a29f8.png)

### Server image
The server image is built on commit events from master and dev branch and on git tags (see [examples here](https://hub.docker.com/r/a1ex4/st-reborn-server/tags), [build logs here](https://github.com/a1ex4/TiltedEvolution/actions/runs/2727009900)):
- master branch -> `master` and `latest` tags
- dev branch -> `dev` tag
- tag v2.0.0 -> `2.0.0` tag

`latest` refers to the latest commit on master branch, so tags can be created without people thinking a new version is available and can be used. `dev` tag can be used by people wanting to try merged PRs without having to have to build the server themselves.

The action uses a matrix job so that each build is run on a dedicated runners (2-core CPU) in parallel. The amd64 image takes ~30 minutes, the arm64 3-4 hours as Github does not provide ARM runners (nor is it planned for the future...). The multi arch manifest is built and pushed once all archs are pushed.