### PR TITLE
Disable sentry

### DIFF
--- a/Code/client/TiltedOnlineApp.h
+++ b/Code/client/TiltedOnlineApp.h
@@ -36,6 +36,6 @@ private:
 #if (!IS_MASTER)
     CrashHandler m_crashHandler;
 #else
-    ScopedCrashHandler m_crashHandler;
+    //ScopedCrashHandler m_crashHandler;
 #endif
 };


### PR DESCRIPTION
Since we're not really using Sentry crash logs anyway, might as well disable it.