### PR TITLE
Weather code rework

### DIFF
--- a/Code/client/Games/Fallout4/Sky/Sky.h
+++ b/Code/client/Games/Fallout4/Sky/Sky.h
@@ -10,6 +10,7 @@ struct Sky
 
     void SetWeather(TESWeather* apWeather) noexcept;
     void ForceWeather(TESWeather* apWeather) noexcept;
+    void ReleaseWeatherOverride() noexcept;
     void ResetWeather() noexcept;
 
     TESWeather* GetWeather() const noexcept;

--- a/Code/client/Games/References.cpp
+++ b/Code/client/Games/References.cpp
@@ -848,6 +848,17 @@ void Sky::ForceWeather(TESWeather* apWeather) noexcept
     TiltedPhoques::ThisCall(RealForceWeather, this, apWeather, true);
 }
 
+void Sky::ReleaseWeatherOverride() noexcept
+{
+#if TP_SKYRIM64
+    TP_THIS_FUNCTION(TReleaseWeatherOverride, void, Sky);
+    POINTER_SKYRIMSE(TReleaseWeatherOverride, releaseWeatherOverride, 26244);
+    // TODO(ft)
+
+    TiltedPhoques::ThisCall(releaseWeatherOverride, this);
+#endif
+}
+
 void Sky::ResetWeather() noexcept
 {
     TP_THIS_FUNCTION(TResetWeather, void, Sky);

--- a/Code/client/Games/References.cpp
+++ b/Code/client/Games/References.cpp
@@ -1013,9 +1013,9 @@ void TP_MAKE_THISCALL(HookSetWeather, Sky, TESWeather* apWeather, bool abOverrid
 
     if (!Sky::s_shouldUpdateWeather)
         return;
+#endif
 
     TiltedPhoques::ThisCall(RealSetWeather, apThis, apWeather, abOverride, abAccelerate);
-#endif
 }
 
 void TP_MAKE_THISCALL(HookForceWeather, Sky, TESWeather* apWeather, bool abOverride)
@@ -1025,9 +1025,9 @@ void TP_MAKE_THISCALL(HookForceWeather, Sky, TESWeather* apWeather, bool abOverr
 
     if (!Sky::s_shouldUpdateWeather)
         return;
+#endif
 
     TiltedPhoques::ThisCall(RealForceWeather, apThis, apWeather, abOverride);
-#endif
 }
 
 TP_THIS_FUNCTION(TUpdateWeather, void, Sky);
@@ -1038,9 +1038,9 @@ void TP_MAKE_THISCALL(HookUpdateWeather, Sky)
 #if 0
     if (!Sky::s_shouldUpdateWeather)
         return;
+#endif
 
     TiltedPhoques::ThisCall(RealUpdateWeather, apThis);
-#endif
 }
 
 TP_THIS_FUNCTION(TAddDeathItems, void, Actor);

