### PR TITLE
Fix naked NPCs bug

### DIFF
--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -191,6 +191,16 @@ TESForm* Actor::GetEquippedAmmo() const noexcept
     return nullptr;
 }
 
+bool Actor::IsWearingBodyPiece() const noexcept
+{
+    return GetContainerChanges()->GetArmor(32) != nullptr;
+}
+
+bool Actor::IsHumanoidNPC() const noexcept
+{
+    return Cast<TESNPC>(baseForm)->outfits[0] != nullptr;
+}
+
 // Get owner of a summon or raised corpse
 Actor* Actor::GetCommandingActor() const noexcept
 {

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -252,7 +252,7 @@ Actor* Actor::GetCommandingActor() const noexcept
 // Get owner of a summon or raised corpse
 void Actor::SetCommandingActor(BSPointerHandle<TESObjectREFR> aCommandingActor) noexcept
 {
-    if (currentProcess && currentProcess->middleProcess && currentProcess->middleProcess)
+    if (currentProcess && currentProcess->middleProcess)
     {
         currentProcess->middleProcess->commandingActor = aCommandingActor;
         flags2 |= ActorFlags::IS_COMMANDED_ACTOR;

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -9,6 +9,7 @@
 #include <Components/TESActorBaseData.h>
 #include <ExtraData/ExtraFactionChanges.h>
 #include <Games/Memory.h>
+#include <Forms/TESLevItem.h>
 
 #include <Events/HealthChangeEvent.h>
 #include <Events/InventoryChangeEvent.h>
@@ -216,14 +217,11 @@ bool Actor::ShouldWearBodyPiece() const noexcept
             pArmor = Cast<TESObjectARMO>(pItem);
         else if (pItem->formType == FormType::LeveledItem)
         {
-            // TODO: leveled items can probably also be handled but afaik,
-            // the naked npc bug mostly occurs to town NPCs.
-            // Since this is a bit more complex and possibly error prone, leave out for now.
-#if 0
             TESLevItem* pLevItem = Cast<TESLevItem>(pItem);
-            if (!pLevItem)
+            if (!pLevItem || !pLevItem->pLeveledListA || !pLevItem->pLeveledListA->pForm)
                 continue;
-#endif
+
+            pArmor = Cast<TESObjectARMO>(pLevItem->pLeveledListA->pForm);
         }
         else
             continue;
@@ -231,7 +229,7 @@ bool Actor::ShouldWearBodyPiece() const noexcept
         if (!pArmor)
             continue;
 
-        if (pArmor->slotType & 0x4) // 0x4 is flag for body piece
+        if (pArmor->IsBodyPiece()) 
             return true;
     }
 

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -205,6 +205,8 @@ struct Actor : TESObjectREFR
     [[nodiscard]] Actor* GetCombatTarget() const noexcept;
     [[nodiscard]] bool HasPerk(uint32_t aPerkFormId) const noexcept;
     [[nodiscard]] uint8_t GetPerkRank(uint32_t aPerkFormId) const noexcept;
+    [[nodiscard]] bool IsWearingBodyPiece() const noexcept;
+    [[nodiscard]] bool IsHumanoidNPC() const noexcept;
 
     // Setters
     void SetSpeed(float aSpeed) noexcept;

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -206,7 +206,7 @@ struct Actor : TESObjectREFR
     [[nodiscard]] bool HasPerk(uint32_t aPerkFormId) const noexcept;
     [[nodiscard]] uint8_t GetPerkRank(uint32_t aPerkFormId) const noexcept;
     [[nodiscard]] bool IsWearingBodyPiece() const noexcept;
-    [[nodiscard]] bool IsHumanoidNPC() const noexcept;
+    [[nodiscard]] bool ShouldWearBodyPiece() const noexcept;
 
     // Setters
     void SetSpeed(float aSpeed) noexcept;

--- a/Code/client/Games/Skyrim/ExtraData/ExtraContainerChanges.cpp
+++ b/Code/client/Games/Skyrim/ExtraData/ExtraContainerChanges.cpp
@@ -28,3 +28,12 @@ bool ExtraContainerChanges::Entry::IsQuestObject() noexcept
 
     return TiltedPhoques::ThisCall(s_isQuestObject, this);
 }
+
+TESObjectARMO* ExtraContainerChanges::Data::GetArmor(uint32_t aSlotId) noexcept
+{
+    TP_THIS_FUNCTION(TGetArmor, TESObjectARMO*, ExtraContainerChanges::Data, uint32_t);
+
+    POINTER_SKYRIMSE(TGetArmor, s_getArmor, 16113);
+
+    return TiltedPhoques::ThisCall(s_getArmor, this, aSlotId);
+}

--- a/Code/client/Games/Skyrim/ExtraData/ExtraContainerChanges.h
+++ b/Code/client/Games/Skyrim/ExtraData/ExtraContainerChanges.h
@@ -6,6 +6,7 @@ struct BGSLoadFormBuffer;
 struct BGSSaveFormBuffer;
 struct TESObjectREFR;
 struct TESForm;
+struct TESObjectARMO;
 
 struct ExtraContainerChanges : BSExtraData
 {
@@ -25,6 +26,7 @@ struct ExtraContainerChanges : BSExtraData
     {
         void Save(BGSSaveFormBuffer* apBuffer);
         void Load(BGSLoadFormBuffer* apBuffer);
+        TESObjectARMO* GetArmor(uint32_t aSlotId) noexcept;
 
         GameList<Entry>* entries;
         TESObjectREFR* parent;

--- a/Code/client/Games/Skyrim/Forms/BGSOutfit.h
+++ b/Code/client/Games/Skyrim/Forms/BGSOutfit.h
@@ -4,4 +4,5 @@
 
 struct BGSOutfit : TESForm
 {
+    GameArray<TESForm*> outfitItems;
 };

--- a/Code/client/Games/Skyrim/Forms/TESForm.h
+++ b/Code/client/Games/Skyrim/Forms/TESForm.h
@@ -14,6 +14,7 @@ enum class FormType : uint8_t
     Npc = 43,
     LeveledCharacter = 44,
     Alchemy = 46,
+    LeveledItem = 53,
     Character = 62,
     QuestItem = 77,
     Count = 0x87

--- a/Code/client/Games/Skyrim/Forms/TESLevItem.h
+++ b/Code/client/Games/Skyrim/Forms/TESLevItem.h
@@ -1,6 +1,9 @@
 #pragma once
 
-struct TESLevItem : BaseFormComponent
-{
+#include "TESLeveledList.h"
 
+struct TESLevItem : TESBoundObject, TESLeveledList
+{
 };
+
+static_assert(sizeof(TESLevItem) == 0x58);

--- a/Code/client/Games/Skyrim/Forms/TESLevItem.h
+++ b/Code/client/Games/Skyrim/Forms/TESLevItem.h
@@ -1,0 +1,6 @@
+#pragma once
+
+struct TESLevItem : BaseFormComponent
+{
+
+};

--- a/Code/client/Games/Skyrim/Forms/TESLeveledList.h
+++ b/Code/client/Games/Skyrim/Forms/TESLeveledList.h
@@ -1,0 +1,18 @@
+#pragma once
+
+struct TESLeveledList : BaseFormComponent
+{
+    struct LEVELED_OBJECT
+    {
+        TESForm* pForm;
+        uint16_t count;
+        uint16_t level;
+        uint32_t padC;
+        void* pItemExtra;
+    };
+
+    LEVELED_OBJECT* pLeveledListA; // this array has count at offset -8
+    uint8_t unk10[0x28 - 0x10];
+};
+
+static_assert(sizeof(TESLeveledList) == 0x28);

--- a/Code/client/Games/Skyrim/Forms/TESObjectARMO.h
+++ b/Code/client/Games/Skyrim/Forms/TESObjectARMO.h
@@ -4,4 +4,6 @@
 
 struct TESObjectARMO : TESForm
 {
+    uint8_t unk20[0x1B8 - sizeof(TESForm)];
+    uint32_t slotType;
 };

--- a/Code/client/Games/Skyrim/Forms/TESObjectARMO.h
+++ b/Code/client/Games/Skyrim/Forms/TESObjectARMO.h
@@ -4,6 +4,11 @@
 
 struct TESObjectARMO : TESForm
 {
+    [[nodiscard]] bool IsBodyPiece() const noexcept
+    {
+        return (slotType & 0x4) != 0; // 0x4 is flag for body piece
+    }
+
     uint8_t unk20[0x1B8 - sizeof(TESForm)];
     uint32_t slotType;
 };

--- a/Code/client/Games/Skyrim/TESObjectREFR.h
+++ b/Code/client/Games/Skyrim/TESObjectREFR.h
@@ -134,7 +134,7 @@ struct TESObjectREFR : TESForm
     virtual void sub_87();
     virtual void sub_88();
     virtual void DisableImpl();
-    virtual void sub_8A();
+    virtual void ResetInventory(bool abLeveledOnly);
     virtual void sub_8B();
     virtual void sub_8C();
     virtual void sub_8D();

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -213,15 +213,7 @@ void DebugService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
         {
             s_f8Pressed = true;
 
-            //PlaceActorInWorld();
-            Actor* pActor = Cast<Actor>(TESForm::GetById(m_formId));
-            if (pActor)
-            {
-                if (pActor->ShouldWearBodyPiece())
-                    spdlog::warn("Actor has body piece");
-                else
-                    spdlog::error("Actor does not have body piece");
-            }
+            PlaceActorInWorld();
         }
     }
     else

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -213,7 +213,15 @@ void DebugService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
         {
             s_f8Pressed = true;
 
-            PlaceActorInWorld();
+            //PlaceActorInWorld();
+            Actor* pActor = Cast<Actor>(TESForm::GetById(m_formId));
+            if (pActor)
+            {
+                if (pActor->ShouldWearBodyPiece())
+                    spdlog::warn("Actor has body piece");
+                else
+                    spdlog::error("Actor does not have body piece");
+            }
         }
     }
     else

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -317,6 +317,9 @@ void InventoryService::RunNakedNPCBugChecks() noexcept
         if (!pActor)
             continue;
 
+        if (pActor->IsDead())
+            continue;
+
         if (!pActor->IsHumanoidNPC())
             continue;
 

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -23,6 +23,7 @@
 #include <Games/TES.h>
 #include <Games/Overrides.h>
 #include <EquipManager.h>
+#include <Games/ActorExtension.h>
 
 #if TP_FALLOUT4
 #include <Forms/BGSObjectInstance.h>
@@ -317,6 +318,9 @@ void InventoryService::RunNakedNPCBugChecks() noexcept
         if (!pActor)
             continue;
 
+        if (pActor->GetExtension()->IsPlayer())
+            continue;
+
         if (pActor->IsDead())
             continue;
 
@@ -326,7 +330,15 @@ void InventoryService::RunNakedNPCBugChecks() noexcept
         if (pActor->IsWearingBodyPiece())
             continue;
 
-        pActor->ResetInventory(false);
+        // Don't broadcast changes if a remote actor needs fixing
+        if (pActor->GetExtension()->IsRemote())
+        {
+            ScopedEquipOverride seo;
+            ScopedInventoryOverride sio;
+            pActor->ResetInventory(false);
+        }
+        else
+            pActor->ResetInventory(false);
     }
 #endif
 }

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -24,6 +24,7 @@
 #include <Games/Overrides.h>
 #include <EquipManager.h>
 #include <Games/ActorExtension.h>
