### PR TITLE
Fix build

### DIFF
--- a/Code/tp_process/main.cpp
+++ b/Code/tp_process/main.cpp
@@ -1,6 +1,6 @@
 
 #include <windows.h>
-#include <OverlayApp.hpp>
+#include <OverlayProc.hpp>
 #include "ProcessHandler.h"
 
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)

--- a/xmake.lua
+++ b/xmake.lua
@@ -45,17 +45,26 @@ add_requires(
 
 add_requireconfs("cpp-httplib", {configs = {ssl = true}})
 add_requireconfs("sentry-native", { configs = { backend = "crashpad" } })
+--[[
 add_requireconfs("magnum", { configs = { sdl2 = true }})
 add_requireconfs("magnum-integration",  { configs = { imgui = true }})
 add_requireconfs("magnum-integration.magnum",  { configs = { sdl2 = true }})
 add_requireconfs("magnum-integration.imgui", { override = true })
+--]]
 
 if is_plat("windows") then
     add_requires(
         "discord", 
-        "imgui", 
+        "imgui"
+    )
+    --[[
+    add_requires(
+        "discord", 
+        "imgui",
         "magnum", 
-        "magnum-integration")
+        "magnum-integration"
+    )
+    --]]
 end
 
 before_build(function (target)


### PR DESCRIPTION
Magnum fails to compile, sdl2 cannot be found. We only used magnum in the admin app, which doesn't function anyway so might as well be excluded. The latest xmake update also seems to change the way they include headers somewhat, which created a conflict in TiltedUI with the two OverlayApp classes.