### PR TITLE
tweak: Attempt to help UI consistency

### DIFF
--- a/Code/immersive_launcher/steam/SteamLoader.cpp
+++ b/Code/immersive_launcher/steam/SteamLoader.cpp
@@ -33,6 +33,7 @@ void Load(const fs::path& aGameDir)
     AddDllDirectory(steamPath.c_str());
 
     fs::path clientPath = steamPath / kSteamDllName;
-    LoadLibraryW(clientPath.c_str());
+    // game exe should load steam itself
+    //LoadLibraryW(clientPath.c_str());
 }
 } // namespace steam


### PR DESCRIPTION
Leaving this as a draft until it is confirmed to help, this PR needs others to confirm: 
- Steam overlay still functions and can type in the overlay 
- Steam detects the account as in-game
- The STRUI shows more consistently than before

For me, with SKSE installed (the only way I could get the UI to consistently not show up), pressing the STRUI keys (F2/RCtrl) did nothing (across 15 game restarts). After commenting out STR loading the steamclient64 dll, the UI showed every time (across 20 game restarts). I also confirmed the above to also work without SKSE installed to make sure SKSE wasn't loading steamclient64. To ensure this isn't a random chance, others need to confirm this.

There may have been two instances of steamclient64 being loaded (or attempting to load), the game exe should load the steamclient64 dll itself rather than STR. As far as I can tell, Steam still loads fine with the in-game overlay, and Steam detecting the account as in-game functioning as expected. As stated before, others need to confirm this.