### PR TITLE
Server command for setting ingame time

### DIFF
--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -245,7 +245,7 @@ void GameServer::BindServerCommands()
 
     m_commands.RegisterCommand<>("quit", "Stop the server", [&](Console::ArgStack&) { Kill(); });
 
-    m_commands.RegisterCommand<uint16_t, uint16_t>("SetTime", "Set ingame time", [&](Console::ArgStack& aStack) {
+    m_commands.RegisterCommand<uint16_t, uint16_t>("SetTime", "Set ingame hours and minutes", [&](Console::ArgStack& aStack) {
         auto out = spdlog::get("ConOut");
 
         auto hour = aStack.Pop<uint16_t>();

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -244,6 +244,23 @@ void GameServer::BindServerCommands()
     });
 
     m_commands.RegisterCommand<>("quit", "Stop the server", [&](Console::ArgStack&) { Kill(); });
+
+    m_commands.RegisterCommand<>("SetTime", "Set ingame time", [&](Console::ArgStack&) {
+        auto out = spdlog::get("ConOut");
+        uint16_t hour = 18;
+        uint16_t minute = 14;
+
+        bool time_set_successfully = m_pWorld->GetCalendarService().SetTime(hour, minute, 1.f);
+
+        if (time_set_successfully)
+        {
+            out->info("Time set to {}:{}", hour, minute);
+        }
+        else
+        {
+            out->error("Hours must between 0-24 and minutes must be between 0-60");
+        }
+    });
 }
 
 void GameServer::UpdateInfo()

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -245,10 +245,11 @@ void GameServer::BindServerCommands()
 
     m_commands.RegisterCommand<>("quit", "Stop the server", [&](Console::ArgStack&) { Kill(); });
 
-    m_commands.RegisterCommand<>("SetTime", "Set ingame time", [&](Console::ArgStack&) {
+    m_commands.RegisterCommand<uint16_t, uint16_t>("SetTime", "Set ingame time", [&](Console::ArgStack& aStack) {
         auto out = spdlog::get("ConOut");
-        uint16_t hour = 18;
-        uint16_t minute = 14;
+
+        auto hour = aStack.Pop<uint16_t>();
+        auto minute = aStack.Pop<uint16_t>();
 
         bool time_set_successfully = m_pWorld->GetCalendarService().SetTime(hour, minute, 1.f);
 

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -250,8 +250,9 @@ void GameServer::BindServerCommands()
 
         auto hour = aStack.Pop<int64_t>();
         auto minute = aStack.Pop<int64_t>();
+        auto timescale = m_pWorld->GetCalendarService().GetTimeScale();
 
-        bool time_set_successfully = m_pWorld->GetCalendarService().SetTime(hour, minute, 1.f);
+        bool time_set_successfully = m_pWorld->GetCalendarService().SetTime(hour, minute, timescale);
 
         if (time_set_successfully)
         {

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -245,11 +245,11 @@ void GameServer::BindServerCommands()
 
     m_commands.RegisterCommand<>("quit", "Stop the server", [&](Console::ArgStack&) { Kill(); });
 
-    m_commands.RegisterCommand<uint16_t, uint16_t>("SetTime", "Set ingame hours and minutes", [&](Console::ArgStack& aStack) {
+    m_commands.RegisterCommand<int64_t, int64_t>("SetTime", "Set ingame hours and minutes", [&](Console::ArgStack& aStack) {
         auto out = spdlog::get("ConOut");
 
-        auto hour = aStack.Pop<uint16_t>();
-        auto minute = aStack.Pop<uint16_t>();
+        auto hour = aStack.Pop<int64_t>();
+        auto minute = aStack.Pop<int64_t>();
 
         bool time_set_successfully = m_pWorld->GetCalendarService().SetTime(hour, minute, 1.f);
 

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -259,7 +259,7 @@ void GameServer::BindServerCommands()
         }
         else
         {
-            out->error("Hours must between 0-24 and minutes must be between 0-60");
+            out->error("Hours must between 0-23 and minutes must be between 0-59");
         }
     });
 }


### PR DESCRIPTION
An often requested feature.

~~Submitted as draft becuase `aStack.Pop<uint16_t>()` currently throws with `std::bad_any_cast` regardless of which numeric types I use. Everything else works as expected, so any help on this would be appreciated.~~
EDIT:
Solved with the help of cosideci
