### PR TITLE
Tweak for multi-stage, multi-arch build for docker server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,29 +8,28 @@ WORKDIR /home/builder
 ENV XMAKE_ROOT=y
 
 RUN git clone --recursive -b ${BRANCH} ${REPO} ./str && \
-    cd str && xmake config -m release -y && xmake -y && xmake install -o package -y && \
-    cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30 /home/builder/libstdc++.so.6 2>/dev/null || :
+    cd str && xmake config -m release -y && xmake -y && xmake install -o package -y
 
 
-#Building for x86_64
+# Building for x86_64
 FROM builder as amd64builder
 
 RUN cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30 /home/builder/libstdc++.so.6 2>/dev/null || :
 
 
-#Building for arm64/v8
+# Building for arm64/v8
 FROM builder as arm64builder
 
 RUN cp /usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.30 /home/builder/libstdc++.so.6 2>/dev/null || :
 
 
-#Intermediate image that has the library specific to our $TARGETARCH
+# Intermediate image that has the library specific to our $TARGETARCH
 FROM ${TARGETARCH}builder as intermediate
+# If a user has built without buildx, attempt to save them
+RUN if [ "${TARGETARCH}" = "" ]; then export LIBFILE="/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30"; if [ ! -e ${LIBFILE} ]; then export LIBFILE=/usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.30; fi ; cp ${LIBFILE} /home/builder/libstdc++.so.6; fi
 
-RUN echo "Building for $TARGETARCH"
 
-
-#Actual server image
+# Build actual server image
 FROM ubuntu:22.04
 
 COPY --from=intermediate /home/builder/str/package/lib/libSTServer.so /home/server/libSTServer.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 
 FROM outshynd/multiarch-builder:latest as builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM tiltedphoques/multiarch-builder:latest as builder
+ARG TARGETARCH=amd64
+
+FROM outshynd/multiarch-builder:latest as builder
 
 ARG REPO=https://github.com/tiltedphoques/TiltedEvolution.git
 ARG BRANCH=master
@@ -14,17 +16,19 @@ RUN git clone --recursive -b ${BRANCH} ${REPO} ./str && \
 #Building for x86_64
 FROM builder as amd64builder
 
-RUN cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30 /home/builder/libstdc++.so.6
+RUN cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30 /home/builder/libstdc++.so.6 2>/dev/null || :
 
 
 #Building for arm64/v8
 FROM builder as arm64builder
 
-RUN cp /usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.30 /home/builder/libstdc++.so.6
+RUN cp /usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.30 /home/builder/libstdc++.so.6 2>/dev/null || :
 
 
 #Intermediate image that has the library specific to our $TARGETARCH
 FROM ${TARGETARCH}builder as intermediate
+
+ARG TARGETARCH
 
 RUN echo "Building for $TARGETARCH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG TARGETARCH
-
-FROM outshynd/multiarch-builder:latest as builder
+FROM tiltedphoques/multiarch-builder:latest as builder
 
 ARG REPO=https://github.com/tiltedphoques/TiltedEvolution.git
 ARG BRANCH=master
@@ -10,7 +8,8 @@ WORKDIR /home/builder
 ENV XMAKE_ROOT=y
 
 RUN git clone --recursive -b ${BRANCH} ${REPO} ./str && \
-    cd str && xmake config -m release -y && xmake -y && xmake install -o package -y
+    cd str && xmake config -m release -y && xmake -y && xmake install -o package -y && \
+    cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30 /home/builder/libstdc++.so.6 2>/dev/null || :
 
 
 #Building for x86_64
@@ -27,8 +26,6 @@ RUN cp /usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.30 /home/builder/libstdc++.so
 
 #Intermediate image that has the library specific to our $TARGETARCH
 FROM ${TARGETARCH}builder as intermediate
-
-ARG TARGETARCH
 
 RUN echo "Building for $TARGETARCH"
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,20 +1,21 @@
-FROM ubuntu:20.04 AS builder
+FROM ubuntu:22.04
 
-RUN apt update && \
-    apt install software-properties-common -y && \
-    add-apt-repository universe -y && \
-    apt update && \
-    apt install libssl-dev curl p7zip-full p7zip-rar zip unzip zlib1g-dev wget -y && \
-    curl -fsSL https://xmake.io/shget.text > getxmake.sh && chmod +x getxmake.sh && ./getxmake.sh && \
-    wget ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-12.1.0/gcc-12.1.0.tar.xz && \
-    tar xf gcc-12.1.0.tar.xz && \
-    rm -f gcc-12.1.0.tar.xz && \
-    cd gcc-12.1.0 && \
-    contrib/download_prerequisites && \
-    mkdir -p obj && \
-    cd obj && \
-    ../configure --enable-languages=c,c++ --disable-multilib && \
-    make -j 4 && \
+WORKDIR /home/builder
+
+RUN apt update && apt install \
+    cmake \
+    unzip \
+    git \
+    gcc-12 \
+    g++-12 \
+    build-essential \
+    ca-certificates \
+    curl \
+    --no-install-recommends -y && \
+    git clone --recursive https://github.com/xmake-io/xmake.git ./xmake && \
+    cd xmake && \
+    make build && \
     make install && \
