### PR TITLE
Fix: black screen on nvidia GPUs

### DIFF
--- a/Code/immersive_launcher/Launcher.cpp
+++ b/Code/immersive_launcher/Launcher.cpp
@@ -7,6 +7,7 @@
 #include "loader/PathRerouting.h"
 
 #include "Utils/Error.h"
+#include "Utils/NvidiaUtil.h"
 #include "Utils/FileVersion.inl"
 
 #include "oobe/PathSelection.h"
@@ -16,6 +17,7 @@
 #include "base/dialogues/win/TaskDialog.h"
 
 #include <BranchInfo.h>
+#include <spdlog/spdlog.h>
 
 // These symbols are defined within the client code skyrimtogetherclient
 extern void InstallStartHook();
@@ -100,6 +102,13 @@ int StartUp(int argc, char** argv)
 
     if (!oobe::SelectInstall(askSelect))
         DIE_NOW(L"Failed to select game install.");
+
+    if (IsNvidiaOverlayLoaded())
+    {
+        HRESULT hr = CreateEarlyDxSwapChain();
+        if (FAILED(hr))
+            spdlog::error("D3D11CreateDeviceAndSwapChain failed! (Detected an NVIDIA GPU, error code={})", hr);
+    }
 
     // Bind path environment.
     loader::InstallPathRouting(LC->gamePath);

--- a/Code/immersive_launcher/Main.cpp
+++ b/Code/immersive_launcher/Main.cpp
@@ -20,9 +20,10 @@ extern "C"
 }
 
 auto kSystemPreloadDlls = {
-    L"\\dinput8.dll", // < Skyrim early init hook
-    L"\\dsound.dll",  // < breaks DSound init in game code
-                      // < X360CE v3 is buggy with COM hooks
+    L"\\dinput8.dll",   // < Skyrim early init hook
+    L"\\dsound.dll",    // < breaks DSound init in game code
+                        // < X360CE v3 is buggy with COM hooks
+    L"\\nvspcap64.dll", // < Nvidia overlay, needs to be loaded before the swap chain creation
     L"\\xinput9_1_0.dll", L"\\xinput1_1.dll", L"\\xinput1_2.dll", L"\\xinput1_3.dll", L"\\xinput1_4.dll", L"\\version.dll"};
 
 static void PreloadSystemDlls()

--- a/Code/immersive_launcher/utils/NvidiaUtil.cpp
+++ b/Code/immersive_launcher/utils/NvidiaUtil.cpp
@@ -1,0 +1,17 @@
+#include <Utils/NvidiaUtil.h>
+#include <d3d11.h>
+
+bool IsNvidiaOverlayLoaded()
+{
+    return GetModuleHandleW(L"nvspcap64.dll");
+}
+
+// This makes the Nvidia overlay happy.
+// The call to D3D11CreateDeviceAndSwapChain probably causes some of their
+// internal hooks to be called and do the required init work before the game window opens.
+HRESULT CreateEarlyDxSwapChain()
+{
+    ID3D11Device* device;
+    return D3D11CreateDeviceAndSwapChain(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, nullptr, 0, D3D11_SDK_VERSION,
+                                         nullptr, nullptr, &device, nullptr, nullptr);
+}

--- a/Code/immersive_launcher/utils/NvidiaUtil.h
+++ b/Code/immersive_launcher/utils/NvidiaUtil.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <Windows.h>
+
+bool IsNvidiaOverlayLoaded();
+
+HRESULT CreateEarlyDxSwapChain();


### PR DESCRIPTION
I should mention that the driver loads nvspcap64.dll regardless of whether you have the overlay enabled or not