### PR TITLE
Fix ESL mods not syncing properly

### DIFF
--- a/Code/client/Systems/ModSystem.cpp
+++ b/Code/client/Systems/ModSystem.cpp
@@ -29,7 +29,7 @@ bool ModSystem::GetServerModId(const uint32_t aGameId, uint32_t& aModId, uint32_
         if (itor != std::end(m_liteToServer))
         {
             aModId = itor->second;
-            aBaseId = liteId;
+            aBaseId = aGameId & 0x00000FFF;
             return true;
         }
 


### PR DESCRIPTION
The lite mod id was assigned to the base ID of the form. The effects of this fix are two-fold: ESL mods will now properly sync, and DJ will stop bothering me about the issue.