### PR TITLE
Add missing German and Dutch translation strings for party invite

### DIFF
--- a/Code/skyrim_ui/src/assets/i18n/de.json
+++ b/Code/skyrim_ui/src/assets/i18n/de.json
@@ -138,6 +138,9 @@
         "CLIENT_MODS_DISALLOWED": "Dieser Server verbietet folgende Mods {{mods}}. Bitte entferne diese, um beitreten zu können.",
         "WRONG_PASSWORD": "Das eingegebene Passwort ist falsch.",
         "NO_REASON": "Der Server hat die Verbindung ohne Angabe von Gründen verweigert."
+      },
+      "PLAYER_LIST": {
+        "PARTY_INVITE": "{{from}} hat Sie zu einer Gruppe eingeladen"
       }
     }
   }

--- a/Code/skyrim_ui/src/assets/i18n/de.json
+++ b/Code/skyrim_ui/src/assets/i18n/de.json
@@ -141,7 +141,7 @@
       }
     },
     "PLAYER_LIST": {
-      "PARTY_INVITE": "{{from}} hat Sie zu einer Gruppe eingeladen"
+      "PARTY_INVITE": "{{from}} hat dich in eine Gruppe eingeladen"
     }
   }
 }

--- a/Code/skyrim_ui/src/assets/i18n/de.json
+++ b/Code/skyrim_ui/src/assets/i18n/de.json
@@ -138,10 +138,10 @@
         "CLIENT_MODS_DISALLOWED": "Dieser Server verbietet folgende Mods {{mods}}. Bitte entferne diese, um beitreten zu können.",
         "WRONG_PASSWORD": "Das eingegebene Passwort ist falsch.",
         "NO_REASON": "Der Server hat die Verbindung ohne Angabe von Gründen verweigert."
-      },
-      "PLAYER_LIST": {
-        "PARTY_INVITE": "{{from}} hat Sie zu einer Gruppe eingeladen"
       }
+    },
+    "PLAYER_LIST": {
+      "PARTY_INVITE": "{{from}} hat Sie zu einer Gruppe eingeladen"
     }
   }
 }

--- a/Code/skyrim_ui/src/assets/i18n/nl.json
+++ b/Code/skyrim_ui/src/assets/i18n/nl.json
@@ -144,6 +144,9 @@
         "WRONG_PASSWORD": "Het ingevoerde wachtwoord is incorrect.",
         "NO_REASON": "De server heeft de verbinding zonder reden geweigerd."
       }
+    },
+    "PLAYER_LIST": {
+      "PARTY_INVITE": "{{from}} heeft je uitgenodigd voor een groep"
     }
   }
 }


### PR DESCRIPTION
Just noticed SERVICE.PLAYER_LIST.PARTY_INVITE was missing in both languages.
Great if @RobbeBryssinck and @scomans could check the NL and DE translations respectively.