### PR TITLE
Tweak: Allows Players to be invited to parties even if they are in a party.

### DIFF
--- a/Code/client/Services/Debug/Views/PartyView.cpp
+++ b/Code/client/Services/Debug/Views/PartyView.cpp
@@ -1,11 +1,11 @@
 #include <Services/DebugService.h>
 
-#include <Messages/PartyKickRequest.h>
-#include <Messages/PartyChangeLeaderRequest.h>
-#include <Messages/PartyInviteRequest.h>
 #include <Messages/PartyAcceptInviteRequest.h>
-#include <Messages/PartyLeaveRequest.h>
+#include <Messages/PartyChangeLeaderRequest.h>
 #include <Messages/PartyCreateRequest.h>
+#include <Messages/PartyInviteRequest.h>
+#include <Messages/PartyKickRequest.h>
+#include <Messages/PartyLeaveRequest.h>
 #include <Messages/TeleportCommandRequest.h>
 
 #include <World.h>
@@ -80,31 +80,29 @@ void DebugService::DrawPartyView()
             ImGui::PopID();
         }
 
-        if (partyService.IsLeader())
+        ImGui::NewLine();
+        ImGui::Text("Other Players");
+        auto playerCount = 0;
+        for (auto& player : partyService.GetPlayers())
         {
-            ImGui::NewLine();
-            ImGui::Text("Other Players");
-            auto playerCount = 0;
-            for (auto& player : partyService.GetPlayers())
-            {
-                if (std::find(std::begin(members), std::end(members), player.first) != std::end(members))
-                    continue;
+            if (std::find(std::begin(members), std::end(members), player.first) != std::end(members))
+                continue;
 
-                playerCount++;
-                ImGui::BulletText(player.second.c_str());
-                ImGui::SameLine(100);
-                if (ImGui::Button("Invite"))
-                {
-                    PartyInviteRequest request;
-                    request.PlayerId = player.first;
-                    m_transport.Send(request);
-                }
-            }
-
-            if (playerCount == 0)
+            playerCount++;
+            ImGui::BulletText(player.second.c_str());
+            ImGui::SameLine(100);
+            if (ImGui::Button("Invite"))
             {
-                ImGui::BulletText("<No one online>");
+                partyService.CreateParty();
+                PartyInviteRequest request;
+                request.PlayerId = player.first;
+                m_transport.Send(request);
             }
+        }
+
+        if (playerCount == 0)
+        {
+            ImGui::BulletText("<No one online>");
         }
     }
 

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -218,7 +218,7 @@ void PartyService::OnPartyInvite(const PacketEvent<PartyInviteRequest>& acPacket
             spdlog::debug("[PartyService]: Inviter not in party, cancelling invite.");
             return;
         }
-        else if (inviteePartyComponent.JoinedPartyId)
+        else if (inviteePartyComponent.JoinedPartyId == inviterPartyComponent.JoinedPartyId)
         {
             spdlog::debug("[PartyService]: Invitee in party already, cancelling invite.");
             return;
@@ -282,8 +282,8 @@ void PartyService::OnPartyAcceptInvite(const PacketEvent<PartyAcceptInviteReques
         if (selfPartyComponent.JoinedPartyId) // Remove from party if in one already. TODO: Decide if player needs to be out of party first
         {
             spdlog::debug("[PartyService]: Invitee already in party, cancelling.");
-            // RemovePlayerFromParty(pSelf, false); // skip sending left event, will override with SendPartyJoinedEvent
-            return;
+            RemovePlayerFromParty(pSelf); // skip sending left event, will override with SendPartyJoinedEvent
+            //return;
         }
 
         party.Members.push_back(pSelf);


### PR DESCRIPTION
Good for when the party leader crashes and the party needs to be remade. Players no longer need to leave their current party to resync with the original party leader in this circumstance. The player leaves their old party when this happens.