### PR TITLE
fix: SetTime crash

### DIFF
--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -327,12 +327,12 @@ void GameServer::BindServerCommands()
 
     m_commands.RegisterCommand<>("quit", "Stop the server", [&](Console::ArgStack&) { Kill(); });
 
-    m_commands.RegisterCommand<int, int>(
+    m_commands.RegisterCommand<int64_t, int64_t>(
         "SetTime", "Set ingame hour and minute", [&](Console::ArgStack& aStack) {
             auto out = spdlog::get("ConOut");
 
-            auto hour = aStack.Pop<int>();
-            auto minute = aStack.Pop<int>();
+            auto hour = aStack.Pop<int64_t>();
+            auto minute = aStack.Pop<int64_t>();
             auto timescale = m_pWorld->GetCalendarService().GetTimeScale();
 
             bool time_set_successfully = m_pWorld->GetCalendarService().SetTime(hour, minute, timescale);


### PR DESCRIPTION
ArgStack integer arguments cannot be popped with any other type than int64_t, as that's how the argstack is created, and std::any will throw if you try to cast it to any other type.

https://github.com/tiltedphoques/TiltedEvolution/blob/master/Code/components/console/ConsoleRegistry.cpp#L290