--- a/Code/client/Games/References.cpp
+++ b/Code/client/Games/References.cpp
@@ -1008,22 +1008,26 @@ void TP_MAKE_THISCALL(HookSetCurrentPickREFR, Console, BSPointerHandle<TESObject
 
 void TP_MAKE_THISCALL(HookSetWeather, Sky, TESWeather* apWeather, bool abOverride, bool abAccelerate)
 {
+#if 0
     spdlog::debug("Set weather form id: {:X}, override: {}, accelerate: {}", apWeather ? apWeather->formID : 0, abOverride, abAccelerate);
 
     if (!Sky::s_shouldUpdateWeather)
         return;
 
     TiltedPhoques::ThisCall(RealSetWeather, apThis, apWeather, abOverride, abAccelerate);
+#endif
 }
 
 void TP_MAKE_THISCALL(HookForceWeather, Sky, TESWeather* apWeather, bool abOverride)
 {
+#if 0
     spdlog::debug("Force weather form id: {:X}, override: {}", apWeather ? apWeather->formID : 0, abOverride);
 
     if (!Sky::s_shouldUpdateWeather)
         return;
 
     TiltedPhoques::ThisCall(RealForceWeather, apThis, apWeather, abOverride);
+#endif
 }
 
 TP_THIS_FUNCTION(TUpdateWeather, void, Sky);
@@ -1031,10 +1035,12 @@ static TUpdateWeather* RealUpdateWeather = nullptr;
 
 void TP_MAKE_THISCALL(HookUpdateWeather, Sky)
 {
+#if 0
     if (!Sky::s_shouldUpdateWeather)
         return;
 
     TiltedPhoques::ThisCall(RealUpdateWeather, apThis);
+#endif
 }
 
 TP_THIS_FUNCTION(TAddDeathItems, void, Actor);

--- a/Code/client/Games/Skyrim/Sky/Sky.h
+++ b/Code/client/Games/Skyrim/Sky/Sky.h
@@ -12,6 +12,7 @@ struct Sky
 
     void SetWeather(TESWeather* apWeather) noexcept;
     void ForceWeather(TESWeather* apWeather) noexcept;
+    void ReleaseWeatherOverride() noexcept;
     void ResetWeather() noexcept;
 
     TESWeather* GetWeather() const noexcept;

--- a/Code/client/Services/Generic/WeatherService.cpp
+++ b/Code/client/Services/Generic/WeatherService.cpp
@@ -184,9 +184,6 @@ void WeatherService::RunWeatherUpdates(const double acDelta) noexcept
 
 void WeatherService::ToggleGameWeatherSystem(bool aToggle) noexcept
 {
-    // TODO: use this
-    m_useGameWeather = aToggle;
-
     if (aToggle)
         Sky::Get()->ReleaseWeatherOverride();
     else

--- a/Code/client/Services/Generic/WeatherService.cpp
+++ b/Code/client/Services/Generic/WeatherService.cpp
@@ -190,18 +190,6 @@ void WeatherService::ToggleGameWeatherSystem(bool aToggle) noexcept
         m_transport.Send(RequestCurrentWeather());
 
     m_cachedWeatherId = 0;
-
-#if 0
-    Sky::s_shouldUpdateWeather = aToggle;
-
-    if (aToggle)
-        Sky::Get()->ResetWeather();
-
-    if (!aToggle)
-        m_transport.Send(RequestCurrentWeather());
-
-    m_cachedWeatherId = 0;
-#endif
 }
 
 void WeatherService::SetCachedWeather() noexcept

--- a/Code/client/Services/WeatherService.h
+++ b/Code/client/Services/WeatherService.h
@@ -30,12 +30,19 @@ protected:
     void RunWeatherUpdates(const double acDelta) noexcept;
 
     void ToggleGameWeatherSystem(bool aToggle) noexcept;
+    void SetCachedWeather() noexcept;
 
 private:
     World& m_world;
     TransportService& m_transport;
 
-    bool m_isInParty{};
+    bool m_useGameWeather{};
+
+    /**
+    * This variable has two uses:
+    * For the party leader, it is used to detect weather changes.
+    * For non-leaders, it is used to reapply the server weather if it changes.
+    */
     uint32_t m_cachedWeatherId{};
 
     entt::scoped_connection m_updateConnection;

--- a/Code/client/Services/WeatherService.h
+++ b/Code/client/Services/WeatherService.h
@@ -36,8 +36,6 @@ private:
     World& m_world;
     TransportService& m_transport;
 
-    bool m_useGameWeather{};
-
     /**
     * This variable has two uses:
     * For the party leader, it is used to detect weather changes.


### PR DESCRIPTION
The old weather code had some problems. Skyrim's weather update loop didn't like being cancelled, resulting in crashes and odd visual bugs. This new strategy does not hook or cancel anything, but will instead use native functions ForceWeather and ReleaseWeatherOverride to force usage of the party leader's weather. In case that fails, there's a polling fallback.