### PR TITLE
fix: q key not working in chat

### DIFF
--- a/Code/client/Services/Generic/InputService.cpp
+++ b/Code/client/Services/Generic/InputService.cpp
@@ -235,7 +235,7 @@ void ProcessKeyboard(uint16_t aKey, uint16_t aScanCode, cef_key_event_type_t aTy
 
     spdlog::debug("ProcessKey, type: {}, key: {}, active: {}", aType, aKey, active);
 
-    if (IsToggleKey(aKey) || (IsDisableKey(aKey) && active))
+    if (aType != KEYEVENT_CHAR && (IsToggleKey(aKey) || (IsDisableKey(aKey) && active)))
     {
         if (!overlay.GetInGame())
         {


### PR DESCRIPTION
'q' was being detected as a toggle key when the KEYEVENT_CHAR event was propagated.