### PR TITLE
FIxes Compiling on windows

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -40,6 +40,7 @@ add_requires(
     "gtest", 
     "mem", 
     "glm", 
+    "catch2 2.13.9",
     "sentry-native", 
     "zlib")
 


### PR DESCRIPTION
While compiling the dev branch, I ran into TiltedConnect and TiltedReverse not compiling due to catch2/catch.hpp  not being found. After adding "catch2 2.13.9" to the xmake.lua for TiltedEvolution, I was once again able to compile
