### PR TITLE
Connect dialog styling fixes

### DIFF
--- a/Code/skyrim_ui/src/app/components/connect/connect.component.html
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.html
@@ -1,8 +1,10 @@
-<div class="app-connect">
-  <p [innerHtml]="'COMPONENT.CONNECT.INFO.SERVER_ADDRESS' | transloco"></p>
-  <p style="color:rgb(247, 54, 54);">
-    {{ 'COMPONENT.CONNECT.INFO.HELGEN' | transloco }}
-  </p>
+<div class="container">
+  <div id="instructions">
+    <p [innerHtml]="'COMPONENT.CONNECT.INFO.SERVER_ADDRESS' | transloco"></p>
+    <p class="warning">
+      {{ 'COMPONENT.CONNECT.INFO.HELGEN' | transloco }}
+    </p>
+  </div>
 
   <input
     #input

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.html
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <div id="instructions">
+  <div class="instructions">
     <p [innerHtml]="'COMPONENT.CONNECT.INFO.SERVER_ADDRESS' | transloco"></p>
     <p class="warning">
       {{ 'COMPONENT.CONNECT.INFO.HELGEN' | transloco }}

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -9,6 +9,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  ::ng-deep {
+    strong {
+      color: mod($-color-background, 1);
+    }
+  }
 }
 
 .save-password {
@@ -19,17 +25,13 @@
   gap: 0.5em;
 }
 
-#instructions > * {
+.instructions > * {
   text-align: center;
   margin: 0.3em;
   line-height: $-size-line;
 }
 
