### PR TITLE
Minor tweak to Server Settings (TogglePvp and TogglePremium)

### DIFF
--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -48,18 +48,36 @@ Console::Setting bAllowMO2{"ModPolicy:bAllowMO2", "Allow clients running Mod Org
                            Console::SettingsFlags::kLocked};
 
 // -- Commands --
-Console::Command<bool> TogglePremium("TogglePremium", "Toggle the premium mode",
-                                     [](Console::ArgStack& aStack) { bPremiumTickrate = aStack.Pop<bool>(); });
+Console::Command<> TogglePremium("TogglePremium", "Toggle Premium Tickrate on/off", [](Console::ArgStack&) {
+    bPremiumTickrate = !bPremiumTickrate;
+    //spdlog::get("ConOut")->info("Premium Tickrate enabled: {}", (bool)bPremiumTickrate); 
+    spdlog::get("ConOut")->info("Premium Tickrate has been {}.", bPremiumTickrate == true ? "enabled" : "disabled");
+});
 
-Console::Command<bool> TogglePvp("TogglePvp", "Toggle pvp",
-                                     [](Console::ArgStack& aStack) { bEnablePvp = aStack.Pop<bool>(); });
+// Console::Command<bool> SetPremium("SetPremium", "pass \'true\' or \'false\' to enable or disable premium tickrate mode", [](Console::ArgStack& aStack) {
+//     bPremiumTickrate = aStack.Pop<bool>();
+//     spdlog::get("ConOut")->info("Premium Tickrate has been {}.", bPremiumTickrate == true ? "enabled" : "disabled");
+// });
 
-Console::Command<> ShowVersion("version", "Show the version the server was compiled with",
-                               [](Console::ArgStack&) { spdlog::get("ConOut")->info("Server " BUILD_COMMIT); });
+Console::Command<> TogglePvp("TogglePvp", "Toggle PvP on/off", [](Console::ArgStack&){
+    bEnablePvp = !bEnablePvp;
+    spdlog::get("ConOut")->info("PvP has been {}.", bEnablePvp == true ? "enabled" : "disabled");
+});
+
+// Console::Command<bool> SetPvp("SetPvp", "pass \'true\' or \'false\' to enable or disable PvP", [](Console::ArgStack& aStack) {
+//     bEnablePvp = aStack.Pop<bool>();
+//     spdlog::get("ConOut")->info("PvP has been {}.", bEnablePvp == true ? "enabled" : "disabled");
+// });
+
+Console::Command<> ShowVersion("version", "Show the version the server was compiled with", [](Console::ArgStack&) {
+    spdlog::get("ConOut")->info("Server " BUILD_COMMIT);
+});
+
 Console::Command<> CrashServer("crash", "Crashes the server, don't use!", [](Console::ArgStack&) {
     int* i = 0;
     *i = 42;
 });
+
 Console::Command<> ShowMoPoStatus("ShowMOPOStats", "Shows the status of ModPolicy", [](Console::ArgStack&) {
     auto formatStatus = [](bool aToggle) { return aToggle ? "yes" : "no"; };
 

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -53,20 +53,10 @@ Console::Command<> TogglePremium("TogglePremium", "Toggle Premium Tickrate on/of
     spdlog::get("ConOut")->info("Premium Tickrate has been {}.", bPremiumTickrate == true ? "enabled" : "disabled");
 });
 
-// Console::Command<bool> SetPremium("SetPremium", "pass \'true\' or \'false\' to enable or disable premium tickrate mode", [](Console::ArgStack& aStack) {
-//     bPremiumTickrate = aStack.Pop<bool>();
-//     spdlog::get("ConOut")->info("Premium Tickrate has been {}.", bPremiumTickrate == true ? "enabled" : "disabled");
-// });
-
 Console::Command<> TogglePvp("TogglePvp", "Toggle PvP on/off", [](Console::ArgStack&){
     bEnablePvp = !bEnablePvp;
     spdlog::get("ConOut")->info("PvP has been {}.", bEnablePvp == true ? "enabled" : "disabled");
 });
-
-// Console::Command<bool> SetPvp("SetPvp", "pass \'true\' or \'false\' to enable or disable PvP", [](Console::ArgStack& aStack) {
-//     bEnablePvp = aStack.Pop<bool>();
-//     spdlog::get("ConOut")->info("PvP has been {}.", bEnablePvp == true ? "enabled" : "disabled");
-// });
 
 Console::Command<> ShowVersion("version", "Show the version the server was compiled with", [](Console::ArgStack&) {
     spdlog::get("ConOut")->info("Server " BUILD_COMMIT);

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -50,7 +50,6 @@ Console::Setting bAllowMO2{"ModPolicy:bAllowMO2", "Allow clients running Mod Org
 // -- Commands --
 Console::Command<> TogglePremium("TogglePremium", "Toggle Premium Tickrate on/off", [](Console::ArgStack&) {
     bPremiumTickrate = !bPremiumTickrate;
-    //spdlog::get("ConOut")->info("Premium Tickrate enabled: {}", (bool)bPremiumTickrate); 
     spdlog::get("ConOut")->info("Premium Tickrate has been {}.", bPremiumTickrate == true ? "enabled" : "disabled");
 });
 


### PR DESCRIPTION
Refactored code to be a bit more readable and consistent.  Changed /TogglePvp and /TogglePremium commands to be true toggles, no boolean argument necessary.  Added feedback after command was successfully executed to inform user of state of toggled setting.

~~Initially I was going to add /SetPvp and /SetPremium for explicit setting of commands, but seemed unnecessary/redundant.  Left the code in but commented out, welcome to enable or delete as preferred.~~