### PR TITLE
Regenerate server ini on startup

### DIFF
--- a/Code/server_runner/DediRunner.cpp
+++ b/Code/server_runner/DediRunner.cpp
@@ -44,6 +44,7 @@ DediRunner::DediRunner(int argc, char** argv)
 
     // it is here for now..
     m_pServerInstance->Initialize();
+    SaveSettingsToIni(m_console, m_SettingsPath);
 }
 
 DediRunner::~DediRunner()


### PR DESCRIPTION
Runs `SaveSettingsToIni` right after the GameServer has been initialized. All previous settings are kept and missing ones will be populated with defaults. Fixes #445.