### PR TITLE
fix: emerald claw crash

### DIFF
--- a/Code/client/Games/Skyrim/Misc/BSScript.cpp
+++ b/Code/client/Games/Skyrim/Misc/BSScript.cpp
@@ -85,7 +85,7 @@ template <class T> T* BSScript::Variable::ExtractComplexType() noexcept
     auto* pPolicy = GameVM::Get()->virtualMachine->GetObjectHandlePolicy();
     BSScript::Object* pBaseObject = GetObject();
 
-    if (!pBaseObject && !pPolicy)
+    if (!pBaseObject || !pPolicy)
         return nullptr;
 
     uint64_t handle = pBaseObject->GetHandle();


### PR DESCRIPTION
This PR fix crash caused when Keyhole for Emerald claw is activated (#561 #568).

NOTE: Issue with door opening synchronizations should be fixed in #570 .