### PR TITLE
fix: animations with new skyrim update

### DIFF
--- a/Code/client/Games/Skyrim/BSAnimationGraphManager.h
+++ b/Code/client/Games/Skyrim/BSAnimationGraphManager.h
@@ -20,7 +20,7 @@ struct BSAnimationGraphManager
     volatile LONG refCount;
     void* pad_ptrs[6];
     BSTSmallArray<BShkbAnimationGraph> animationGraphs; // 40 - 20
-    void* pad_ptrs2[8];
+    void* pad_ptrs2[9];
     BSRecursiveLock lock; // 98 - 4C
     void* unkPtrAfterLock; // A0 - 58
 
@@ -38,8 +38,8 @@ struct BSAnimationGraphManager
 
 #if TP_PLATFORM_64
 static_assert(offsetof(BSAnimationGraphManager, animationGraphs) == 0x40);
-static_assert(offsetof(BSAnimationGraphManager, lock) == 0x98);
-static_assert(offsetof(BSAnimationGraphManager, animationGraphIndex) == 0xA8);
+static_assert(offsetof(BSAnimationGraphManager, lock) == 0xA0);
+static_assert(offsetof(BSAnimationGraphManager, animationGraphIndex) == 0xB0);
 #else
 static_assert(offsetof(BSAnimationGraphManager, animationGraphs) == 0x20);
 static_assert(offsetof(BSAnimationGraphManager, lock) == 0x4C);


### PR DESCRIPTION
Bethesda has modified another struct, BSAnimationGraphManager. Needed extra padding to properly work again, so that NPCs can draw their weapons and the player can sprint.