### PR TITLE
Fix: rare animation related crash when entering a party leader's cell

### DIFF
--- a/Code/client/Games/Animation.cpp
+++ b/Code/client/Games/Animation.cpp
@@ -120,7 +120,7 @@ bool ActorMediator::ForceAction(TESActionData* apAction) noexcept
     uint8_t result = 0;
 
     auto pActor = static_cast<Actor*>(apAction->actor);
-    if (!pActor || pActor->animationGraphHolder.IsReady())
+    if (pActor && pActor->animationGraphHolder.IsReady())
     {
         result = TiltedPhoques::ThisCall(PerformComplexAction, this, apAction);
 


### PR DESCRIPTION
From the looks of it, sometimes `PerformComplexAction` was called with `pActor == nullptr`