### PR TITLE
tweak: add TARGET_NAME to selectable-executable filter

### DIFF
--- a/Code/immersive_launcher/oobe/PathSelection.cpp
+++ b/Code/immersive_launcher/oobe/PathSelection.cpp
@@ -82,25 +82,7 @@ bool SelectInstall(bool aForceSelect)
     auto exePath = Registry::ReadString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitleExe");
 
     bool result = true;
-    bool correctExeFound = false;
-
-    if (!aForceSelect)
-    {
-        std::wstring suggestedExe = SuggestTitlePath().append(TARGET_NAME L".exe");
-
-        if (std::filesystem::exists(suggestedExe))
-        {
-            correctExeFound = true;
-
-            exePath = suggestedExe;
-            titlePath = exePath.substr(0, exePath.find_last_of(L'\\'));
-
-            result = Registry::WriteString(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitlePath", titlePath) &&
-                     Registry::WriteString(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitleExe", exePath);
-        }
-    }
-
-    if (!std::filesystem::exists(titlePath) || !std::filesystem::exists(exePath) || aForceSelect || !correctExeFound)
+    if (!std::filesystem::exists(titlePath) || !std::filesystem::exists(exePath) || aForceSelect)
     {
         constexpr int kSelectionAttempts = 3;
 

--- a/Code/immersive_launcher/oobe/PathSelection.cpp
+++ b/Code/immersive_launcher/oobe/PathSelection.cpp
@@ -82,7 +82,25 @@ bool SelectInstall(bool aForceSelect)
     auto exePath = Registry::ReadString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitleExe");
 
     bool result = true;
-    if (!std::filesystem::exists(titlePath) || !std::filesystem::exists(exePath) || aForceSelect)
+    bool correctExeFound = false;
+
+    if (!aForceSelect)
+    {
+        std::wstring suggestedExe = SuggestTitlePath().append(TARGET_NAME L".exe");
+
+        if (std::filesystem::exists(suggestedExe))
+        {
+            correctExeFound = true;
+
+            exePath = suggestedExe;
+            titlePath = exePath.substr(0, exePath.find_last_of(L'\\'));
+
+            result = Registry::WriteString(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitlePath", titlePath) &&
+                     Registry::WriteString(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitleExe", exePath);
+        }
+    }
+
+    if (!std::filesystem::exists(titlePath) || !std::filesystem::exists(exePath) || aForceSelect || !correctExeFound)
     {
         constexpr int kSelectionAttempts = 3;
 

--- a/Code/immersive_launcher/oobe/PathSelection.cpp
+++ b/Code/immersive_launcher/oobe/PathSelection.cpp
@@ -38,7 +38,7 @@ std::optional<std::wstring> OpenPathSelectionDialog2(const std::wstring& aPathSu
 
     pFileDialog->SetTitle(L"Select the game executable (" TARGET_NAME L".exe)");
 
-    static constinit COMDLG_FILTERSPEC rgSpec[] = {{L"Executables", L"*.exe"}};
+    static constinit COMDLG_FILTERSPEC rgSpec[] = {{L"Executables", TARGET_NAME L".exe"}};
     pFileDialog->SetFileTypes(1, &rgSpec[0]);
 
     // pre select suggested folder & exe


### PR DESCRIPTION
Adds TARGET_NAME to the executable elements to select from in the executable-select dialog 
Related feature request https://github.com/tiltedphoques/TiltedEvolution/issues/656