### PR TITLE
got facgen to "work" with this simple line change

### DIFF
--- a/Code/client/TiltedOnlineApp.cpp
+++ b/Code/client/TiltedOnlineApp.cpp
@@ -72,7 +72,7 @@ void TiltedOnlineApp::Update()
     POINTER_SKYRIMSE(uint32_t, bUseFaceGenPreprocessedHeads, 378620);
     POINTER_FALLOUT4(uint32_t, bUseFaceGenPreprocessedHeads, 196397);
 
-    *bUseFaceGenPreprocessedHeads = 0;
+    *bUseFaceGenPreprocessedHeads = 1;
 
     // Make sure the window stays active
     POINTER_SKYRIMSE(uint32_t, bAlwaysActive, 380768);


### PR DESCRIPTION
Months ago I noticed that I had this bug in which if you reload a cell npc facegen can sometimes break. Sometimes it was indistinguishable other time you could see it a mile away. Do note I was on a modded version of STR but when reading discord history about this bug I've seen plenty of other users also had this bug on a vanilla environment with mismatched face and skin textures. So I've decided to see why this issue only persists on reborn and not on single player. I've then found the solution which irked me for months this line of code was set to this bUseFaceGenPreprocessedHeads = 0 which should've been this bUseFaceGenPreprocessedHeads = 1.

After figuring this out decided to research why this was disabled by default and found this quote from one of the head devs Yamashi: "Otherwise you have no facegen and get the weird skin tints"

So I've decided to test out this statement and the results were:

- Facegen worked for NPCs AND players on Reborn with no tint errors nor missing facegen
- Facegen/tint errors only happen when A) this setting was turned OFF instead of ON and B) when you coc through the main menu
- Also did some quick test with lan players and the results is that their tints work correctly and no missing facegen error no tint errors unlike on default settings when having this disabled those errors happened
