### PR TITLE
If you ever suffer from recursive or looping crashes, this is the (trivial) patch for you

### DIFF
--- a/Code/client/CrashHandler.cpp
+++ b/Code/client/CrashHandler.cpp
@@ -22,7 +22,9 @@ std::string SerializeTimePoint(const time_point& time, const std::string& format
 
 LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 {
-    if (pExceptionInfo->ExceptionRecord->ExceptionCode == 0xC0000005)
+    static int alreadycrashed = 0;
+
+    if (pExceptionInfo->ExceptionRecord->ExceptionCode == 0xC0000005 && alreadycrashed++ == 0)
     {
         spdlog::error("Crash occurred!");
         MINIDUMP_EXCEPTION_INFORMATION M;


### PR DESCRIPTION
If there's a crash cycle or recursive cycle, "the real problem crash dump" is overwritten by a "subsequent problem crash dump," hiding the real problem. And the loop may go on forever. Stop after first crash dump.