### PR TITLE
Fix: don't send queued (un)equip messages

### DIFF
--- a/Code/client/Games/Skyrim/EquipManager.cpp
+++ b/Code/client/Games/Skyrim/EquipManager.cpp
@@ -157,7 +157,7 @@ void* TP_MAKE_THISCALL(EquipHook, EquipManager, Actor* apActor, TESForm* apItem,
     // Consumables are "equipped" as well. We don't want this to sync, for several reasons.
     // The right hand item on the server would be overridden by the consumable.
     // Furthermore, the equip action on the other clients would doubly subtract the consumables.
-    if (pExtension->IsLocal() && !apItem->IsConsumable())
+    if (pExtension->IsLocal() && !apItem->IsConsumable() && !apData->bQueueEquip)
     {
         EquipmentChangeEvent evt{};
         evt.ActorId = apActor->formID;
@@ -189,7 +189,7 @@ void* TP_MAKE_THISCALL(UnEquipHook, EquipManager, Actor* apActor, TESForm* apIte
             return nullptr;
     }
 
-    if (pExtension->IsLocal() && !ScopedUnequipOverride::IsOverriden())
+    if (pExtension->IsLocal() && !ScopedUnequipOverride::IsOverriden() && !apData->bQueueEquip)
     {
         EquipmentChangeEvent evt{};
         evt.ActorId = apActor->formID;
@@ -216,7 +216,7 @@ void* TP_MAKE_THISCALL(EquipSpellHook, EquipManager, Actor* apActor, TESForm* ap
     if (pExtension->IsRemote() && !ScopedEquipOverride::IsOverriden())
         return nullptr;
 
-    if (pExtension->IsLocal())
+    if (pExtension->IsLocal() && !apData->bQueueEquip)
     {
         EquipmentChangeEvent evt{};
         evt.ActorId = apActor->formID;
@@ -241,7 +241,7 @@ void* TP_MAKE_THISCALL(UnEquipSpellHook, EquipManager, Actor* apActor, TESForm* 
     if (pExtension->IsRemote() && !ScopedEquipOverride::IsOverriden())
         return nullptr;
 
-    if (pExtension->IsLocal() && !ScopedUnequipOverride::IsOverriden())
+    if (pExtension->IsLocal() && !ScopedUnequipOverride::IsOverriden() && !apData->bQueueEquip)
     {
         EquipmentChangeEvent evt{};
         evt.ActorId = apActor->formID;
@@ -265,6 +265,7 @@ void* TP_MAKE_THISCALL(EquipShoutHook, EquipManager, Actor* apActor, TESForm* ap
     if (pExtension->IsRemote() && !ScopedEquipOverride::IsOverriden())
         return nullptr;
 
+    // TODO: queue check?
     if (pExtension->IsLocal())
     {
         EquipmentChangeEvent evt{};
@@ -289,6 +290,7 @@ void* TP_MAKE_THISCALL(UnEquipShoutHook, EquipManager, Actor* apActor, TESForm* 
     if (pExtension->IsRemote() && !ScopedEquipOverride::IsOverriden())
         return nullptr;
 
+    // TODO: queue check?
     if (pExtension->IsLocal() && !ScopedUnequipOverride::IsOverriden())
     {
         EquipmentChangeEvent evt{};

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -173,19 +173,9 @@ void InventoryService::OnNotifyEquipmentChanges(const NotifyEquipmentChanges& ac
     uint32_t equipSlotId = modSystem.GetGameId(acMessage.EquipSlotId);
     TESForm* pEquipSlot = TESForm::GetById(equipSlotId);
 
-    // TODO: ft, does it have the same problem?
-#if TP_SKYRIM64
     uint32_t slotId = 0;
     if (pEquipSlot == DefaultObjectManager::Get().rightEquipSlot)
         slotId = 1;
-
-    // There's a bug where double equipping something magically unequips something secretly.
-    // TODO: should this be done for armor as well?
-    // Also, find out why the client is sending two equip messages in the first place.
-    // TODO: this fix makes it so that weapons and spells are sometimes invisible :/
-    if (!acMessage.Unequip && pActor->GetEquippedWeapon(slotId) == pItem)
-        return;
-#endif
 
     auto* pEquipManager = EquipManager::Get();
 

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -173,9 +173,11 @@ void InventoryService::OnNotifyEquipmentChanges(const NotifyEquipmentChanges& ac
     uint32_t equipSlotId = modSystem.GetGameId(acMessage.EquipSlotId);
     TESForm* pEquipSlot = TESForm::GetById(equipSlotId);
 
+#if TP_SKYRIM64
     uint32_t slotId = 0;
     if (pEquipSlot == DefaultObjectManager::Get().rightEquipSlot)
         slotId = 1;
+#endif
 
     auto* pEquipManager = EquipManager::Get();
 


### PR DESCRIPTION
Could potentially fix invisible weapons as well, would have to be tested.