-::ng-deep {
-  strong {
-    color: mod($-color-background, 1);
-  }
-}
+
 
 input {
   width: 100%;

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -3,56 +3,47 @@
 @import "functions/mod";
 @import "mixins/gapped-vertical";
 
-:host {
-  display: block;
-  font-size: 1.25rem;
-}
-
-.app-connect {
+.container {
   @include gapped-vertical($-size-gap);
 
   display: flex;
   flex-direction: column;
   align-items: center;
+}
 
-  .save-password {
-    margin-top: 0.2em;
-    width: 100%;
-    display: flex;
-    justify-items: start;
-    align-items: center;
+.save-password {
+  width: 100%;
+  display: flex;
+  justify-items: start;
+  align-items: center;
+  gap: 0.5em;
+}
 
-    label {
-      font-size: 0.8em;
-    }
+#instructions > * {
+  text-align: center;
+  margin: 0.3em;
+  line-height: $-size-line;
+}
 
-    app-checkbox {
-      margin-right: 0.3em;
-      width: unset;
-    }
+::ng-deep {
+  strong {
+    color: mod($-color-background, 1);
   }
+}
 
-  p {
-    line-height: $-size-line;
-    text-align: justify;
-  }
+input {
+  width: 100%;
+}
 
-  ::ng-deep {
-    strong {
-      color: mod($-color-background, 1);
-    }
-  }
+.warning {
+  color: rgb(247, 54, 54);
+}
 
-  input {
-    width: 100%;
-  }
-
-  hr {
-    border: 0;
-    clear: both;
-    display: block;
-    width: 80%;
-    background-color: grey;
-    height: 1px;
-  }
+hr {
+  border: 0;
+  clear: both;
+  display: block;
+  width: 80%;
+  background-color: grey;
+  height: 1px;
 }

--- a/Code/skyrim_ui/src/app/components/root/root.component.ts
+++ b/Code/skyrim_ui/src/app/components/root/root.component.ts
@@ -7,7 +7,7 @@ import { fadeInOutActiveAnimation } from '../../animations/fade-in-out-active.an
 import { View } from '../../models/view.enum';
 import { ClientService } from '../../services/client.service';
 import { DestroyService } from '../../services/destroy.service';
-import { SettingService } from '../../services/setting.service';
+import { SettingService, fontSizeToPixels } from '../../services/setting.service';
 import { Sound, SoundService } from '../../services/sound.service';
 import { UiRepository } from '../../store/ui.repository';
 import { ChatComponent } from '../chat/chat.component';
@@ -15,7 +15,6 @@ import { GroupComponent } from '../group/group.component';
 import { controlsAnimation } from './controls.animation';
 import { notificationsAnimation } from './notifications.animation';
 import {map} from 'rxjs/operators';
-import {fontSizeToPixels} from '../settings/settings.component';
 
 
 @Component({
@@ -87,7 +86,7 @@ export class RootComponent implements OnInit {
     this.settingService.fontSizeChange
     .pipe(takeUntil(this.destroy$), map(size => fontSizeToPixels[size]))
     .subscribe( size => {
-      document.documentElement.setAttribute('style', `font-size: ${size};`);
+      document.documentElement.setAttribute('style', `font-size: ${size}px;`);
     })
   }
 

--- a/Code/skyrim_ui/src/app/components/server-list/server-list.component.html
+++ b/Code/skyrim_ui/src/app/components/server-list/server-list.component.html
@@ -94,7 +94,7 @@
         {{ 'COMPONENT.SERVER_LIST.NO_SERVERS' | transloco }}
       </div>
 
-      <cdk-virtual-scroll-viewport *ngIf="serverlist.length !== 0" [itemSize]="rowHeight" class="virtual-viewport">
+      <cdk-virtual-scroll-viewport *ngIf="serverlist.length !== 0" [itemSize]="rowHeight | async" class="virtual-viewport">
         <div class="server-list-table">
           <div *cdkVirtualFor="let server of serverlist; let odd = odd" class="row" [class.odd]="odd">
             <div>{{ server.name }}</div>

--- a/Code/skyrim_ui/src/app/components/server-list/server-list.component.scss
+++ b/Code/skyrim_ui/src/app/components/server-list/server-list.component.scss
@@ -8,7 +8,7 @@
   display: flex;
   gap: 1em;
   width: 70vw;
-  --server-list-row-height: calc(16 * 100vw / 1920 * 2);
+  --server-list-row-height: 40px;
 }
 
 .server-list-action-bar {
@@ -115,6 +115,7 @@
       width: 100%;
       border-bottom: 1px solid grey;
       border-collapse: separate;
+      font-size: 15px;
 
       &.odd {
         background: transparentize(mod($-color-background, 1), 0.95);

--- a/Code/skyrim_ui/src/app/components/server-list/server-list.component.scss
+++ b/Code/skyrim_ui/src/app/components/server-list/server-list.component.scss
@@ -8,7 +8,8 @@
   display: flex;
   gap: 1em;
   width: 70vw;
-  --server-list-row-height: 40px;
+  --server-list-font-size: 1rem;
+  --server-list-row-height: 2rem;
 }
 
 .server-list-action-bar {
@@ -114,7 +115,7 @@
       width: 100%;
       border-bottom: 1px solid grey;
       border-collapse: separate;
-      font-size: 15px;
+      font-size: var(--server-list-font-size);
 
       &.odd {
         background: transparentize(mod($-color-background, 1), 0.95);

--- a/Code/skyrim_ui/src/app/components/server-list/server-list.component.scss
+++ b/Code/skyrim_ui/src/app/components/server-list/server-list.component.scss
@@ -88,7 +88,6 @@
   font-size: 0.85rem;
   border-radius: 7px;
   height: 1.5rem;
-  border: none;
 }
 
 .server-list {

--- a/Code/skyrim_ui/src/app/components/server-list/server-list.component.ts
+++ b/Code/skyrim_ui/src/app/components/server-list/server-list.component.ts
@@ -16,7 +16,6 @@ import { StoreService } from '../../services/store.service';
 import { UiRepository } from '../../store/ui.repository';
 import { SortOrder } from '../order/order.component';
 
-
 interface SortFunction {
   fn: ((a: Server, b: Server) => number);
   priority: number;
@@ -49,7 +48,7 @@ export class ServerListComponent {
   clientVersion$: Observable<string>;
 
   formSearch = new FormControl<string>('');
-  rowHeight = new BehaviorSubject(16)
+  rowHeight$: Observable<number>;
 
   @Output() public done = new EventEmitter<void>();
 
@@ -141,9 +140,7 @@ export class ServerListComponent {
     }
     this.favoriteServers.next(favoriteServers);
 
-    settingService.fontSizeChange.subscribe(fontSize => {
-      this.rowHeight.next(fontSizeToPixels[fontSize]*2)
-    })
+    this.rowHeight$ = this.settingService.fontSizeChange.pipe(map(fontSize => fontSizeToPixels[fontSize]*2));
   }
 
   public cancel(): void {

--- a/Code/skyrim_ui/src/app/components/server-list/server-list.component.ts
+++ b/Code/skyrim_ui/src/app/components/server-list/server-list.component.ts
@@ -10,10 +10,12 @@ import { View } from '../../models/view.enum';
 import { ClientService } from '../../services/client.service';
 import { ErrorService } from '../../services/error.service';
 import { ServerListService } from '../../services/server-list.service';
+import { SettingService } from '../../services/setting.service';
 import { Sound, SoundService } from '../../services/sound.service';
 import { StoreService } from '../../services/store.service';
 import { UiRepository } from '../../store/ui.repository';
 import { SortOrder } from '../order/order.component';
+import { fontSizeToPixels } from '../settings/settings.component';
 
 
 interface SortFunction {
@@ -48,7 +50,7 @@ export class ServerListComponent {
   clientVersion$: Observable<string>;
 
   formSearch = new FormControl<string>('');
-  rowHeight = 40
+  rowHeight = new BehaviorSubject(16)
 
   @Output() public done = new EventEmitter<void>();
 
@@ -56,6 +58,7 @@ export class ServerListComponent {
     private readonly errorService: ErrorService,
     private readonly serverListService: ServerListService,
     private readonly clientService: ClientService,
+    private readonly settingService: SettingService,
     private readonly soundService: SoundService,
     private readonly storeService: StoreService,
     private readonly uiRepository: UiRepository,
@@ -138,6 +141,11 @@ export class ServerListComponent {
       favoriteServers[`${ favoriteServer.ip }:${ favoriteServer.port }`] = favoriteServer;
     }
     this.favoriteServers.next(favoriteServers);
+
+    settingService.fontSizeChange.subscribe(fontSize => {
+      const font_height_str = fontSizeToPixels[fontSize].slice(-2);
+      this.rowHeight.next(parseInt(font_height_str)*2)
+    })
   }
 
   public cancel(): void {

--- a/Code/skyrim_ui/src/app/components/server-list/server-list.component.ts
+++ b/Code/skyrim_ui/src/app/components/server-list/server-list.component.ts
@@ -48,7 +48,7 @@ export class ServerListComponent {
   clientVersion$: Observable<string>;
 
   formSearch = new FormControl<string>('');
-  rowHeight = 16 * document.documentElement.clientWidth / 1920 * 2;
+  rowHeight = 40
 
   @Output() public done = new EventEmitter<void>();
 

--- a/Code/skyrim_ui/src/app/components/server-list/server-list.component.ts
+++ b/Code/skyrim_ui/src/app/components/server-list/server-list.component.ts
@@ -10,12 +10,11 @@ import { View } from '../../models/view.enum';
 import { ClientService } from '../../services/client.service';
 import { ErrorService } from '../../services/error.service';
 import { ServerListService } from '../../services/server-list.service';
-import { SettingService } from '../../services/setting.service';
+import { SettingService, fontSizeToPixels } from '../../services/setting.service';
 import { Sound, SoundService } from '../../services/sound.service';
 import { StoreService } from '../../services/store.service';
 import { UiRepository } from '../../store/ui.repository';
 import { SortOrder } from '../order/order.component';
-import { fontSizeToPixels } from '../settings/settings.component';
 
 
 interface SortFunction {
@@ -143,8 +142,7 @@ export class ServerListComponent {
     this.favoriteServers.next(favoriteServers);
 
     settingService.fontSizeChange.subscribe(fontSize => {
-      const font_height_str = fontSizeToPixels[fontSize].slice(-2);
-      this.rowHeight.next(parseInt(font_height_str)*2)
+      this.rowHeight.next(fontSizeToPixels[fontSize]*2)
     })
   }
 

--- a/Code/skyrim_ui/src/app/components/settings/settings.component.ts
+++ b/Code/skyrim_ui/src/app/components/settings/settings.component.ts
@@ -16,8 +16,8 @@ export const fontSizeToPixels: Record<FontSize, string> = {
   [FontSize.XS]: '10px',
   [FontSize.S]: '12px',
   [FontSize.M]: '16px',
-  [FontSize.L]: '18px',
-  [FontSize.XL]: '20px',
+  [FontSize.L]: '20px',
+  [FontSize.XL]: '26px',
 }
 
 export enum PartyAnchor {

--- a/Code/skyrim_ui/src/app/components/settings/settings.component.ts
+++ b/Code/skyrim_ui/src/app/components/settings/settings.component.ts
@@ -1,24 +1,8 @@
 import { Component, EventEmitter, HostListener, OnInit, Output } from '@angular/core';
 import { TranslocoService } from '@ngneat/transloco';
 import { ClientService } from 'src/app/services/client.service';
-import { SettingService } from 'src/app/services/setting.service';
+import { FontSize, SettingService } from 'src/app/services/setting.service';
 import { Sound, SoundService } from '../../services/sound.service';
-
-export enum FontSize {
-  XS = 'xs',
-  S = 's',
-  M = 'm',
-  L = 'l',
-  XL = 'xl'
-}
-
-export const fontSizeToPixels: Record<FontSize, string> = {
-  [FontSize.XS]: '10px',
-  [FontSize.S]: '12px',
-  [FontSize.M]: '16px',
-  [FontSize.L]: '20px',
-  [FontSize.XL]: '26px',
-}
 
 export enum PartyAnchor {
   TOP_LEFT,

--- a/Code/skyrim_ui/src/app/services/setting.service.ts
+++ b/Code/skyrim_ui/src/app/services/setting.service.ts
@@ -1,9 +1,24 @@
 import { Injectable } from '@angular/core';
 import { TranslocoService } from '@ngneat/transloco';
 import { BehaviorSubject } from 'rxjs';
-import {FontSize, PartyAnchor} from '../components/settings/settings.component';
+import { PartyAnchor} from '../components/settings/settings.component';
 import { StoreService } from './store.service';
 
+export enum FontSize {
+  XS = 'xs',
+  S = 's',
+  M = 'm',
+  L = 'l',
+  XL = 'xl'
+}
+
+export const fontSizeToPixels: Record<FontSize, number> = {
+  [FontSize.XS]: 10,
+  [FontSize.S]: 12,
+  [FontSize.M]: 16,
+  [FontSize.L]: 20,
+  [FontSize.XL]: 26,
+}
 
 @Injectable({
   providedIn: 'root',

--- a/Code/skyrim_ui/src/styles.scss
+++ b/Code/skyrim_ui/src/styles.scss
@@ -52,8 +52,10 @@ select {
   padding: $-size-gap * 0.5;
   background: transparent;
   color: mod($-color-background, 1);
-  border: 3px solid #808081;
+}
 
+input[type=text] {  
+  border: 3px solid #808081;
   &:hover {
     border: 3px solid mod($-color-background, 0.75);;
   }

--- a/Code/skyrim_ui/src/styles.scss
+++ b/Code/skyrim_ui/src/styles.scss
@@ -52,8 +52,15 @@ select {
   padding: $-size-gap * 0.5;
   background: transparent;
   color: mod($-color-background, 1);
-  border: 3px solid;
-  border-image: url("assets/images/separator/single.svg") 3;
+  border: 3px solid #808081;
+
+  &:hover {
+    border: 3px solid mod($-color-background, 0.75);;
+  }
+
+  &:focus-visible {
+    border: 3px solid mod($-color-background, 0.9);;
+  }
 }
 
 input[type=range] {


### PR DESCRIPTION
- Save password is now readable and has proper margins
- Input boxes light up when hovered or focused, so you can see where you are typing even if the caret doesn't load
- Server list no longer skips around when scrolling. This was solved by making the font size fixed again so it doesn't interfere virtual scroll.

Before:
![image](https://user-images.githubusercontent.com/43607012/188852517-d95aa948-2f7a-4a12-a822-681620fb056c.png)

After:
![image](https://user-images.githubusercontent.com/43607012/188852200-e23daf2a-2015-4c34-b681-a828b1ef1f23.png)