-    cd ../.. && \
-    rm -rf gcc-12.1.0
+    cd .. && rm -rf xmake/ && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 110 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12 && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
     ports:
-      - "10578:10578/udp"
+      - 10578:10578/udp
     restart: unless-stopped
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,17 @@
-version: '3'
+version: "3"
 
 services:
-  skyrim_server:
-    build:
-      context: .
+  skyrim-together:
+    image: tiltedphoques/st-reborn-server:latest
+    container_name: skyrim-together
     volumes:
-     - ./build/config:/home/server/config
-     - ./build/logs:/home/server/logs
-     - ./build/Data:/home/server/Data
+      - /home/user/skyrim-together:/home/server/config
+      - /home/user/skyrim-together/Data:/home/server/Data
+      - /home/user/skyrim-together/logs:/home/server/logs
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     ports:
-    - 10578:10578/udp
-    
+      - "10578:10578/udp"
+    restart: unless-stopped
+    stdin_open: true
+    tty: true

--- a/docker-multiarch-build.sh
+++ b/docker-multiarch-build.sh
@@ -1,0 +1,5 @@
+#build the builder for both x86_64 and arm64 platforms
+docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.builder -t tiltedphoques/multiarch-builder:latest --push .
+
+#build the server for both x86_64 and arm64 platforms
+docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile -t tiltedphoques/str-reborn-server:latest --push .

--- a/docker-multiarch-build.sh
+++ b/docker-multiarch-build.sh
@@ -1,5 +1,14 @@
+#set up buildx builder
+docker buildx create --name str-multiarch --use
+
+#clean up qemu for some reason
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
 #build the builder for both x86_64 and arm64 platforms
-docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.builder -t tiltedphoques/multiarch-builder:latest --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.builder -t outshynd/multiarch-builder:latest --push .
 
 #build the server for both x86_64 and arm64 platforms
-docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile -t tiltedphoques/str-reborn-server:latest --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile -t outshynd/str-reborn-server:latest --push .
+
+#remove buildx builder
+docker buildx rm str-multiarch

--- a/docker-multiarch-build.sh
+++ b/docker-multiarch-build.sh
@@ -5,10 +5,10 @@ docker buildx create --name str-multiarch --use
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 #build the builder for both x86_64 and arm64 platforms
-docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.builder -t outshynd/multiarch-builder:latest --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.builder -t tiltedphoques/multiarch-builder:latest --push .
 
 #build the server for both x86_64 and arm64 platforms
-docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile -t outshynd/str-reborn-server:latest --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile -t tiltedphoques/str-reborn-server:latest --push .
 
 #remove buildx builder
 docker buildx rm str-multiarch

--- a/docker-multiarch-build.sh
+++ b/docker-multiarch-build.sh
@@ -8,7 +8,7 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.builder -t tiltedphoques/multiarch-builder:latest --push .
 
 #build the server for both x86_64 and arm64 platforms
-docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile -t tiltedphoques/str-reborn-server:latest --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile -t tiltedphoques/st-reborn-server:latest --push .
 
 #remove buildx builder
 docker buildx rm str-multiarch


### PR DESCRIPTION
In an effort to teach myself a bit more about Docker, I set about reconfiguring the docker build process for the server.

I matched the docker build process a bit more closely to the `Build linux` workflow, just in case there are any build differences that don't catch edge-case issues.  This includes using `ubuntu:22.04` as a base, installing gcc-12/g++-12 with apt and using `apt update-alternatives` to set it as default.

I also used a little bit of intermediate build trickery to copy only the architecture specific libstdc++.so.6, though I placed it in the server directory (instead of system lib directory) to get around platform issues.

Added `docker-multiarch-build.sh` which automates the build process, including pushing to docker hub.  The commands for building manually are contained in this file.

I changed docker-compose.yml to be more in line with pulling and running a server, enabling a few tweaks like mounting localtime for correct timestamped logs and enabing the equivalent of `-it` flags to allow users to attach and send commands.