### PR TITLE
fix: wrong damage on hit from enemies

### DIFF
--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -170,15 +170,18 @@ void InventoryService::OnNotifyEquipmentChanges(const NotifyEquipmentChanges& ac
     uint32_t equipSlotId = modSystem.GetGameId(acMessage.EquipSlotId);
     TESForm* pEquipSlot = TESForm::GetById(equipSlotId);
 
+    // TODO: ft, does it have the same problem?
+#if TP_SKYRIM64
     uint32_t slotId = 0;
     if (pEquipSlot == DefaultObjectManager::Get().rightEquipSlot)
         slotId = 1;
 
     // There's a bug where double equipping something magically unequips something secretly.
-    // TODO: verify this, also, should this be done for armor as well?
+    // TODO: should this be done for armor as well?
     // Also, find out why the client is sending two equip messages in the first place.
     if (!acMessage.Unequip && pActor->GetEquippedWeapon(slotId) == pItem)
         return;
+#endif
 
     auto* pEquipManager = EquipManager::Get();
 

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -170,19 +170,25 @@ void InventoryService::OnNotifyEquipmentChanges(const NotifyEquipmentChanges& ac
     uint32_t equipSlotId = modSystem.GetGameId(acMessage.EquipSlotId);
     TESForm* pEquipSlot = TESForm::GetById(equipSlotId);
 
+    uint32_t slotId = 0;
+    if (pEquipSlot == DefaultObjectManager::Get().rightEquipSlot)
+        slotId = 1;
+
+    // There's a bug where double equipping something magically unequips something secretly.
+    // TODO: verify this, also, should this be done for armor as well?
+    // Also, find out why the client is sending two equip messages in the first place.
+    if (!acMessage.Unequip && pActor->GetEquippedWeapon(slotId) == pItem)
+        return;
+
     auto* pEquipManager = EquipManager::Get();
 
 #if TP_SKYRIM64
     if (acMessage.IsSpell)
     {
-        uint32_t spellSlotId = 0;
-        if (pEquipSlot == DefaultObjectManager::Get().rightEquipSlot)
-            spellSlotId = 1;
-
         if (acMessage.Unequip)
-            pEquipManager->UnEquipSpell(pActor, pItem, spellSlotId);
+            pEquipManager->UnEquipSpell(pActor, pItem, slotId);
         else
-            pEquipManager->EquipSpell(pActor, pItem, spellSlotId);
+            pEquipManager->EquipSpell(pActor, pItem, slotId);
 
         return;
     }


### PR DESCRIPTION
Fixed a bug where sometimes, enemies would not have a weapon equipped "internally", meaning that the damage would be whatever damage their unarmed attacks did.

Issue #306 