+#include <Forms/TESNPC.h>
 
 #if TP_FALLOUT4
 #include <Forms/BGSObjectInstance.h>
@@ -324,10 +325,10 @@ void InventoryService::RunNakedNPCBugChecks() noexcept
         if (pActor->IsDead())
             continue;
 
-        if (!pActor->IsHumanoidNPC())
+        if (pActor->IsWearingBodyPiece())
             continue;
 
-        if (pActor->IsWearingBodyPiece())
+        if (!pActor->ShouldWearBodyPiece())
             continue;
 
         // Don't broadcast changes if a remote actor needs fixing

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -183,10 +183,8 @@ void InventoryService::OnNotifyEquipmentChanges(const NotifyEquipmentChanges& ac
     // TODO: should this be done for armor as well?
     // Also, find out why the client is sending two equip messages in the first place.
     // TODO: this fix makes it so that weapons and spells are sometimes invisible :/
-    #if 0
     if (!acMessage.Unequip && pActor->GetEquippedWeapon(slotId) == pItem)
         return;
-    #endif
 #endif
 
     auto* pEquipManager = EquipManager::Get();
@@ -331,15 +329,12 @@ void InventoryService::RunNakedNPCBugChecks() noexcept
         if (!pActor->ShouldWearBodyPiece())
             continue;
 
-        // Don't broadcast changes if a remote actor needs fixing
-        if (pActor->GetExtension()->IsRemote())
-        {
-            ScopedEquipOverride seo;
-            ScopedInventoryOverride sio;
-            pActor->ResetInventory(false);
-        }
-        else
-            pActor->ResetInventory(false);
+        // Don't broadcast changes, it'll just make things messier.
+        // If all clients have this problem, they'll all fix it individually.
+        ScopedEquipOverride seo;
+        ScopedInventoryOverride sio;
+
+        pActor->ResetInventory(false);
     }
 #endif
 }

--- a/Code/client/Services/InventoryService.h
+++ b/Code/client/Services/InventoryService.h
@@ -56,6 +56,11 @@ private:
      * and if so, send the new states to the server.
      */
     void RunWeaponStateUpdates() noexcept;
+    /**
+    * Checks whether an NPC's (local or remote) equipment is bugged (i.e. naked NPCS)
+    * and resets their inventory.
+    */
+    void RunNakedNPCBugChecks() noexcept;
 
     World& m_world;
     entt::dispatcher& m_dispatcher;


### PR DESCRIPTION
Check whether an NPC that should be wearing clothes is naked. What NPCs should be wearing clothes is determined by whether they have a default outfit. This distinguishes NPCs in a city from, say, a falmer.