### PR TITLE
Fix for RegisterQuitHandler under linux

### DIFF
--- a/Code/server_runner/main.cpp
+++ b/Code/server_runner/main.cpp
@@ -19,7 +19,7 @@
 #ifdef _WIN32
 #include <base/dialogues/win/TaskDialog.h>
 #pragma comment(lib, "Comctl32.lib")
-#elif defined(linux)
+#elif defined(__linux__)
 #include <signal.h>
 #endif
 
@@ -118,17 +118,12 @@ static bool RegisterQuitHandler()
 
     return SetConsoleCtrlHandler(CtrlHandler, TRUE);
 
-#elif defined(linux)
+#elif defined(__linux__)
     static auto CtrlHandler = ([](int aSig) {
         if (auto* pRunner = GetDediRunner())
         {
             pRunner->RequestKill();
-            return true;
         }
-
-        // if the user kills during the ctor we deny the request
-        // to save our dear life.
-        return false;
     });
 
     signal(SIGINT, CtrlHandler);


### PR DESCRIPTION
`linux` did not seem to be defined and thus the RegisterQuitHandler for linux did not compile at all.  Tests were passed even though the function CtrlHandler was incorrectly typed -- `bool (*)(int)` when __sighandler_t is `void (*)(int)`.

This fixes both the compile by switching to `__linux__` and incorrect typedef.  Since CtrlHandler is now void instead of bool the logic for attempting to save our dear life has been removed.

Tested in Ubuntu 22.04 with gcc-12.