### PR TITLE
Less janky combat targeting

### DIFF
--- a/Code/client/Games/Combat/CombatController.cpp
+++ b/Code/client/Games/Combat/CombatController.cpp
@@ -1,0 +1,12 @@
+#include "CombatController.h"
+
+// TODO: ft
+void CombatController::SetTarget(Actor* apTarget)
+{
+#if TP_SKYRIM64
+    TP_THIS_FUNCTION(TSetTarget, void, CombatController, Actor*);
+    POINTER_SKYRIMSE(TSetTarget, s_setTarget, 33235);
+    TiltedPhoques::ThisCall(s_setTarget, this, apTarget);
+#endif
+}
+

--- a/Code/client/Games/Combat/CombatController.h
+++ b/Code/client/Games/Combat/CombatController.h
@@ -1,0 +1,6 @@
+#pragma once
+
+struct CombatController
+{
+    void SetTarget(Actor* apTarget);
+};

--- a/Code/client/Games/Fallout4/Actor.h
+++ b/Code/client/Games/Fallout4/Actor.h
@@ -140,6 +140,7 @@ struct Actor : TESObjectREFR
     void DropOrPickUpObject(const Inventory::Entry& arEntry, NiPoint3* apPoint, NiPoint3* apRotate) noexcept;
     void UnequipItem(TESBoundObject* apObject) noexcept;
     void StartCombatEx(Actor* apTarget) noexcept;
+    void SetCombatTargetEx(Actor* apTarget) noexcept;
     void StartCombat(Actor* apTarget) noexcept;
     void StopCombat() noexcept;
 

--- a/Code/client/Games/References.cpp
+++ b/Code/client/Games/References.cpp
@@ -29,6 +29,7 @@
 #include <AI/AIProcess.h>
 #include <Magic/MagicCaster.h>
 #include <Sky/Sky.h>
+#include <Games/Combat/CombatController.h>
 
 #include <Events/LockChangeEvent.h>
 #include <Events/InitPackageEvent.h>
@@ -805,6 +806,15 @@ void Actor::StartCombatEx(Actor* apTarget) noexcept
         StopCombat();
         StartCombat(apTarget);
     }
+}
+
+// TODO: ft
+void Actor::SetCombatTargetEx(Actor* apTarget) noexcept
+{
+#if TP_SKYRIM64
+    if (pCombatController)
+        pCombatController->SetTarget(apTarget);
+#endif
 }
 
 void Actor::StartCombat(Actor* apTarget) noexcept

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -238,6 +238,7 @@ struct Actor : TESObjectREFR
     void DropOrPickUpObject(const Inventory::Entry& arEntry, NiPoint3* apPoint, NiPoint3* apRotate) noexcept;
     void SpeakSound(const char* pFile);
     void StartCombatEx(Actor* apTarget) noexcept;
+    void SetCombatTargetEx(Actor* apTarget) noexcept;
     void StartCombat(Actor* apTarget) noexcept;
     void StopCombat() noexcept;
 

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -207,10 +207,7 @@ void DebugService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
         {
             s_f8Pressed = true;
 
-            // m_world.GetOverlayService().Reload();
-            auto* pPlayer = PlayerCharacter::Get();
-            spdlog::info("{}", pPlayer->formID);
-            pPlayer->UnEquipAll();
+            PlaceActorInWorld();
         }
     }
     else

--- a/Code/client/Services/Generic/CombatService.cpp
+++ b/Code/client/Services/Generic/CombatService.cpp
@@ -217,7 +217,7 @@ void CombatService::OnHitEvent(const HitEvent& acEvent) const noexcept
 
     m_world.emplace_or_replace<CombatComponent>(*hitteeIt, acEvent.HitterId);
 
-    pHittee->StartCombatEx(pHitter);
+    pHittee->SetCombatTargetEx(pHitter);
 }
 
 void CombatService::RunTargetUpdates(const float acDelta) const noexcept
@@ -263,7 +263,7 @@ void CombatService::RunTargetUpdates(const float acDelta) const noexcept
             continue;
         }
 
-        pActor->StartCombatEx(pTarget);
+        pActor->SetCombatTargetEx(pTarget);
     }
 
     for (const auto entity : toRemove)


### PR DESCRIPTION
Enemies will lock onto players directly without shortly leaving combat first (i.e. sheathing and drawing their weapons constantly).