### PR TITLE
If you ever suffer from recursive or looping crashes, this is the (tr…

### DIFF
--- a/Code/client/CrashHandler.cpp
+++ b/Code/client/CrashHandler.cpp
@@ -22,7 +22,9 @@ std::string SerializeTimePoint(const time_point& time, const std::string& format
 
 LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 {
-    if (pExceptionInfo->ExceptionRecord->ExceptionCode == 0xC0000005)
+    static int alreadycrashed = 0;
+
+    if (pExceptionInfo->ExceptionRecord->ExceptionCode == 0xC0000005 && alreadycrashed++ == 0)
     {
         spdlog::error("Crash occurred!");
         MINIDUMP_EXCEPTION_INFORMATION M;

--- a/xmake.lua
+++ b/xmake.lua
@@ -30,6 +30,7 @@ if has_config("unitybuild") then
     add_rules("c++.unity_build", {batchsize = 12})
 end
 
+add_defines("GLM_ENABLE_EXPERIMENTAL")
 add_requires(
     "entt v3.10.0", 
     "recastnavigation v1.6.0", 

--- a/xmake.lua
+++ b/xmake.lua
@@ -30,7 +30,6 @@ if has_config("unitybuild") then
     add_rules("c++.unity_build", {batchsize = 12})
 end
 
-add_defines("GLM_ENABLE_EXPERIMENTAL")
 add_requires(
     "entt v3.10.0", 
     "recastnavigation v1.6.0", 


### PR DESCRIPTION
…ivial) patch for you.

If there's a crash cycle or recursive crash, "the real problem crash dump" is overwritten by a "subsequent problem crash dump," hiding the real problem. And the loop may go on forever. Stop after first crash dump.