### PR TITLE
Add TimeScale Server Setting

### DIFF
--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -263,6 +263,23 @@ void GameServer::BindServerCommands()
             out->error("Hours must between 0-23 and minutes must be between 0-59");
         }
     });
+
+    m_commands.RegisterCommand<int64_t>("SetTimeScale", "Set how fast time passes. 1 is realtime. 20 is Default. ", [&](Console::ArgStack& aStack) {
+        auto out = spdlog::get("ConOut");
+
+        auto timescale = static_cast<float>(aStack.Pop<int64_t>());
+
+        bool timescale_set_successfully = m_pWorld->GetCalendarService().SetTimeScale(timescale);
+        
+        if (timescale_set_successfully)
+        {
+            out->info("Every IRL second, game time will progress by {} seconds.", timescale);
+        }
+        else
+        {
+            out->error("Scale must between 0 and 1000.");
+        }
+    });
 }
 
 void GameServer::UpdateInfo()

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -37,7 +37,7 @@ Console::Setting uDifficulty{"Gameplay:uDifficulty", "In game difficulty (0 to 5
 Console::Setting bEnableGreetings{"Gameplay:bEnableGreetings", "Enables NPC greetings (disabled by default since they can be spammy with dialogue sync)", false};
 Console::Setting bEnablePvp{"Gameplay:bEnablePvp", "Enables pvp", false};
 Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes", "Sync chests and displays in player homes and other NoResetZones", false};
-
+Console::Setting uTimeScale{"Gameplay:uTimeScale", "How many seconds pass ingame for every real second (0 to 1000). Changing this can make the game unstable", 20u};
 // ModPolicy Stuff
 Console::Setting bEnableModCheck{"ModPolicy:bEnableModCheck", "Bypass the checking of mods on the server", false,
                                  Console::SettingsFlags::kLocked};
@@ -117,6 +117,7 @@ GameServer::GameServer(Console::ConsoleRegistry& aConsole) noexcept
     m_pWorld = MakeUnique<World>();
 
     BindMessageHandlers();
+    UpdateTimeScale();
 }
 
 GameServer::~GameServer()
@@ -263,23 +264,6 @@ void GameServer::BindServerCommands()
             out->error("Hours must between 0-23 and minutes must be between 0-59");
         }
     });
-
-    m_commands.RegisterCommand<int64_t>("SetTimeScale", "Set how fast time passes. 1 is realtime. 20 is Default. ", [&](Console::ArgStack& aStack) {
-        auto out = spdlog::get("ConOut");
-
-        auto timescale = static_cast<float>(aStack.Pop<int64_t>());
-
-        bool timescale_set_successfully = m_pWorld->GetCalendarService().SetTimeScale(timescale);
-        
-        if (timescale_set_successfully)
-        {
-            out->info("Every IRL second, game time will progress by {} seconds.", timescale);
-        }
-        else
-        {
-            out->error("Scale must between 0 and 1000.");
-        }
-    });
 }
 
 void GameServer::UpdateInfo()
@@ -290,6 +274,21 @@ void GameServer::UpdateInfo()
     m_info.icon_url = "";
     m_info.tagList = "";
     m_info.tick_rate = GetUserTickRate();
+}
+
+void GameServer::UpdateTimeScale()
+{
+    auto timescale = uTimeScale.value_as<float>();
+
+    bool timescale_set_successfully = m_pWorld->GetCalendarService().SetTimeScale(timescale);
+
+    if (!timescale_set_successfully)
+    {
+        spdlog::warn("TimeScale is invalid (should be from 0 to 1000, current value is {}), setting TimeScale to 20 (default)",
+                     timescale);
+
+        uTimeScale = 20u;
+    }
 }
 
 void GameServer::OnUpdate()

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -45,6 +45,7 @@ struct GameServer final : Server
     void BindServerCommands();
 
     void UpdateInfo();
+    void UpdateTimeScale();
 
     // Packet dispatching
     void Send(ConnectionId_t aConnectionId, const ServerMessage& acServerMessage) const;

--- a/Code/server/Services/CalendarService.cpp
+++ b/Code/server/Services/CalendarService.cpp
@@ -84,3 +84,19 @@ CalendarService::TDate CalendarService::GetDate() const noexcept
 {
     return {m_timeModel.Day, m_timeModel.Month, m_timeModel.Year};
 }
+
+bool CalendarService::SetTimeScale(float aScale) noexcept
+{
+    if (aScale >= 0.f && aScale <= 1000.f)
+    {
+        m_timeModel.TimeScale = aScale;
+
+        ServerTimeSettings timeMsg;
+        timeMsg.TimeScale = m_timeModel.TimeScale;
+        timeMsg.Time = m_timeModel.Time;
+        GameServer::Get()->SendToLoaded(timeMsg);
+        return true;
+    }
+
+    return false;
+}

--- a/Code/server/Services/CalendarService.cpp
+++ b/Code/server/Services/CalendarService.cpp
@@ -94,7 +94,7 @@ bool CalendarService::SetTimeScale(float aScale) noexcept
         ServerTimeSettings timeMsg;
         timeMsg.TimeScale = m_timeModel.TimeScale;
         timeMsg.Time = m_timeModel.Time;
-        GameServer::Get()->SendToLoaded(timeMsg);
+        GameServer::Get()->SendToPlayers(timeMsg);
         return true;
     }
 

--- a/Code/server/Services/CalendarService.h
+++ b/Code/server/Services/CalendarService.h
@@ -32,6 +32,7 @@ public:
     TDate GetDate() const noexcept;
 
     float GetTimeScale() const noexcept { return m_timeModel.TimeScale; }
+    bool SetTimeScale(float aScale) noexcept;
 
 private:
     void OnUpdate(const UpdateEvent &) noexcept; 


### PR DESCRIPTION
Let you set how fast time passes on the server. 
- 0 will stop the clock
- 1 will move at realtime
- 1000 set it to 50x skyrim's normal speed

Tested in game with two clients. Left on for an hour at 1000 timescale with no noticable effects, other than water moving animating way too fast.

https://user-images.githubusercontent.com/43607012/181633426-df0830c2-1ecd-42a8-8d2e-427f227efd37.mp4


