### PR TITLE
Truncate Server name when it's loaded from config

### DIFF
--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -20,6 +20,7 @@
 #include <Messages/NotifyPlayerJoined.h>
 #include <console/ConsoleRegistry.h>
 
+constexpr size_t kMaxSererNameLength = 128u;
 
 // -- Cvars --
 Console::Setting<uint16_t> uServerPort{"GameServer:uPort", "Which port to host the server on", 10578u};
@@ -269,10 +270,10 @@ void GameServer::UpdateInfo()
 {
     const String cServerName = sServerName.c_str();
 
-    if (cServerName.length() > cm_MaxServerNameLength) 
+    if (cServerName.length() > kMaxSererNameLength) 
     {
-        spdlog::error("sServerName is longer than the limit of {} characters/bytes, and has been cut short", cm_MaxServerNameLength);
-        m_info.name = cServerName.substr(0U, cm_MaxServerNameLength);
+        spdlog::error("sServerName is longer than the limit of {} characters/bytes, and has been cut short", kMaxSererNameLength);
+        m_info.name = cServerName.substr(0U, kMaxSererNameLength);
     }
     else
     {

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -264,11 +264,21 @@ void GameServer::BindServerCommands()
         }
     });
 }
-
+    /* Update Info fields from user facing CVARS.*/
 void GameServer::UpdateInfo()
 {
-    // Update Info fields from user facing CVARS.
-    m_info.name = sServerName.c_str();
+    const String cServerName = sServerName.c_str();
+
+    if (cServerName.length() > cm_MaxServerNameLength) 
+    {
+        spdlog::error("sServerName is longer than the limit of {} characters/bytes, and has been cut short", cm_MaxServerNameLength);
+        m_info.name = cServerName.substr(0U, cm_MaxServerNameLength);
+    }
+    else
+    {
+        m_info.name = cServerName;
+    }
+
     m_info.desc = "";
     m_info.icon_url = "";
     m_info.tagList = "";

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -99,8 +99,6 @@ private:
     Info m_info{};
     UniquePtr<World> m_pWorld;
     Console::ConsoleRegistry& m_commands;
-    
-    const uint64_t cm_MaxServerNameLength = 100U;
 
     TiltedPhoques::Set<ConnectionId_t> m_adminSessions;
     TiltedPhoques::Map<ConnectionId_t, entt::entity> m_connectionToEntity;

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -99,6 +99,8 @@ private:
     Info m_info{};
     UniquePtr<World> m_pWorld;
     Console::ConsoleRegistry& m_commands;
+    
+    const uint64_t cm_MaxServerNameLength = 100U;
 
     TiltedPhoques::Set<ConnectionId_t> m_adminSessions;
     TiltedPhoques::Map<ConnectionId_t, entt::entity> m_connectionToEntity;


### PR DESCRIPTION
This prevents users from setting server names that are extremely long and announcing them to the Serverlist. 

Limit is set to 100 bytes. Server names over this will result in the name being truncated and an error message in the console.

Tested on STServer and FTServer.