### PR TITLE
Fix: Limit length of servername in serverlist UI

### DIFF
--- a/Code/skyrim_ui/src/app/services/server-list.service.ts
+++ b/Code/skyrim_ui/src/app/services/server-list.service.ts
@@ -6,6 +6,12 @@ import { environment } from '../../environments/environment';
 import { GeoLocation } from '../models/geo-location';
 import { Server } from '../models/server';
 
+const MAX_SERVERNAME_LENGTH = 100;
+
+function truncateServerName(server: Server): Server {
+  const name = server.name.substring(0, MAX_SERVERNAME_LENGTH);
+  return {...server, name};
+};
 
 @Injectable({
   providedIn: 'root',
@@ -20,7 +26,8 @@ export class ServerListService {
   public getServerList(): Observable<Server[]> {
     return this.http.get<Server[]>(`${ environment.urlProtocol }://${ environment.url }/list`)
       .pipe(
-        map((data: any) => data.servers),
+        map<any, Server[]>((data: any) => {console.log(data); return data.servers}),
+        map(servers => servers.map(truncateServerName))
       );
   }
 


### PR DESCRIPTION
^
Limit set to 100 characters, since any lower would break a lot of discord links.