### PR TITLE
Feature: auto party join

### DIFF
--- a/Code/client/TiltedOnlineApp.h
+++ b/Code/client/TiltedOnlineApp.h
@@ -2,7 +2,7 @@
 
 #if (!IS_MASTER)
 #include "CrashHandler.h"
-#elif
+#else
 #include <crash_handler/CrashHandler.h>
 #endif
 
@@ -35,7 +35,7 @@ protected:
 private:
 #if (!IS_MASTER)
     CrashHandler m_crashHandler;
-#elif
+#else
     ScopedCrashHandler m_crashHandler;
 #endif
 };

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -115,6 +115,22 @@ void PartyService::OnPartyCreate(const PacketEvent<PartyCreateRequest>& acPacket
 
         spdlog::debug("[PartyService]: Created party for {}", player->GetId());
         SendPartyJoinedEvent(party, player);
+
+        if (m_parties.size() == 1)
+        {
+            for (Player* otherPlayer : m_world.GetPlayerManager())
+            {
+                if (otherPlayer->GetId() != player->GetId())
+                {
+                    party.Members.push_back(otherPlayer);
+                    otherPlayer->GetParty().JoinedPartyId = partyId;
+
+                    SendPartyJoinedEvent(party, otherPlayer);
+                }
+            }
+
+            BroadcastPartyInfo(partyId);
+        }
     }
 }
 

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -195,7 +195,7 @@ void PartyService::OnPartyKick(const PacketEvent<PartyKickRequest>& acPacket) no
     }
 }
 
-void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) const noexcept
+void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept
 {
     BroadcastPlayerList();
 
@@ -211,6 +211,27 @@ void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) const noexcept
     spdlog::debug("[Party] New notify player {:x} {}", notify.PlayerId, notify.Username.c_str());
 
     GameServer::Get()->SendToPlayers(notify, acEvent.pPlayer);
+
+    if (m_parties.size() == 1)
+    {
+        for (Player* player : m_world.GetPlayerManager())
+        {
+            if (IsPlayerInParty(player))
+            {
+                uint32_t partyId = 0;
+                Party& party = m_parties[partyId];
+
+                party.Members.push_back(acEvent.pPlayer);
+                acEvent.pPlayer->GetParty().JoinedPartyId = partyId;
+
+                SendPartyJoinedEvent(party, acEvent.pPlayer);
+
+                BroadcastPartyInfo(partyId);
+
+                break;
+            }
+        }
+    }
 }
 
 void PartyService::OnPartyInvite(const PacketEvent<PartyInviteRequest>& acPacket) noexcept

--- a/Code/server/Services/PartyService.h
+++ b/Code/server/Services/PartyService.h
@@ -38,7 +38,7 @@ struct PartyService
 
 protected:
     void OnUpdate(const UpdateEvent& acEvent) noexcept;
-    void OnPlayerJoin(const PlayerJoinEvent& acEvent) const noexcept;
+    void OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept;
     void OnPlayerLeave(const PlayerLeaveEvent& acEvent) noexcept;
     void OnPartyInvite(const PacketEvent<PartyInviteRequest>& acPacket) noexcept;
     void OnPartyAcceptInvite(const PacketEvent<PartyAcceptInviteRequest>& acPacket) noexcept;


### PR DESCRIPTION
If there are no parties on the server, when a party is created, every player is automatically added to the party

If there is one party in the server, when a player connects, they are automatically added to the party

Only functions if the server is private

For issues #378 and #404