### PR TITLE
Accept party invite from popup notification

### DIFF
--- a/Code/skyrim_ui/src/app/components/notification-popup-container/notification-popup-container.component.scss
+++ b/Code/skyrim_ui/src/app/components/notification-popup-container/notification-popup-container.component.scss
@@ -2,4 +2,8 @@
   position: fixed;
   bottom: 0;
   right: 0;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
 }

--- a/Code/skyrim_ui/src/app/components/notification-popup-container/notification-popup-container.component.ts
+++ b/Code/skyrim_ui/src/app/components/notification-popup-container/notification-popup-container.component.ts
@@ -45,10 +45,7 @@ export class NotificationPopupContainerComponent implements OnInit {
     this.cdr.detectChanges();
   }
 
-  remove(notification: PopupNotification, userAction: boolean) {
-    notification.onClose.next(userAction);
-    notification.onClose.complete();
-
+  remove(notification: PopupNotification) {
     const index = this.notifications.indexOf(notification);
     this.notifications.splice(index, 1);
     this.notifications = [...this.notifications];
@@ -57,10 +54,6 @@ export class NotificationPopupContainerComponent implements OnInit {
   }
 
   removeAll() {
-    for (const notification of this.notifications) {
-      notification.onClose.next(false);
-      notification.onClose.complete();
-    }
     this.notifications = [];
     this.cdr.detectChanges();
   }

--- a/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.html
+++ b/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.html
@@ -1,10 +1,10 @@
 <div *transloco="let t" class="notification-popup" (click)="clickNotification()" (mouseenter)="onEnter()" (mouseleave)="onLeave()">
-  <img *ngIf="notification.imageUrl" src="{{notification.imageUrl}}" />
+  <img *ngIf="notification.imageUrl" [src]="notification.imageUrl" />
   <div *ngIf="notification.icon" class="icon">
-    <fa-icon  [icon]="notification.icon"></fa-icon>
+    <fa-icon [icon]="notification.icon"></fa-icon>
   </div>
   <p>{{ t(notification.messageKey, notification.messageParams) }}</p>
   <button *ngFor="let action of notification.actions" (click)="action.callback()">
-    {{t(action.nameKey)}}
+    {{ t(action.nameKey) }}
   </button>
 </div>

--- a/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.html
+++ b/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.html
@@ -1,5 +1,10 @@
-<div class="notification-popup" (click)="clickNotification()" (mouseenter)="onEnter()" (mouseleave)="onLeave()">
-  <div *ngIf="notification.player?.avatar" class="friendavatar" [ngStyle]="{ 'background-image': 'url(' + notification.player.avatar + ')' }"></div>
-  <div class="text-connection-popup">{{ notification.message }}</div>
-  <div *ngIf="isConnected" class="friendstatus" [class.online]="notification.player?.online"></div>
+<div *transloco="let t" class="notification-popup" (click)="clickNotification()" (mouseenter)="onEnter()" (mouseleave)="onLeave()">
+  <img *ngIf="notification.imageUrl" src="{{notification.imageUrl}}" />
+  <div *ngIf="notification.icon" class="icon">
+    <fa-icon  [icon]="notification.icon"></fa-icon>
+  </div>
+  <p>{{ t(notification.messageKey, notification.messageParams) }}</p>
+  <button *ngFor="let action of notification.actions" (click)="action.callback()">
+    {{t(action.nameKey)}}
+  </button>
 </div>

--- a/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.scss
+++ b/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.scss
@@ -5,10 +5,14 @@
 
 :host {
   display: block;
-  min-width: 10vw;
-  min-height: 2vw;
   margin-right: 2em;
   margin-bottom: 0.5em;
+
+  color: white;
+
+  background-color: $-color-background;
+
+  font-size: 1.3rem;
 
   &:last-child {
     margin-bottom: 1em;
@@ -16,38 +20,43 @@
 }
 
 .notification-popup {
-  width: 100%;
-  height: 100%;
   display: flex;
   align-items: center;
   background-color: rgba($color: #000000, $alpha: 0.7);
+
+  padding: 0.5em;
 }
 
-.friendavatar {
+.notification-popup:first-child {
   margin-left: 1em;
+}
+
+.notification-popup > *{
   margin-right: 1em;
-  width: 2vw;
-  height: 2vw;
+}
+
+img, .icon {
+  width: 2em;
+  height: 2em;
   background-size: contain;
 }
 
-.text-connection-popup {
-  color: white;
-  white-space: normal;
-  flex: 1 1 auto;
+.icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.friendstatus {
-  width: 0.5em;
-  height: 0.5em;
-  margin-right: 1em;
-  margin-left: 1em;
-  background: #993333;
-  border-radius: 50%;
+.icon > * {
+  font-size: 1.5em;
+}
 
-  &.online {
-    background: #339933;
-  }
+p {
+  max-width: 25em;
+}
+
+button {
+  font-size: 1em;
 }
 
 

--- a/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.scss
+++ b/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.scss
@@ -7,11 +7,8 @@
   display: block;
   margin-right: 2em;
   margin-bottom: 0.5em;
-
   color: white;
-
   background-color: $-color-background;
-
   font-size: 1.3rem;
 
   &:last-child {
@@ -23,7 +20,6 @@
   display: flex;
   align-items: center;
   background-color: rgba($color: #000000, $alpha: 0.7);
-
   padding: 0.5em;
 }
 

--- a/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.ts
+++ b/Code/skyrim_ui/src/app/components/notification-popup/notification-popup.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
-import { NotificationType, PopupNotification } from '../../models/popup-notification';
+import { PopupNotification } from '../../models/popup-notification';
 import { DestroyService } from '../../services/destroy.service';
 
 
@@ -53,10 +53,6 @@ export class NotificationPopupComponent implements OnInit, OnDestroy {
       clearTimeout(this.eraseTimer);
       this.eraseTimer = null;
     }
-  }
-
-  get isConnected(): boolean {
-    return this.notification.type === NotificationType.Connection;
   }
 
   async clickNotification() {

--- a/Code/skyrim_ui/src/app/models/popup-notification.ts
+++ b/Code/skyrim_ui/src/app/models/popup-notification.ts
@@ -1,22 +1,18 @@
-import { Subject } from 'rxjs';
-import { Player } from './player';
-
-
-export enum NotificationType {
-  Connection = 1,
-  Invitation
-}
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 
 export interface PopupNotification {
-  message: string;
-  type?: NotificationType;
-  player?: Player;
+  /** Translation Key. Plaintext should **NOT** be used */
+  messageKey: string;
+  messageParams?: Record<string, any>;
+  imageUrl?: string;
+  icon?: IconDefinition;
+  /** milliseconds */
   duration?: number;
-  onClose: Subject<boolean>;
+  actions?: PopupNotifactionAction[];
 }
 
-export interface PopupNotifactionOptions {
-  type?: NotificationType;
-  player?: Player;
-  duration?: number;
+export interface PopupNotifactionAction {
+  /** Translation Key. Plaintext should **NOT** be used */
+  nameKey: string;
+  callback: () => void;
 }

--- a/Code/skyrim_ui/src/app/services/mock-client.service.ts
+++ b/Code/skyrim_ui/src/app/services/mock-client.service.ts
@@ -1,16 +1,15 @@
 import { Injectable } from '@angular/core';
 import { TranslocoService } from '@ngneat/transloco';
-import { firstValueFrom, fromEvent, takeUntil, withLatestFrom } from 'rxjs';
+import { fromEvent, takeUntil } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { PartyInfo } from '../models/party-info';
-import { Player } from '../models/player';
 import { PlayerManagerTab } from '../models/player-manager-tab.enum';
-import { NotificationType } from '../models/popup-notification';
 import { View } from '../models/view.enum';
 import { UiRepository } from '../store/ui.repository';
 import { ClientService } from './client.service';
 import { DestroyService } from './destroy.service';
 import { PopupNotificationService } from './popup-notification.service';
+import { faHandshakeSimple } from '@fortawesome/free-solid-svg-icons';
 
 
 // TODO: this is bad. We shouldn't take different paths to accommodate for
@@ -66,33 +65,40 @@ export class MockClientService extends DestroyService {
         this.partyInfo.playerIds.push(playerId);
         this.clientService.onPartyInfo(this.partyInfo.playerIds, this.partyInfo.leaderId);
       });
-
-    fromEvent(window, 'keydown')
+      fromEvent(window, 'keydown')
       .pipe(
         takeUntil(this),
-        filter((e: KeyboardEvent) => e.key === 'n'),
-        withLatestFrom(this.translocoService.selectTranslate('SERVICE.PLAYER_LIST.PARTY_INVITE', { from: 'Dumbeldor' })),
+        filter((e: KeyboardEvent) => e.key === 'n')
       )
-      .subscribe(([, inviteMessage]) => {
-        const message = this.popupNotificationService
-          .addMessage(inviteMessage, {
-            type: NotificationType.Connection,
-            duration: 10000,
-            player: new Player({
-                name: 'Dumbeldor',
-                online: true,
-                avatar: 'https://skyrim-together.com/images/float/avatars/random3.jpg',
-              },
-            ),
-          });
-        firstValueFrom(message.onClose)
-          .then(clicked => {
-            if (clicked) {
-              this.uiRepository.openView(View.PLAYER_MANAGER);
-              this.uiRepository.openPlayerManagerTab(PlayerManagerTab.PARTY_MENU);
-            }
-          });
-      });
+      .subscribe(() => {
+        this.popupNotificationService.addMessage({
+          messageKey: 'Notifications can show an image, an icon or both. Supports multiple actions or none. Text that is too long will be wrapped. Supports live translation',
+          duration: 10000,
+          imageUrl: 'https://skyrim-together.com/images/logo.png',
+          icon: faHandshakeSimple
+        })
+        this.popupNotificationService.addMessage({
+          messageKey: 'SERVICE.GROUP.LEVEL_UP',
+          messageParams: { name: 'Dumbeldor', level: 100 },
+          duration: 10000,
+          actions: [
+          {
+            nameKey: "OPTION",
+            callback: () => {console.log("1")}
+          },
+          {
+            nameKey: "OPTION",
+            callback: () => {console.log("2")}
+          },
+          {
+            nameKey: "OPTION",
+            callback: () => {console.log("3")}
+          },
+          
+        ]
+        })
+        this.popupNotificationService.addPartyInvite('Cosideci', () => console.log("ACCEPTED!"));
+      })
   }
 
   private onPartyJoined() {

--- a/Code/skyrim_ui/src/app/services/player-list.service.ts
+++ b/Code/skyrim_ui/src/app/services/player-list.service.ts
@@ -1,10 +1,9 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { TranslocoService } from '@ngneat/transloco';
-import { BehaviorSubject, firstValueFrom, Subscription } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import { Player } from '../models/player';
 import { PlayerList } from '../models/player-list';
 import { PlayerManagerTab } from '../models/player-manager-tab.enum';
-import { NotificationType } from '../models/popup-notification';
 import { View } from '../models/view.enum';
 import { UiRepository } from '../store/ui.repository';
 import { ClientService } from './client.service';
@@ -125,22 +124,7 @@ export class PlayerListService implements OnDestroy {
         const invitingPlayer = this.getPlayerById(inviterId);
         invitingPlayer.hasInvitedLocalPlayer = true;
         this.playerList.next(playerList);
-        const inviteMessage = await firstValueFrom(
-          this.translocoService.selectTranslate('SERVICE.PLAYER_LIST.PARTY_INVITE', { from: invitingPlayer.name }),
-        );
-        const message = this.popupNotificationService
-          .addMessage(inviteMessage, {
-            type: NotificationType.Invitation,
-            player: invitingPlayer,
-            duration: 10000,
-          });
-        firstValueFrom(message.onClose)
-          .then(clicked => {
-            if (clicked) {
-              this.uiRepository.openView(View.PLAYER_MANAGER);
-              this.uiRepository.openPlayerManagerTab(PlayerManagerTab.PARTY_MENU);
-            }
-          });
+        this.popupNotificationService.addPartyInvite(invitingPlayer.name, () => this.acceptPartyInvite(inviterId));
       }
     });
   }

--- a/Code/skyrim_ui/src/app/services/popup-notification.service.ts
+++ b/Code/skyrim_ui/src/app/services/popup-notification.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
+import { faHandshakeSimple } from '@fortawesome/free-solid-svg-icons';
 import { Subject } from 'rxjs';
-import { PopupNotifactionOptions, PopupNotification } from '../models/popup-notification';
+import { PopupNotification } from '../models/popup-notification';
 import { Sound, SoundService } from './sound.service';
 
 
@@ -19,17 +20,22 @@ export class PopupNotificationService {
   ) {
   }
 
-  public addMessage(message: string, options: PopupNotifactionOptions) {
-    const notification: PopupNotification = {
-      message,
-      type: options.type,
-      player: options.player,
-      duration: options.duration ? (options.duration < 0 ? 500 : options.duration) : 5000,
-      onClose: new Subject(),
-    };
+  public addMessage(notification: PopupNotification) {
     this.message.next(notification);
     this.soundService.play(Sound.Focus);
-    return notification;
+  }
+
+  public addPartyInvite(from: string, callback: ()=>void ) {
+    this.addMessage({
+      messageKey: 'SERVICE.PLAYER_LIST.PARTY_INVITE',
+      messageParams: {from},
+      icon: faHandshakeSimple,
+      duration: 30000,
+      actions: [{
+        nameKey: 'COMPONENT.NOTIFICATIONS.ACCEPT',
+        callback
+      }],
+    });
   }
 
   public clearMessages() {

--- a/Code/skyrim_ui/src/assets/i18n/de.json
+++ b/Code/skyrim_ui/src/assets/i18n/de.json
@@ -31,7 +31,9 @@
       "OK": "Ok"
     },
     "NOTIFICATIONS": {
-      "MESSAGE_FROM": "Nachricht von"
+      "MESSAGE_FROM": "Nachricht von",
+      "ACCEPT": "Akzeptieren",
+      "DECLINE": "Annuleren"
     },
     "PARTY_MENU": {
       "ACCEPT_INVITE": "Einladung von {{name}} akzeptieren",

--- a/Code/skyrim_ui/src/assets/i18n/de.json
+++ b/Code/skyrim_ui/src/assets/i18n/de.json
@@ -33,7 +33,7 @@
     "NOTIFICATIONS": {
       "MESSAGE_FROM": "Nachricht von",
       "ACCEPT": "Akzeptieren",
-      "DECLINE": "Annuleren"
+      "DECLINE": "Ablehnen"
     },
     "PARTY_MENU": {
       "ACCEPT_INVITE": "Einladung von {{name}} akzeptieren",

--- a/Code/skyrim_ui/src/assets/i18n/en.json
+++ b/Code/skyrim_ui/src/assets/i18n/en.json
@@ -33,7 +33,9 @@
       "OK": "Ok"
     },
     "NOTIFICATIONS": {
-      "MESSAGE_FROM": "Message from"
+      "MESSAGE_FROM": "Message from",
+      "ACCEPT": "Accept",
+      "DECLINE": "Decline"
     },
     "PARTY_MENU": {
       "ACCEPT_INVITE": "Accept invite from {{name}}",


### PR DESCRIPTION
![accept-party-invite](https://user-images.githubusercontent.com/43607012/183709307-5cfcd83c-01fc-43b0-b6f9-d4b94d099b46.png)
As the title says, you can now accept party invites by pressing the "Accept" button on the notification, where previously it only brough up the party menu. "Decline" button is not included as this is not implemented in the client. Notification will disappear after 30s or if you click on it.

I have reworked popup notifcations so they support images, icons and buttons with callbacks. They also scale propely based on their contents.
![notifcs](https://user-images.githubusercontent.com/43607012/183709628-f1d4f96d-fc0f-4d01-8837-d43493089bbd.png)

German translation are included to test translations. Not a native speaker, so feel free to correct my grammar.