### PR TITLE
Fix master build. Undo an apparently unused and inadvertent change in…

### DIFF
--- a/Code/client/TiltedOnlinePCH.h
+++ b/Code/client/TiltedOnlinePCH.h
@@ -4,8 +4,6 @@
 #define NOMINMAX
 #endif
 
-#include <BranchInfo.h>
-
 #include <TiltedCore/Platform.hpp>
 
 #if defined(TP_SKYRIM) && TP_PLATFORM_64


### PR DESCRIPTION
…troduced by commit 8d1130c2f77798ce15d892afbfa17d14001d64ac, that causes most of the client code to recompile on every compile.