### PR TITLE
Remove limit to BehaviorVars on the wire.

### DIFF
--- a/Code/client/Games/References.cpp
+++ b/Code/client/Games/References.cpp
@@ -227,10 +227,9 @@ void TESObjectREFR::SaveAnimationVariables(AnimationVariables& aVariables) const
             if (!pVariableSet)
                 return;
 
-            aVariables.Booleans = 0;
-
-            aVariables.Floats.resize(pDescriptor->FloatLookupTable.size());
-            aVariables.Integers.resize(pDescriptor->IntegerLookupTable.size());
+            aVariables.Booleans.assign(pDescriptor->BooleanLookUpTable.size(), false);
+            aVariables.Floats.assign(pDescriptor->FloatLookupTable.size(), 0.f);
+            aVariables.Integers.assign(pDescriptor->IntegerLookupTable.size(), 0);
 
 #if TP_FALLOUT4
             // TODO: maybe send a var with the variables indicating first or third person?
@@ -251,14 +250,14 @@ void TESObjectREFR::SaveAnimationVariables(AnimationVariables& aVariables) const
                         continue;
 
                     if (pFirstPersonVariables->data[*firstPersonIdx] != 0)
-                        aVariables.Booleans |= (1ull << i);
+                        aVariables.Booleans[i] = true;
 
                     continue;
                 }
 #endif
 
                 if (pVariableSet->data[idx] != 0)
-                    aVariables.Booleans |= (1ull << i);
+                    aVariables.Booleans[i] = true;
             }
 
             for (size_t i = 0; i < pDescriptor->FloatLookupTable.size(); ++i)
@@ -361,7 +360,7 @@ void TESObjectREFR::LoadAnimationVariables(const AnimationVariables& aVariables)
 
                 if (pVariableSet->size > idx)
                 {
-                    pVariableSet->data[idx] = (aVariables.Booleans & (1ull << i)) != 0;
+                    pVariableSet->data[idx] = aVariables.Booleans[i];
                 }
             }
 

--- a/Code/encoding/Structs/AnimationVariables.h
+++ b/Code/encoding/Structs/AnimationVariables.h
@@ -6,7 +6,7 @@ using TiltedPhoques::Vector;
 
 struct AnimationVariables
 {
-    uint64_t Booleans{0};
+    Vector<bool> Booleans{};
     Vector<uint32_t> Integers{};
     Vector<float> Floats{};
 
@@ -18,4 +18,6 @@ struct AnimationVariables
 
     void GenerateDiff(const AnimationVariables& aPrevious, TiltedPhoques::Buffer::Writer& aWriter) const;
     void ApplyDiff(TiltedPhoques::Buffer::Reader& aReader);
+    void VectorBool_to_String(const Vector<bool>& bools, TiltedPhoques::String& chars) const;
+    void String_to_VectorBool(const TiltedPhoques::String& chars, Vector<bool>& bools);
 };

--- a/Code/tests/encoding.cpp
+++ b/Code/tests/encoding.cpp
@@ -276,7 +276,12 @@ TEST_CASE("Differential structures", "[encoding.differential]")
     GIVEN("AnimationVariables")
     {
         AnimationVariables vars, recvVars;
-        vars.Booleans = 0x12345678ull;
+ 
+        vars.Booleans.resize(76);
+        String testString("\xDE\xAD\xBE\xEF"
+                          "\xDE\xAD\xBE\xEF\x76\xB");
+        vars.String_to_VectorBool(testString, vars.Booleans);
+
         vars.Floats.push_back(1.f);
         vars.Floats.push_back(7.f);
         vars.Floats.push_back(12.f);
@@ -305,7 +310,11 @@ TEST_CASE("Differential structures", "[encoding.differential]")
             REQUIRE(vars.Integers == recvVars.Integers);
         }
 
-        vars.Booleans = 0x9456123ull;
+        vars.Booleans.resize(33);
+        vars.Booleans[16] = false;
+        vars.Booleans[17] = false;
+        vars.Booleans[18] = false;
+        vars.Booleans[19] = false;
         vars.Floats[3] = 42.f;
         vars.Integers[0] = 18;
         vars.Integers[3] = 0;
@@ -444,7 +453,10 @@ TEST_CASE("Packets", "[encoding.packets]")
         auto& move = update.UpdatedMovement;
 
         AnimationVariables vars;
-        vars.Booleans = 0x12345678ull;
+        vars.Booleans.resize(76);
+        String testString("\xDE\xAD\xBE\xEF\x76\xB");
+        vars.String_to_VectorBool(testString, vars.Booleans);
+
         vars.Floats.push_back(1.f);
         vars.Floats.push_back(7.f);
         vars.Floats.push_back(12.f);


### PR DESCRIPTION
STR is up against the limit, using 62 of a hardwired 64  boolean behavior vars to be synced. This fix removes the limit before it becomes a barrier.

Since "unlimited" will bite us, note the base code has some lengths encoded in 16-bit ints that will bite eventually. Trying to sync even a fraction of that many will cause problems, though.

Reimplemented the Boolean long long as a (bit) Vector. This made all vars (bools, ints, floats) vectors, so some code simplification of the wire protocol is accessible.

The Booleans are just passed "as is," no attempt to detect which ones changed as the space required to send the delta is more than just sending the bits.

Overall impact on wire protocol: sending humanoids will be slightly longer, as the 64-bits available is almost full. But that's longer by a byte (or maybe two since I used String to simplify the code).

Everything else sent will be shorter and less overhead.

There's no avoiding iterating the bits of the Vector<bool>. But the overhead when translating the array of \<bool> to an array of bits and back is about the same.

There was a bunch of extra overhead if Serialization::WriteBool() were to be used, so optimized that part out.

Overall, should be better on the wire, and neutral-to-better on CPU.

2nd commit msg:
Reworked creating and applying Behavior variable diffs and serializing them. Simpler, easier to read, should usually save bytes on the wire.