### PR TITLE
Fix - Exclude book activation sync when reading them

### DIFF
--- a/Code/client/Games/Skyrim/TESObjectREFR.cpp
+++ b/Code/client/Games/Skyrim/TESObjectREFR.cpp
@@ -593,7 +593,9 @@ bool TP_MAKE_THISCALL(HookPlayAnimation, void, uint32_t auiStackID, TESObjectREF
 void TP_MAKE_THISCALL(HookActivate, TESObjectREFR, TESObjectREFR* apActivator, uint8_t aUnk1, TESBoundObject* apObjectToGet, int32_t aCount, char aDefaultProcessing)
 {
     Actor* pActivator = Cast<Actor>(apActivator);
-    if (pActivator)
+
+    // Exclude books from activation since reading them removes them from the cell
+    if (pActivator && apObjectToGet->formType != FormType::Book)
         World::Get().GetRunner().Trigger(ActivateEvent(apThis, pActivator, apObjectToGet, aUnk1, aCount, aDefaultProcessing));
 
     return TiltedPhoques::ThisCall(RealActivate, apThis, apActivator, aUnk1, apObjectToGet, aCount, aDefaultProcessing);

--- a/Code/client/Games/Skyrim/TESObjectREFR.cpp
+++ b/Code/client/Games/Skyrim/TESObjectREFR.cpp
@@ -594,8 +594,9 @@ void TP_MAKE_THISCALL(HookActivate, TESObjectREFR, TESObjectREFR* apActivator, u
 {
     Actor* pActivator = Cast<Actor>(apActivator);
 
-    // Exclude books from activation since reading them removes them from the cell
-    if (pActivator && apObjectToGet->formType != FormType::Book)
+    // Exclude books from activation since only reading them removes them from the cell
+    // Note: Books are now unsynced 
+    if (pActivator && apThis->baseForm->formType != FormType::Book)
         World::Get().GetRunner().Trigger(ActivateEvent(apThis, pActivator, apObjectToGet, aUnk1, aCount, aDefaultProcessing));
 
     return TiltedPhoques::ThisCall(RealActivate, apThis, apActivator, aUnk1, apObjectToGet, aCount, aDefaultProcessing);


### PR DESCRIPTION
Books now remain in a cell after only reading them