### PR TITLE
fix: force spdlog flush on crash

### DIFF
--- a/Code/client/CrashHandler.cpp
+++ b/Code/client/CrashHandler.cpp
@@ -24,6 +24,7 @@ LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 {
     if (pExceptionInfo->ExceptionRecord->ExceptionCode == 0xC0000005)
     {
+        spdlog::error("Crash occured!");
         MINIDUMP_EXCEPTION_INFORMATION M;
         char dumpPath[MAX_PATH];
 
@@ -61,6 +62,9 @@ LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
                           (pExceptionInfo) ? &M : NULL, NULL, NULL);
 
         CloseHandle(hDumpFile);
+
+        spdlog::error("Coredump created -> flush logs.");
+        spdlog::default_logger()->flush();
 
         return EXCEPTION_EXECUTE_HANDLER;
     }

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -337,6 +337,7 @@ void DebugService::OnDraw() noexcept
         if (ImGui::Button("Crash Client"))
         {
 #if (!IS_MASTER)
+            spdlog::error("Crash client");
             int* m = 0;
             *m = 1338;
 #else


### PR DESCRIPTION
Fix for #538 

This fix contains log flush, when CrashHandler is used.
I don't know how fix it, when ScopedCrashHandler is used, but this should not be problem, because PR #511 (Crash dump dialog) remove ScopedCrashHandler and use CrashHandler for master and dev branches.