### PR TITLE
Fix: double consumption bug

### DIFF
--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -147,7 +147,7 @@ struct Actor : TESObjectREFR
     virtual void sub_10C();
     virtual void sub_10D();
     virtual void KillImpl(Actor* apAttacker, float aDamage, bool aSendEvent, bool aRagdollInstant);
-    virtual void sub_10F();
+    virtual void DrinkPotion(TESBoundObject* apItem, ExtraDataList* apExtraDataList); // 90% sure about this
     virtual void sub_110();
     virtual void sub_111();
     virtual void sub_112();

--- a/Code/client/Games/Skyrim/EquipManager.cpp
+++ b/Code/client/Games/Skyrim/EquipManager.cpp
@@ -144,7 +144,10 @@ void* TP_MAKE_THISCALL(EquipHook, EquipManager, Actor* apActor, TESForm* apItem,
             return nullptr;
     }
 
-    if (pExtension->IsLocal())
+    // Consumables are "equipped" as well. We don't want this to sync, for several reasons.
+    // The right hand item on the server would be overridden by the consumable.
+    // Furthermore, the equip action on the other clients would doubly subtract the consumables.
+    if (pExtension->IsLocal() && !apItem->IsConsumable())
     {
         EquipmentChangeEvent evt{};
         evt.ActorId = apActor->formID;

--- a/Code/client/Games/Skyrim/Forms/TESForm.h
+++ b/Code/client/Games/Skyrim/Forms/TESForm.h
@@ -8,10 +8,12 @@ enum class FormType : uint8_t
     Book = 27,
     Container = 28,
     Door = 29,
+    Ingredient = 30,
     Weapon = 41,
     Ammo = 42,
     Npc = 43,
     LeveledCharacter = 44,
+    Alchemy = 46,
     Character = 62,
     QuestItem = 77,
     Count = 0x87
@@ -107,6 +109,7 @@ struct TESForm : BaseFormComponent
 
     bool IsDisabled() const noexcept { return (flags & DISABLED) != 0; }
     bool IsTemporary() const noexcept { return formID >= 0xFF000000; }
+    bool IsConsumable() const noexcept { return formType == FormType::Ingredient || formType == FormType::Alchemy; }
 
     uintptr_t unk4;
     uint32_t flags;


### PR DESCRIPTION
Ingredients, food and potions would be consumed multiple times due to them being "equipped". This PR fixes that by excluding the consumable equips from syncing, and just syncing the effects and withdrawing one item.