### PR TITLE
Feature: auto party join

### DIFF
--- a/Code/encoding/Structs/ServerSettings.cpp
+++ b/Code/encoding/Structs/ServerSettings.cpp
@@ -5,7 +5,7 @@ using TiltedPhoques::Serialization;
 
 bool ServerSettings::operator==(const ServerSettings& acRhs) const noexcept
 {
-    return Difficulty == acRhs.Difficulty && GreetingsEnabled == acRhs.GreetingsEnabled && PvpEnabled == acRhs.PvpEnabled && SyncPlayerHomes == acRhs.SyncPlayerHomes && DeathSystemEnabled == acRhs.DeathSystemEnabled;
+    return Difficulty == acRhs.Difficulty && GreetingsEnabled == acRhs.GreetingsEnabled && PvpEnabled == acRhs.PvpEnabled && SyncPlayerHomes == acRhs.SyncPlayerHomes && DeathSystemEnabled == acRhs.DeathSystemEnabled && AutoPartyJoin == acRhs.AutoPartyJoin;
 }
 
 bool ServerSettings::operator!=(const ServerSettings& acRhs) const noexcept
@@ -21,6 +21,7 @@ void ServerSettings::Serialize(TiltedPhoques::Buffer::Writer& aWriter) const noe
     Serialization::WriteBool(aWriter, SyncPlayerHomes);
     Serialization::WriteBool(aWriter, DeathSystemEnabled);
     Serialization::WriteBool(aWriter, SyncPlayerCalendar);
+    Serialization::WriteBool(aWriter, AutoPartyJoin);
 }
 
 void ServerSettings::Deserialize(TiltedPhoques::Buffer::Reader& aReader) noexcept
@@ -31,4 +32,5 @@ void ServerSettings::Deserialize(TiltedPhoques::Buffer::Reader& aReader) noexcep
     SyncPlayerHomes = Serialization::ReadBool(aReader);
     DeathSystemEnabled = Serialization::ReadBool(aReader);
     SyncPlayerCalendar = Serialization::ReadBool(aReader);
+    AutoPartyJoin = Serialization::ReadBool(aReader);
 }

--- a/Code/encoding/Structs/ServerSettings.h
+++ b/Code/encoding/Structs/ServerSettings.h
@@ -16,4 +16,5 @@ struct ServerSettings
     bool SyncPlayerHomes{};
     bool DeathSystemEnabled{};
     bool SyncPlayerCalendar{};
+    bool AutoPartyJoin{};
 };

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -52,6 +52,9 @@ Console::Setting uTimeScale{
 Console::Setting bSyncPlayerCalendar{
     "Gameplay:bSyncPlayerCalendar",
     "Syncs up all player calendars to be the same day, month, and year. This uses the date of the player with the furthest ahead date at connection.", false};
+Console::Setting bAutoPartyJoin{
+    "Gameplay:bAutoPartyJoin",
+    "Join parties automatically, as long as there is only one party in the server", true};
 // ModPolicy Stuff
 Console::Setting bEnableModCheck{"ModPolicy:bEnableModCheck", "Bypass the checking of mods on the server", false,
                                  Console::SettingsFlags::kLocked};
@@ -142,6 +145,7 @@ ServerSettings GetSettings()
     settings.SyncPlayerHomes = bSyncPlayerHomes;
     settings.DeathSystemEnabled = bEnableDeathSystem;
     settings.SyncPlayerCalendar = bSyncPlayerCalendar;
+    settings.AutoPartyJoin = bAutoPartyJoin;
     return settings;
 }
 

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -211,6 +211,19 @@ void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept
     spdlog::debug("[Party] New notify player {:x} {}", notify.PlayerId, notify.Username.c_str());
 
     GameServer::Get()->SendToPlayers(notify, acEvent.pPlayer);
+
+    if (m_parties.size() == 1)
+    {
+        uint32_t partyId = 0;
+        Party& party = m_parties[partyId];
+
+        party.Members.push_back(acEvent.pPlayer);
+        acEvent.pPlayer->GetParty().JoinedPartyId = partyId;
+
+        SendPartyJoinedEvent(party, acEvent.pPlayer);
+
+        BroadcastPartyInfo(partyId);
+    }
 }
 
 void PartyService::OnPartyInvite(const PacketEvent<PartyInviteRequest>& acPacket) noexcept

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -219,15 +219,24 @@ void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept
 
     if (m_parties.size() == 1 && !bAnnounceServer)
     {
-        uint32_t partyId = 0;
-        Party& party = m_parties[partyId];
+        for (Player* player : m_world.GetPlayerManager())
+        {
+            if (IsPlayerInParty(player))
+            {
+                auto& playerPartyComponent = player->GetParty();
+                Party& party = m_parties[*playerPartyComponent.JoinedPartyId];
 
-        party.Members.push_back(acEvent.pPlayer);
-        acEvent.pPlayer->GetParty().JoinedPartyId = partyId;
+                party.Members.push_back(acEvent.pPlayer);
+                acEvent.pPlayer->GetParty().JoinedPartyId = *playerPartyComponent.JoinedPartyId;
 
-        SendPartyJoinedEvent(party, acEvent.pPlayer);
+                SendPartyJoinedEvent(party, acEvent.pPlayer);
 
-        BroadcastPartyInfo(partyId);
+                BroadcastPartyInfo(*playerPartyComponent.JoinedPartyId);
+
+                break;
+            }
+        }
+        
     }
 }
 

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -21,7 +21,7 @@
 
 namespace
 {
-Console::Setting bAnnounceServer{"LiveServices:bAnnounceServer", "Whether to list the server on the public server list", false};
+Console::Setting bAutoPartyJoin{"Gameplay:bAutoPartyJoin", "Join parties automatically, as long as there is only one party in the server", true};
 }
 
 PartyService::PartyService(World& aWorld, entt::dispatcher& aDispatcher) noexcept
