### PR TITLE
Fix chat encoding

### DIFF
--- a/Code/client/CrashHandler.cpp
+++ b/Code/client/CrashHandler.cpp
@@ -24,7 +24,7 @@ LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 {
     if (pExceptionInfo->ExceptionRecord->ExceptionCode == 0xC0000005)
     {
-        spdlog::error("Crash occured!");
+        spdlog::error("Crash occurred!");
         MINIDUMP_EXCEPTION_INFORMATION M;
         char dumpPath[MAX_PATH];
 

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -483,7 +483,7 @@ void CharacterService::OnCharacterSpawn(const CharacterSpawnRequest& acMessage) 
     if (pActor->IsDead() != acMessage.IsDead)
         acMessage.IsDead ? pActor->Kill() : pActor->Respawn();
 
-    spdlog::info("Spawn Reqeust Is summon {}", acMessage.IsPlayerSummon);
+    spdlog::info("Spawn Request Is summon {}", acMessage.IsPlayerSummon);
 
 #if TP_SKYRIM64
     if (acMessage.IsPlayerSummon)

--- a/Code/client/Services/Generic/InputService.cpp
+++ b/Code/client/Services/Generic/InputService.cpp
@@ -438,7 +438,7 @@ LRESULT CALLBACK InputService::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPAR
         if (!IsWindowUnicode(hwnd))
         {
             wchar_t wch;
-            ::MultiByteToWideChar(s_currentACP, MB_PRECOMPOSED, (char*) &virtualKey, 2, &wch, sizeof(wchar_t));
+            ::MultiByteToWideChar(s_currentACP, MB_PRECOMPOSED, reinterpret_cast<char*>(&virtualKey), 2, &wch, sizeof(wchar_t));
             virtualKey = wch;
         }
         ProcessKeyboard(virtualKey, scancode, KEYEVENT_CHAR, false, false);

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -92,7 +92,7 @@ void InventoryService::OnEquipmentChangeEvent(const EquipmentChangeEvent& acEven
     std::optional<uint32_t> serverIdRes = Utils::GetServerId(*iter);
     if (!serverIdRes.has_value())
     {
-        spdlog::error(__FUNCTION__ ": failed to find server id, actor id: {:X}, item id: {:X}, unequip: {}, slot: {:X}", acEvent.ActorId, acEvent.IsAmmo, acEvent.Unequip, acEvent.EquipSlotId);
+        spdlog::error(__FUNCTION__ ": failed to find server id, actor id: {:X}, item id: {:X}, isAmmo: {}, unequip: {}, slot: {:X}", acEvent.ActorId, acEvent.ItemId, acEvent.IsAmmo, acEvent.Unequip, acEvent.EquipSlotId);
         return;
     }
 

--- a/Code/client/Services/Generic/OverlayClient.cpp
+++ b/Code/client/Services/Generic/OverlayClient.cpp
@@ -110,7 +110,7 @@ void OverlayClient::ProcessChatMessage(CefRefPtr<CefListValue> aEventArgs)
         messageRequest.MessageType = static_cast<ChatMessageType>(aEventArgs->GetInt(0));
         messageRequest.ChatMessage = contents;
 
-        // Logging of unicode character is broken and fixing it is not realistic
+        // @TODO fix logging of unicode characters
         spdlog::info("Send chat message of type {}: '{}' ", messageRequest.MessageType, messageRequest.ChatMessage);
         m_transport.Send(messageRequest);
     }

--- a/Code/client/Services/Generic/OverlayClient.cpp
+++ b/Code/client/Services/Generic/OverlayClient.cpp
@@ -110,6 +110,7 @@ void OverlayClient::ProcessChatMessage(CefRefPtr<CefListValue> aEventArgs)
         messageRequest.MessageType = static_cast<ChatMessageType>(aEventArgs->GetInt(0));
         messageRequest.ChatMessage = contents;
 
+        // Logging of unicode character is broken and fixing it is not realistic
         spdlog::info("Send chat message of type {}: '{}' ", messageRequest.MessageType, messageRequest.ChatMessage);
         m_transport.Send(messageRequest);
     }

--- a/Code/client/Services/Generic/OverlayClient.cpp
+++ b/Code/client/Services/Generic/OverlayClient.cpp
@@ -110,8 +110,7 @@ void OverlayClient::ProcessChatMessage(CefRefPtr<CefListValue> aEventArgs)
         messageRequest.MessageType = static_cast<ChatMessageType>(aEventArgs->GetInt(0));
         messageRequest.ChatMessage = contents;
 
-        // @TODO fix logging of unicode characters
-        spdlog::info("Send chat message of type {}: '{}' ", messageRequest.MessageType, messageRequest.ChatMessage);
+        spdlog::info(L"Send chat message of type {}: '{}' ", messageRequest.MessageType, aEventArgs->GetString(1).ToWString());
         m_transport.Send(messageRequest);
     }
 }

--- a/Code/client/TiltedOnlineApp.cpp
+++ b/Code/client/TiltedOnlineApp.cpp
@@ -22,6 +22,9 @@ using TiltedPhoques::Debug;
 
 TiltedOnlineApp::TiltedOnlineApp()
 {
+    // Set console code page to UTF-8 so console known how to interpret string data
+    SetConsoleOutputCP(CP_UTF8);
+
     auto logPath = TiltedPhoques::GetPath() / "logs";
 
     std::error_code ec;

--- a/Code/client/TiltedOnlinePCH.h
+++ b/Code/client/TiltedOnlinePCH.h
@@ -52,6 +52,7 @@ extern void* RipAllocateN(size_t blockLength);
 #include <JitAssembly.hpp>
 
 #define SPDLOG_WCHAR_FILENAMES
+#define SPDLOG_WCHAR_TO_UTF8_SUPPORT
 #include <entt/entt.hpp>
 #include <spdlog/spdlog.h>
 #include <glm/glm.hpp>


### PR DESCRIPTION
Fix for #234.

Tested mainly with Czech keyboard, that contains characters that were also broken (ěšěčšřčžřýáíé...).
Done little testing with Russian keyboard and look to me fixed. 
![Encoding-cz](https://user-images.githubusercontent.com/13061508/209572909-3341c9d2-ed02-4169-addd-0e088f2acf8c.png)
![Encoding-ru](https://user-images.githubusercontent.com/13061508/209572915-8fe09d5b-7538-4864-be6d-dcb9d0604f4b.png)
