### PR TITLE
fix: serverlist related crashes

### DIFF
--- a/Code/encoding/Structs/ReferenceUpdate.cpp
+++ b/Code/encoding/Structs/ReferenceUpdate.cpp
@@ -32,9 +32,6 @@ void ReferenceUpdate::Deserialize(TiltedPhoques::Buffer::Reader& aReader)
     UpdatedMovement.Deserialize(aReader);
 
     const auto count = Serialization::ReadVarInt(aReader);
-    // TODO: keeps throwing in fallout together with more than 2 players
-    if (count > 0x100)
-        throw std::runtime_error("Too many reference updates received !");
 
     ActionEvents.resize(count);
 

--- a/Code/server/Services/ServerListService.cpp
+++ b/Code/server/Services/ServerListService.cpp
@@ -93,16 +93,16 @@ void ServerListService::PostAnnouncement(String acName, String acDesc, String ac
 
     httplib::Client client(kMasterServerEndpoint);
     client.enable_server_certificate_verification(false);
+    client.set_read_timeout(std::chrono::milliseconds(1500));
     const auto response = client.Post("/announce", params);
 
-    // If we send a 203 it means we banned this server
+    // If we send a 403 it means we banned this server
     if (response)
     {
         if (response->status == 403)
             GameServer::Get()->Kill();
         else if (response->status != 200)
             spdlog::error("Server list error! {}", response->body);
-
     }
     else
     {


### PR DESCRIPTION
Exception shouldn't really be thrown in the event of too many requests to the client.