### PR TITLE
fix: crash when attempting soul trap animal #406

### DIFF
--- a/Code/client/Games/Misc/SubtitleManager.cpp
+++ b/Code/client/Games/Misc/SubtitleManager.cpp
@@ -55,7 +55,7 @@ void TP_MAKE_THISCALL(HookShowSubtitle, SubtitleManager, TESObjectREFR* apSpeake
     //spdlog::debug("Subtitle for actor {:X} (bool {}):\n\t{}", apSpeaker ? apSpeaker->formID : 0, aIsInDialogue, apSubtitleText);
 
     Actor* pActor = Cast<Actor>(apSpeaker);
-    if (pActor && pActor->GetExtension()->IsLocal() && !pActor->GetExtension()->IsPlayer())
+    if (apSubtitleText && pActor && pActor->GetExtension()->IsLocal() && !pActor->GetExtension()->IsPlayer())
 #if TP_SKYRIM64
         World::Get().GetRunner().Trigger(SubtitleEvent(apSpeaker->formID, apSubtitleText));
 #elif TP_FALLOUT4


### PR DESCRIPTION
Fixed issue #406  for me.
Tested with chicken and fox.