@@ -121,7 +121,7 @@ void PartyService::OnPartyCreate(const PacketEvent<PartyCreateRequest>& acPacket
         spdlog::debug("[PartyService]: Created party for {}", player->GetId());
         SendPartyJoinedEvent(party, player);
 
-        if (m_parties.size() == 1 && !bAnnounceServer)
+        if (m_parties.size() == 1 && bAutoPartyJoin)
         {
             for (Player* otherPlayer : m_world.GetPlayerManager())
             {
@@ -217,7 +217,7 @@ void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept
 
     GameServer::Get()->SendToPlayers(notify, acEvent.pPlayer);
 
-    if (m_parties.size() == 1 && !bAnnounceServer)
+    if (m_parties.size() == 1 && bAutoPartyJoin)
     {
         for (Player* player : m_world.GetPlayerManager())
         {

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -115,6 +115,22 @@ void PartyService::OnPartyCreate(const PacketEvent<PartyCreateRequest>& acPacket
 
         spdlog::debug("[PartyService]: Created party for {}", player->GetId());
         SendPartyJoinedEvent(party, player);
+
+        if (m_parties.size() == 1)
+        {
+            for (Player* otherPlayer : m_world.GetPlayerManager())
+            {
+                if (otherPlayer->GetId() != player->GetId())
+                {
+                    party.Members.push_back(otherPlayer);
+                    otherPlayer->GetParty().JoinedPartyId = partyId;
+
+                    SendPartyJoinedEvent(party, otherPlayer);
+                }
+            }
+
+            BroadcastPartyInfo(partyId);
+        }
     }
 }
 
@@ -179,7 +195,7 @@ void PartyService::OnPartyKick(const PacketEvent<PartyKickRequest>& acPacket) no
     }
 }
 
-void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) const noexcept
+void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept
 {
     BroadcastPlayerList();
 

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -19,6 +19,11 @@
 #include <Messages/PartyKickRequest.h>
 #include <Messages/NotifyPlayerJoined.h>
 
+namespace
+{
+Console::Setting bAnnounceServer{"LiveServices:bAnnounceServer", "Whether to list the server on the public server list", false};
+}
+
 PartyService::PartyService(World& aWorld, entt::dispatcher& aDispatcher) noexcept
     : m_world(aWorld)
     , m_updateEvent(aDispatcher.sink<UpdateEvent>().connect<&PartyService::OnUpdate>(this))
@@ -116,7 +121,7 @@ void PartyService::OnPartyCreate(const PacketEvent<PartyCreateRequest>& acPacket
         spdlog::debug("[PartyService]: Created party for {}", player->GetId());
         SendPartyJoinedEvent(party, player);
 
-        if (m_parties.size() == 1)
+        if (m_parties.size() == 1 && !bAnnounceServer)
         {
             for (Player* otherPlayer : m_world.GetPlayerManager())
             {
@@ -212,7 +217,7 @@ void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept
 
     GameServer::Get()->SendToPlayers(notify, acEvent.pPlayer);
 
-    if (m_parties.size() == 1)
+    if (m_parties.size() == 1 && !bAnnounceServer)
     {
         uint32_t partyId = 0;
         Party& party = m_parties[partyId];

--- a/Code/server/Services/PartyService.h
+++ b/Code/server/Services/PartyService.h
@@ -38,7 +38,7 @@ struct PartyService
 
 protected:
     void OnUpdate(const UpdateEvent& acEvent) noexcept;
-    void OnPlayerJoin(const PlayerJoinEvent& acEvent) const noexcept;
+    void OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept;
     void OnPlayerLeave(const PlayerLeaveEvent& acEvent) noexcept;
     void OnPartyInvite(const PacketEvent<PartyInviteRequest>& acPacket) noexcept;
     void OnPartyAcceptInvite(const PacketEvent<PartyAcceptInviteRequest>& acPacket) noexcept;


### PR DESCRIPTION
If there are no parties on the server, when a party is created, every player is automatically added to the party

If there is one party in the server, when a player connects, they are automatically added to the party

Can be toggled in the server config (on by default)

For issues #378 and #404