### PR TITLE
Optional death system

### DIFF
--- a/Code/client/Games/Fallout4/Actor.h
+++ b/Code/client/Games/Fallout4/Actor.h
@@ -121,7 +121,7 @@ struct Actor : TESObjectREFR
     void SetPackage(TESPackage* apPackage) noexcept;
     void SetNoBleedoutRecovery(bool aSet) noexcept;
     void SetEssentialEx(bool aSet) noexcept;
-    void SetPlayerRespawnMode() noexcept;
+    void SetPlayerRespawnMode(bool aSet = true) noexcept;
 
     // Actions
     void UnEquipAll() noexcept;

--- a/Code/client/Games/References.cpp
+++ b/Code/client/Games/References.cpp
@@ -716,11 +716,21 @@ void Actor::SetPackage(TESPackage* apPackage) noexcept
     s_execInitPackage = false;
 }
 
-void Actor::SetPlayerRespawnMode() noexcept
+void Actor::SetPlayerRespawnMode(bool aSet) noexcept
 {
-    SetEssentialEx(true);
+    SetEssentialEx(aSet);
     // Makes the player go in an unrecoverable bleedout state
-    SetNoBleedoutRecovery(true);
+    SetNoBleedoutRecovery(aSet);
+
+#if TP_SKYRIM64
+    if (formID != 0x14)
+    {
+        auto pPlayerFaction = Cast<TESFaction>(TESForm::GetById(0xDB1));
+        SetFactionRank(pPlayerFaction, 1);
+    }
+#elif TP_FALLOUT4
+    // TODO: ft
+#endif
 }
 
 void Actor::SetEssentialEx(bool aSet) noexcept

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -442,21 +442,6 @@ void Actor::SetNoBleedoutRecovery(bool aSet) noexcept
     ThisCall(s_setNoBleedoutRecovery, this, aSet);
 }
 
-void Actor::SetPlayerRespawnMode() noexcept
-{
-    SetEssentialEx(true);
-    // Makes the player go in an unrecoverable bleedout state
-    SetNoBleedoutRecovery(true);
-
-    if (formID != 0x14)
-    {
-        //SetPlayerTeammate(true);
-
-        auto pPlayerFaction = Cast<TESFaction>(TESForm::GetById(0xDB1));
-        SetFactionRank(pPlayerFaction, 1);
-    }
-}
-
 void Actor::SetPlayerTeammate(bool aSet) noexcept
 {
     TP_THIS_FUNCTION(TSetPlayerTeammate, void, Actor, bool aSet, bool abCanDoFavor);

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -216,7 +216,7 @@ struct Actor : TESObjectREFR
     void SetMagicEquipment(const MagicEquipment& acEquipment) noexcept;
     void SetEssentialEx(bool aSet) noexcept;
     void SetNoBleedoutRecovery(bool aSet) noexcept;
-    void SetPlayerRespawnMode() noexcept;
+    void SetPlayerRespawnMode(bool aSet = true) noexcept;
     void SetPlayerTeammate(bool aSet) noexcept;
 
     // Actions

--- a/Code/client/Services/Generic/DiscoveryService.cpp
+++ b/Code/client/Services/Generic/DiscoveryService.cpp
@@ -260,6 +260,8 @@ BSTEventResult DiscoveryService::OnEvent(const TESLoadGameEvent*, const EventDis
     spdlog::info("Finished loading, triggering visit cell");
     VisitCell(true);
 
+    PlayerCharacter::Get()->SetPlayerRespawnMode();
+
     return BSTEventResult::kOk;
 }
 

--- a/Code/client/Services/Generic/DiscoveryService.cpp
+++ b/Code/client/Services/Generic/DiscoveryService.cpp
@@ -260,8 +260,6 @@ BSTEventResult DiscoveryService::OnEvent(const TESLoadGameEvent*, const EventDis
     spdlog::info("Finished loading, triggering visit cell");
     VisitCell(true);
 
-    PlayerCharacter::Get()->SetPlayerRespawnMode();
-
     return BSTEventResult::kOk;
 }
 

--- a/Code/client/Services/PlayerService.h
+++ b/Code/client/Services/PlayerService.h
@@ -49,6 +49,8 @@ private:
     void RunDifficultyUpdates() const noexcept;
     void RunLevelUpdates() const noexcept;
 
+    void ToggleDeathSystem(bool aSet) const noexcept;
+
     World& m_world;
     entt::dispatcher& m_dispatcher;
     TransportService& m_transport;

--- a/Code/encoding/Structs/ServerSettings.cpp
+++ b/Code/encoding/Structs/ServerSettings.cpp
@@ -5,7 +5,11 @@ using TiltedPhoques::Serialization;
 
 bool ServerSettings::operator==(const ServerSettings& acRhs) const noexcept
 {
-    return Difficulty == acRhs.Difficulty;
+    return Difficulty == acRhs.Difficulty &&
+           GreetingsEnabled == acRhs.GreetingsEnabled &&
+           PvpEnabled == acRhs.PvpEnabled &&
+           SyncPlayerHomes == acRhs.SyncPlayerHomes &&
+           DeathSystemEnabled == acRhs.DeathSystemEnabled;
 }
 
 bool ServerSettings::operator!=(const ServerSettings& acRhs) const noexcept
@@ -19,6 +23,7 @@ void ServerSettings::Serialize(TiltedPhoques::Buffer::Writer& aWriter) const noe
     Serialization::WriteBool(aWriter, GreetingsEnabled);
     Serialization::WriteBool(aWriter, PvpEnabled);
     Serialization::WriteBool(aWriter, SyncPlayerHomes);
+    Serialization::WriteBool(aWriter, DeathSystemEnabled);
 }
 
 void ServerSettings::Deserialize(TiltedPhoques::Buffer::Reader& aReader) noexcept
@@ -27,5 +32,6 @@ void ServerSettings::Deserialize(TiltedPhoques::Buffer::Reader& aReader) noexcep
     GreetingsEnabled = Serialization::ReadBool(aReader);
     PvpEnabled = Serialization::ReadBool(aReader);
     SyncPlayerHomes = Serialization::ReadBool(aReader);
+    DeathSystemEnabled = Serialization::ReadBool(aReader);
 }
 

--- a/Code/encoding/Structs/ServerSettings.h
+++ b/Code/encoding/Structs/ServerSettings.h
@@ -16,4 +16,5 @@ struct ServerSettings
     bool GreetingsEnabled{};
     bool PvpEnabled{};
     bool SyncPlayerHomes{};
+    bool DeathSystemEnabled{};
 };


### PR DESCRIPTION
The multiplayer death system is now an optional, default enabled server setting, since some people want to use an alternative death system through other mods. Disabling our death system includes a fat warning on server startup, since this can cause issues.