### PR TITLE
Feat: settime chat command

### DIFF
--- a/Code/client/Events/SetTimeCommandEvent.h
+++ b/Code/client/Events/SetTimeCommandEvent.h
@@ -3,7 +3,10 @@
 struct SetTimeCommandEvent
 {
     SetTimeCommandEvent() = delete;
-    SetTimeCommandEvent(uint8_t aHours, uint8_t aMinutes, uint32_t aPlayerId) : Hours(aHours), Minutes(aMinutes), PlayerId(aPlayerId)
+    SetTimeCommandEvent(uint8_t aHours, uint8_t aMinutes, uint32_t aPlayerId)
+        : Hours(aHours)
+        , Minutes(aMinutes)
+        , PlayerId(aPlayerId)
     {
     }
 

--- a/Code/client/Events/SetTimeCommandEvent.h
+++ b/Code/client/Events/SetTimeCommandEvent.h
@@ -3,10 +3,11 @@
 struct SetTimeCommandEvent
 {
     SetTimeCommandEvent() = delete;
-    SetTimeCommandEvent(int32_t aHours, int32_t aMinutes) : Hours(aHours), Minutes(aMinutes)
+    SetTimeCommandEvent(uint8_t aHours, uint8_t aMinutes, uint32_t aPlayerId) : Hours(aHours), Minutes(aMinutes), PlayerId(aPlayerId)
     {
     }
 
     uint8_t Hours;
     uint8_t Minutes;
+    uint32_t PlayerId;
 };

--- a/Code/client/Events/SetTimeCommandEvent.h
+++ b/Code/client/Events/SetTimeCommandEvent.h
@@ -1,0 +1,12 @@
+﻿#pragma once
+
+struct SetTimeCommandEvent
+{
+    SetTimeCommandEvent() = delete;
+    SetTimeCommandEvent(int32_t aHours, int32_t aMinutes) : Hours(aHours), Minutes(aMinutes)
+    {
+    }
+
+    uint8_t Hours;
+    uint8_t Minutes;
+};

--- a/Code/client/Services/CommandService.h
+++ b/Code/client/Services/CommandService.h
@@ -2,6 +2,7 @@
 
 struct World;
 struct TransportService;
+struct SetTimeCommandEvent;
 struct TeleportCommandResponse;
 
 /**
@@ -19,6 +20,7 @@ public:
     TP_NOCOPYMOVE(CommandService);
 
 protected:
+    void OnSetTimeCommand(const SetTimeCommandEvent&) const noexcept;
     /**
      * @brief Processes result of teleport command.
      */
@@ -28,5 +30,6 @@ private:
     World& m_world;
     TransportService& m_transport;
 
+    entt::scoped_connection m_setTimeConnection;
     entt::scoped_connection m_teleportConnection;
 };

--- a/Code/client/Services/Generic/CommandService.cpp
+++ b/Code/client/Services/Generic/CommandService.cpp
@@ -30,6 +30,7 @@ void CommandService::OnSetTimeCommand(const SetTimeCommandEvent& acEvent) const 
     SetTimeCommandRequest request{};
     request.Hours = acEvent.Hours;
     request.Minutes = acEvent.Minutes;
+    request.PlayerId = acEvent.PlayerId;
     m_transport.Send(request);
 }
 

--- a/Code/client/Services/Generic/CommandService.cpp
+++ b/Code/client/Services/Generic/CommandService.cpp
@@ -1,3 +1,4 @@
+
 #include <Services/CommandService.h>
 #include <Services/TransportService.h>
 
@@ -8,8 +9,11 @@
 #include <Forms/TESWorldSpace.h>
 #include <PlayerCharacter.h>
 
+#include <Events/SetTimeCommandEvent.h>
+
 #include <Messages/TeleportCommandRequest.h>
 #include <Messages/TeleportCommandResponse.h>
+#include "Messages/SetTimeCommandRequest.h"
 
 #include <Structs/GridCellCoords.h>
 
@@ -17,7 +21,16 @@ CommandService::CommandService(World& aWorld, TransportService& aTransport, entt
     : m_world(aWorld)
     , m_transport(aTransport)
 {
+    m_setTimeConnection = aDispatcher.sink<SetTimeCommandEvent>().connect<&CommandService::OnSetTimeCommand>(this);
     m_teleportConnection = aDispatcher.sink<TeleportCommandResponse>().connect<&CommandService::OnTeleportCommandResponse>(this);
+}
+
+void CommandService::OnSetTimeCommand(const SetTimeCommandEvent& acEvent) const noexcept
+{
+    SetTimeCommandRequest request{};
+    request.Hours = acEvent.Hours;
+    request.Minutes = acEvent.Minutes;
+    m_transport.Send(request);
 }
 
 void CommandService::OnTeleportCommandResponse(const TeleportCommandResponse& acMessage) noexcept

--- a/Code/client/Services/Generic/OverlayClient.cpp
+++ b/Code/client/Services/Generic/OverlayClient.cpp
@@ -122,9 +122,10 @@ void OverlayClient::ProcessChatMessage(CefRefPtr<CefListValue> aEventArgs)
 
 void OverlayClient::ProcessSetTimeCommand(CefRefPtr<CefListValue> aEventArgs)
 {
-    uint8_t hours = static_cast<uint8_t>(aEventArgs->GetInt(0));
-    uint8_t minutes = static_cast<uint8_t>(aEventArgs->GetInt(1));
-    World::Get().GetDispatcher().trigger(SetTimeCommandEvent(hours, minutes));
+    const uint8_t hours = static_cast<uint8_t>(aEventArgs->GetInt(0));
+    const uint8_t minutes = static_cast<uint8_t>(aEventArgs->GetInt(1));
+    const uint32_t senderId = m_transport.GetLocalPlayerId();
+    World::Get().GetDispatcher().trigger(SetTimeCommandEvent(hours, minutes, senderId));
 }
 
 void OverlayClient::ProcessTeleportMessage(CefRefPtr<CefListValue> aEventArgs)

--- a/Code/client/Services/Generic/OverlayClient.cpp
+++ b/Code/client/Services/Generic/OverlayClient.cpp
@@ -8,6 +8,8 @@
 #include <Messages/SendChatMessageRequest.h>
 #include <Messages/TeleportRequest.h>
 
+#include <Events/SetTimeCommandEvent.h>
+
 #include <World.h>
 
 OverlayClient::OverlayClient(TransportService& aTransport, TiltedPhoques::OverlayRenderHandler* apHandler)
@@ -44,6 +46,8 @@ bool OverlayClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefR
             ProcessDisconnectMessage();
         else if (eventName == "sendMessage")
             ProcessChatMessage(eventArgs);
+        else if (eventName == "setTime")
+            ProcessSetTimeCommand(eventArgs);
         else if (eventName == "launchParty")
             World::Get().GetPartyService().CreateParty();
         else if (eventName == "leaveParty")
@@ -111,8 +115,16 @@ void OverlayClient::ProcessChatMessage(CefRefPtr<CefListValue> aEventArgs)
         messageRequest.ChatMessage = contents;
 
         spdlog::info(L"Send chat message of type {}: '{}' ", messageRequest.MessageType, aEventArgs->GetString(1).ToWString());
+
         m_transport.Send(messageRequest);
     }
+}
+
+void OverlayClient::ProcessSetTimeCommand(CefRefPtr<CefListValue> aEventArgs)
+{
+    uint8_t hours = static_cast<uint8_t>(aEventArgs->GetInt(0));
+    uint8_t minutes = static_cast<uint8_t>(aEventArgs->GetInt(1));
+    World::Get().GetDispatcher().trigger(SetTimeCommandEvent(hours, minutes));
 }
 
 void OverlayClient::ProcessTeleportMessage(CefRefPtr<CefListValue> aEventArgs)

--- a/Code/client/Services/Generic/TransportService.cpp
+++ b/Code/client/Services/Generic/TransportService.cpp
@@ -37,6 +37,7 @@ TransportService::TransportService(World& aWorld, entt::dispatcher& aDispatcher)
 {
     m_updateConnection = m_dispatcher.sink<UpdateEvent>().connect<&TransportService::HandleUpdate>(this);
     m_settingsChangeConnection = m_dispatcher.sink<NotifySettingsChange>().connect<&TransportService::HandleNotifySettingsChange>(this);
+    m_connectedConnection = m_dispatcher.sink<ConnectedEvent>().connect<&TransportService::HandleConnect>(this);
 
     m_connected = false;
 
@@ -179,6 +180,11 @@ void TransportService::OnUpdate()
 void TransportService::HandleUpdate(const UpdateEvent& acEvent) noexcept
 {
     Update();
+}
+
+void TransportService::HandleConnect(const ConnectedEvent& acEvent) noexcept
+{
+    m_localPlayerId = acEvent.PlayerId;
 }
 
 void TransportService::HandleAuthenticationResponse(const AuthenticationResponse& acMessage) noexcept

--- a/Code/client/Services/Generic/TransportService.cpp
+++ b/Code/client/Services/Generic/TransportService.cpp
@@ -37,7 +37,8 @@ TransportService::TransportService(World& aWorld, entt::dispatcher& aDispatcher)
 {
     m_updateConnection = m_dispatcher.sink<UpdateEvent>().connect<&TransportService::HandleUpdate>(this);
     m_settingsChangeConnection = m_dispatcher.sink<NotifySettingsChange>().connect<&TransportService::HandleNotifySettingsChange>(this);
-    m_connectedConnection = m_dispatcher.sink<ConnectedEvent>().connect<&TransportService::HandleConnect>(this);
+    m_connectedConnection = m_dispatcher.sink<ConnectedEvent>().connect<&TransportService::HandleConnected>(this);
+    m_disconnectedConnection = m_dispatcher.sink<DisconnectedEvent>().connect<&TransportService::HandleDisconnected>(this);
 
     m_connected = false;
 
@@ -182,9 +183,14 @@ void TransportService::HandleUpdate(const UpdateEvent& acEvent) noexcept
     Update();
 }
 
-void TransportService::HandleConnect(const ConnectedEvent& acEvent) noexcept
+void TransportService::HandleConnected(const ConnectedEvent& acEvent) noexcept
 {
     m_localPlayerId = acEvent.PlayerId;
+}
+
+void TransportService::HandleDisconnected(const DisconnectedEvent& acEvent) noexcept
+{
+    m_localPlayerId = NULL;
 }
 
 void TransportService::HandleAuthenticationResponse(const AuthenticationResponse& acMessage) noexcept

--- a/Code/client/Services/OverlayClient.h
+++ b/Code/client/Services/OverlayClient.h
@@ -25,6 +25,7 @@ private:
     void ProcessConnectMessage(CefRefPtr<CefListValue> aEventArgs);
     void ProcessDisconnectMessage();
     void ProcessChatMessage(CefRefPtr<CefListValue> aEventArgs);
+    void ProcessSetTimeCommand(CefRefPtr<CefListValue> aEventArgs);
     void ProcessTeleportMessage(CefRefPtr<CefListValue> aEventArgs);
     void ProcessToggleDebugUI();
 

--- a/Code/client/Services/TransportService.h
+++ b/Code/client/Services/TransportService.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Events/ConnectedEvent.h"
+#include "Events/DisconnectedEvent.h"
 
 #include <atomic>
 #include <Client.hpp>
@@ -39,7 +40,8 @@ struct TransportService : Client
 protected:
     // Event handlers
     void HandleUpdate(const UpdateEvent& acEvent) noexcept;
-    void HandleConnect(const ConnectedEvent& acEvent) noexcept;
+    void HandleConnected(const ConnectedEvent& acEvent) noexcept;
+    void HandleDisconnected(const DisconnectedEvent& acEvent) noexcept;
 
     // Packet handlers
     void HandleAuthenticationResponse(const AuthenticationResponse& acMessage) noexcept;
@@ -56,5 +58,6 @@ private:
     entt::scoped_connection m_sendServerMessageConnection;
     entt::scoped_connection m_settingsChangeConnection;
     entt::scoped_connection m_connectedConnection;
+    entt::scoped_connection m_disconnectedConnection;
     std::function<void(UniquePtr<ServerMessage>&)> m_messageHandlers[kServerOpcodeMax];
 };

--- a/Code/client/Services/TransportService.h
+++ b/Code/client/Services/TransportService.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Events/ConnectedEvent.h"
+
 #include <atomic>
 #include <Client.hpp>
 
@@ -32,10 +34,12 @@ struct TransportService : Client
 
     [[nodiscard]] bool IsOnline() const noexcept { return m_connected; }
     void SetServerPassword(const std::string& acPassword) noexcept { m_serverPassword = acPassword; }
+    const uint32_t& GetLocalPlayerId() const noexcept { return m_localPlayerId; }
 
 protected:
     // Event handlers
     void HandleUpdate(const UpdateEvent& acEvent) noexcept;
+    void HandleConnect(const ConnectedEvent& acEvent) noexcept;
 
     // Packet handlers
     void HandleAuthenticationResponse(const AuthenticationResponse& acMessage) noexcept;
@@ -46,9 +50,11 @@ private:
     entt::dispatcher& m_dispatcher;
     bool m_connected;
     String m_serverPassword{};
+    uint32_t m_localPlayerId;
 
     entt::scoped_connection m_updateConnection;
     entt::scoped_connection m_sendServerMessageConnection;
     entt::scoped_connection m_settingsChangeConnection;
+    entt::scoped_connection m_connectedConnection;
     std::function<void(UniquePtr<ServerMessage>&)> m_messageHandlers[kServerOpcodeMax];
 };

--- a/Code/components/console/ConsoleRegistry.cpp
+++ b/Code/components/console/ConsoleRegistry.cpp
@@ -258,7 +258,7 @@ void ConsoleRegistry::StoreCommandInHistory(const TiltedPhoques::String& acLine)
     // Do some housekeeping.
     if (m_commandHistory.size() == 10)
     {
-        m_commandHistory.erase(m_commandHistory.end());
+        m_commandHistory.pop_back();
     }
 }
 

--- a/Code/encoding/ChatMessageTypes.h
+++ b/Code/encoding/ChatMessageTypes.h
@@ -6,5 +6,6 @@ enum ChatMessageType : unsigned char
     kGlobalChat,
     kPlayerDialogue,
     kPartyChat,
-    kLocalChat
+    kLocalChat,
+    kSetTime
 };

--- a/Code/encoding/ChatMessageTypes.h
+++ b/Code/encoding/ChatMessageTypes.h
@@ -6,6 +6,5 @@ enum ChatMessageType : unsigned char
     kGlobalChat,
     kPlayerDialogue,
     kPartyChat,
-    kLocalChat,
-    kSetTime
+    kLocalChat
 };

--- a/Code/encoding/Messages/ClientMessageFactory.h
+++ b/Code/encoding/Messages/ClientMessageFactory.h
@@ -66,10 +66,10 @@ struct ClientMessageFactory
     {
         auto s_visitor = CreateMessageVisitor<
             AuthenticationRequest, AssignCharacterRequest, CancelAssignmentRequest, ClientReferencesMoveRequest, EnterInteriorCellRequest, RequestInventoryChanges, RequestFactionsChanges, RequestQuestUpdate, PartyInviteRequest, PartyAcceptInviteRequest, PartyLeaveRequest, PartyCreateRequest,
-            PartyChangeLeaderRequest, PartyKickRequest, RequestActorValueChanges, RequestActorMaxValueChanges, EnterExteriorCellRequest, RequestHealthChangeBroadcast, ActivateRequest, LockChangeRequest, AssignObjectsRequest, RequestDeathStateChange, ShiftGridCellRequest,
-            RequestOwnershipTransfer, RequestOwnershipClaim, RequestObjectInventoryChanges, SpellCastRequest, ProjectileLaunchRequest, InterruptCastRequest, AddTargetRequest, ScriptAnimationRequest, DrawWeaponRequest, MountRequest, NewPackageRequest, RequestRespawn, SyncExperienceRequest,
-            RequestEquipmentChanges, SendChatMessageRequest, TeleportCommandRequest, PlayerRespawnRequest, DialogueRequest, SubtitleRequest, PlayerDialogueRequest, PlayerLevelRequest, TeleportRequest, RequestPlayerHealthUpdate, RequestWeatherChange, RequestCurrentWeather, RequestSetWaypoint,
-            RequestRemoveWaypoint, SetTimeCommandRequest>;
+            PartyChangeLeaderRequest, PartyKickRequest, RequestActorValueChanges, RequestActorMaxValueChanges, EnterExteriorCellRequest, RequestHealthChangeBroadcast, ActivateRequest, LockChangeRequest, AssignObjectsRequest, RequestDeathStateChange, ShiftGridCellRequest, RequestOwnershipTransfer,
+            RequestOwnershipClaim, RequestObjectInventoryChanges, SpellCastRequest, ProjectileLaunchRequest, InterruptCastRequest, AddTargetRequest, ScriptAnimationRequest, DrawWeaponRequest, MountRequest, NewPackageRequest, RequestRespawn, SyncExperienceRequest, RequestEquipmentChanges,
+            SendChatMessageRequest, TeleportCommandRequest, PlayerRespawnRequest, DialogueRequest, SubtitleRequest, PlayerDialogueRequest, PlayerLevelRequest, TeleportRequest, RequestPlayerHealthUpdate, RequestWeatherChange, RequestCurrentWeather, RequestSetWaypoint, RequestRemoveWaypoint,
+            SetTimeCommandRequest>;
 
         return s_visitor(std::forward<T>(func));
     }

--- a/Code/encoding/Messages/ClientMessageFactory.h
+++ b/Code/encoding/Messages/ClientMessageFactory.h
@@ -43,6 +43,7 @@
 #include <Messages/RequestEquipmentChanges.h>
 #include <Messages/SendChatMessageRequest.h>
 #include <Messages/TeleportCommandRequest.h>
+#include <Messages/SetTimeCommandRequest.h>
 #include <Messages/PlayerRespawnRequest.h>
 #include <Messages/DialogueRequest.h>
 #include <Messages/SubtitleRequest.h>
@@ -68,7 +69,7 @@ struct ClientMessageFactory
             PartyChangeLeaderRequest, PartyKickRequest, RequestActorValueChanges, RequestActorMaxValueChanges, EnterExteriorCellRequest, RequestHealthChangeBroadcast, ActivateRequest, LockChangeRequest, AssignObjectsRequest, RequestDeathStateChange, ShiftGridCellRequest,
             RequestOwnershipTransfer, RequestOwnershipClaim, RequestObjectInventoryChanges, SpellCastRequest, ProjectileLaunchRequest, InterruptCastRequest, AddTargetRequest, ScriptAnimationRequest, DrawWeaponRequest, MountRequest, NewPackageRequest, RequestRespawn, SyncExperienceRequest,
             RequestEquipmentChanges, SendChatMessageRequest, TeleportCommandRequest, PlayerRespawnRequest, DialogueRequest, SubtitleRequest, PlayerDialogueRequest, PlayerLevelRequest, TeleportRequest, RequestPlayerHealthUpdate, RequestWeatherChange, RequestCurrentWeather, RequestSetWaypoint,
-            RequestRemoveWaypoint>;
+            RequestRemoveWaypoint, SetTimeCommandRequest>;
 
         return s_visitor(std::forward<T>(func));
     }

--- a/Code/encoding/Messages/NotifySetTimeResult.cpp
+++ b/Code/encoding/Messages/NotifySetTimeResult.cpp
@@ -1,0 +1,15 @@
+﻿#include <Messages/NotifySetTimeResult.h>
+
+void NotifySetTimeResult::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept
+{
+    aWriter.WriteBits(static_cast<uint64_t>(Result), 8);
+}
+
+void NotifySetTimeResult::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
+{
+    ServerMessage::DeserializeRaw(aReader);
+
+    uint64_t dest = 0;
+    aReader.ReadBits(dest, 8);
+    Result = static_cast<SetTimeResult>(dest & 0xFF);
+}

--- a/Code/encoding/Messages/NotifySetTimeResult.h
+++ b/Code/encoding/Messages/NotifySetTimeResult.h
@@ -1,0 +1,28 @@
+﻿#pragma once
+
+#include "Message.h"
+
+struct NotifySetTimeResult final : ServerMessage
+{
+    static constexpr ServerOpcode Opcode = kNotifySetTimeResult;
+
+    NotifySetTimeResult() : ServerMessage(Opcode)
+    {
+    }
+
+    void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
+    void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
+
+    bool operator==(const NotifySetTimeResult& achRhs) const noexcept
+    {
+        return GetOpcode() == achRhs.GetOpcode() && Result == achRhs.Result;
+    }
+
+    enum class SetTimeResult : uint8_t
+    {
+        kSuccess,
+        kPublicServer
+    };
+
+    SetTimeResult Result{};
+};

--- a/Code/encoding/Messages/NotifySetTimeResult.h
+++ b/Code/encoding/Messages/NotifySetTimeResult.h
@@ -6,17 +6,15 @@ struct NotifySetTimeResult final : ServerMessage
 {
     static constexpr ServerOpcode Opcode = kNotifySetTimeResult;
 
-    NotifySetTimeResult() : ServerMessage(Opcode)
+    NotifySetTimeResult()
+        : ServerMessage(Opcode)
     {
     }
 
     void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
     void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
 
-    bool operator==(const NotifySetTimeResult& achRhs) const noexcept
-    {
-        return GetOpcode() == achRhs.GetOpcode() && Result == achRhs.Result;
-    }
+    bool operator==(const NotifySetTimeResult& achRhs) const noexcept { return GetOpcode() == achRhs.GetOpcode() && Result == achRhs.Result; }
 
     enum class SetTimeResult : uint8_t
     {

--- a/Code/encoding/Messages/NotifySetTimeResult.h
+++ b/Code/encoding/Messages/NotifySetTimeResult.h
@@ -21,7 +21,7 @@ struct NotifySetTimeResult final : ServerMessage
     enum class SetTimeResult : uint8_t
     {
         kSuccess,
-        kPublicServer
+        kNoPermission
     };
 
     SetTimeResult Result{};

--- a/Code/encoding/Messages/ServerMessageFactory.h
+++ b/Code/encoding/Messages/ServerMessageFactory.h
@@ -72,8 +72,8 @@ struct ServerMessageFactory
             AuthenticationResponse, AssignCharacterResponse, ServerReferencesMoveRequest, ServerTimeSettings, CharacterSpawnRequest, NotifyInventoryChanges, StringCacheUpdate, NotifyFactionsChanges, NotifyRemoveCharacter, NotifyQuestUpdate, NotifyPlayerList, NotifyPartyInfo, NotifyPartyInvite,
             NotifyActorValueChanges, NotifyPartyJoined, NotifyPartyLeft, NotifyActorMaxValueChanges, NotifyHealthChangeBroadcast, NotifySpawnData, NotifyActivate, NotifyLockChange, AssignObjectsResponse, NotifyDeathStateChange, NotifyOwnershipTransfer, NotifyObjectInventoryChanges, NotifySpellCast,
             NotifyProjectileLaunch, NotifyInterruptCast, NotifyAddTarget, NotifyScriptAnimation, NotifyDrawWeapon, NotifyMount, NotifyNewPackage, NotifyRespawn, NotifySyncExperience, NotifyEquipmentChanges, NotifyChatMessageBroadcast, TeleportCommandResponse, NotifyPlayerRespawn, NotifyDialogue,
-            NotifySubtitle, NotifyPlayerDialogue, NotifyActorTeleport, NotifyRelinquishControl, NotifyPlayerLeft, NotifyPlayerJoined, NotifyDialogue, NotifySubtitle, NotifyPlayerDialogue, NotifyPlayerLevel, NotifyPlayerCellChanged, NotifyTeleport, NotifyPlayerHealthUpdate, NotifySettingsChange, NotifyWeatherChange, NotifySetWaypoint,
-            NotifyRemoveWaypoint, NotifySetTimeResult>;
+            NotifySubtitle, NotifyPlayerDialogue, NotifyActorTeleport, NotifyRelinquishControl, NotifyPlayerLeft, NotifyPlayerJoined, NotifyDialogue, NotifySubtitle, NotifyPlayerDialogue, NotifyPlayerLevel, NotifyPlayerCellChanged, NotifyTeleport, NotifyPlayerHealthUpdate, NotifySettingsChange,
+            NotifyWeatherChange, NotifySetWaypoint, NotifyRemoveWaypoint, NotifySetTimeResult>;
 
         return s_visitor(std::forward<T>(func));
     }

--- a/Code/encoding/Messages/ServerMessageFactory.h
+++ b/Code/encoding/Messages/ServerMessageFactory.h
@@ -58,6 +58,7 @@
 #include <Messages/NotifyWeatherChange.h>
 #include <Messages/NotifySetWaypoint.h>
 #include <Messages/NotifyRemoveWaypoint.h>
+#include <Messages/NotifySetTimeResult.h>
 
 using TiltedPhoques::UniquePtr;
 
@@ -72,7 +73,7 @@ struct ServerMessageFactory
             NotifyActorValueChanges, NotifyPartyJoined, NotifyPartyLeft, NotifyActorMaxValueChanges, NotifyHealthChangeBroadcast, NotifySpawnData, NotifyActivate, NotifyLockChange, AssignObjectsResponse, NotifyDeathStateChange, NotifyOwnershipTransfer, NotifyObjectInventoryChanges, NotifySpellCast,
             NotifyProjectileLaunch, NotifyInterruptCast, NotifyAddTarget, NotifyScriptAnimation, NotifyDrawWeapon, NotifyMount, NotifyNewPackage, NotifyRespawn, NotifySyncExperience, NotifyEquipmentChanges, NotifyChatMessageBroadcast, TeleportCommandResponse, NotifyPlayerRespawn, NotifyDialogue,
             NotifySubtitle, NotifyPlayerDialogue, NotifyActorTeleport, NotifyRelinquishControl, NotifyPlayerLeft, NotifyPlayerJoined, NotifyDialogue, NotifySubtitle, NotifyPlayerDialogue, NotifyPlayerLevel, NotifyPlayerCellChanged, NotifyTeleport, NotifyPlayerHealthUpdate, NotifySettingsChange, NotifyWeatherChange, NotifySetWaypoint,
-            NotifyRemoveWaypoint>;
+            NotifyRemoveWaypoint, NotifySetTimeResult>;
 
         return s_visitor(std::forward<T>(func));
     }

--- a/Code/encoding/Messages/SetTimeCommandRequest.cpp
+++ b/Code/encoding/Messages/SetTimeCommandRequest.cpp
@@ -4,6 +4,7 @@ void SetTimeCommandRequest::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter)
 {
     aWriter.WriteBits(Hours, 8);
     aWriter.WriteBits(Minutes, 8);
+    aWriter.WriteBits(PlayerId, 32);
 }
 
 void SetTimeCommandRequest::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
@@ -15,4 +16,6 @@ void SetTimeCommandRequest::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReade
     Hours = dest & 0xFF;
     aReader.ReadBits(dest, 8);
     Minutes = dest & 0xFF;
+    aReader.ReadBits(dest, 32);
+    PlayerId = dest & 0xFFFFFFFF;
 }

--- a/Code/encoding/Messages/SetTimeCommandRequest.cpp
+++ b/Code/encoding/Messages/SetTimeCommandRequest.cpp
@@ -1,0 +1,18 @@
+﻿#include "SetTimeCommandRequest.h"
+
+void SetTimeCommandRequest::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept
+{
+    aWriter.WriteBits(Hours, 8);
+    aWriter.WriteBits(Minutes, 8);
+}
+
+void SetTimeCommandRequest::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
+{
+    ClientMessage::DeserializeRaw(aReader);
+
+    uint64_t dest = 0;
+    aReader.ReadBits(dest, 8);
+    Hours = dest & 0xFF;
+    aReader.ReadBits(dest, 8);
+    Minutes = dest & 0xFF;
+}

--- a/Code/encoding/Messages/SetTimeCommandRequest.h
+++ b/Code/encoding/Messages/SetTimeCommandRequest.h
@@ -15,9 +15,10 @@ struct SetTimeCommandRequest final : ClientMessage
 
     bool operator==(const SetTimeCommandRequest& acRhs) const noexcept
     {
-        return GetOpcode() == acRhs.GetOpcode() && Hours == acRhs.Hours && Minutes == acRhs.Minutes;
+        return GetOpcode() == acRhs.GetOpcode() && Hours == acRhs.Hours && Minutes == acRhs.Minutes && PlayerId == acRhs.PlayerId;
     }
 
     uint8_t Hours{};
     uint8_t Minutes{};
+    uint32_t PlayerId{};
 };

--- a/Code/encoding/Messages/SetTimeCommandRequest.h
+++ b/Code/encoding/Messages/SetTimeCommandRequest.h
@@ -6,17 +6,15 @@ struct SetTimeCommandRequest final : ClientMessage
 {
     static constexpr ClientOpcode Opcode = kSetTimeCommandRequest;
 
-    SetTimeCommandRequest() : ClientMessage(Opcode)
+    SetTimeCommandRequest()
+        : ClientMessage(Opcode)
     {
     }
 
     void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
     void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
 
-    bool operator==(const SetTimeCommandRequest& acRhs) const noexcept
-    {
-        return GetOpcode() == acRhs.GetOpcode() && Hours == acRhs.Hours && Minutes == acRhs.Minutes && PlayerId == acRhs.PlayerId;
-    }
+    bool operator==(const SetTimeCommandRequest& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && Hours == acRhs.Hours && Minutes == acRhs.Minutes && PlayerId == acRhs.PlayerId; }
 
     uint8_t Hours{};
     uint8_t Minutes{};

--- a/Code/encoding/Messages/SetTimeCommandRequest.h
+++ b/Code/encoding/Messages/SetTimeCommandRequest.h
@@ -1,0 +1,23 @@
+﻿#pragma once
+
+#include "Message.h"
+
+struct SetTimeCommandRequest final : ClientMessage
+{
+    static constexpr ClientOpcode Opcode = kSetTimeCommandRequest;
+
+    SetTimeCommandRequest() : ClientMessage(Opcode)
+    {
+    }
+
+    void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
+    void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
+
+    bool operator==(const SetTimeCommandRequest& acRhs) const noexcept
+    {
+        return GetOpcode() == acRhs.GetOpcode() && Hours == acRhs.Hours && Minutes == acRhs.Minutes;
+    }
+
+    uint8_t Hours{};
+    uint8_t Minutes{};
+};

--- a/Code/encoding/Opcodes.h
+++ b/Code/encoding/Opcodes.h
@@ -52,6 +52,7 @@ enum ClientOpcode : unsigned char
     kRequestCurrentWeather,
     kRequestSetWaypoint,
     kRequestRemoveWaypoint,
+    kSetTimeCommandRequest,
     kClientOpcodeMax
 };
 
@@ -111,5 +112,6 @@ enum ServerOpcode : unsigned char
     kNotifyWeatherChange,
     kNotifySetWaypoint,
     kNotifyRemoveWaypoint,
+    kNotifySetTimeResult,
     kServerOpcodeMax
 };

--- a/Code/server/Game/PlayerManager.cpp
+++ b/Code/server/Game/PlayerManager.cpp
@@ -90,6 +90,31 @@ Player const* PlayerManager::GetById(uint32_t aId) const noexcept
     return nullptr;
 }
 
+Player* PlayerManager::GetByUsername(const String& acUsername) const noexcept
+{
+    auto itor = std::begin(m_players);
+    const auto end = std::end(m_players);
+
+    for (; itor != end; ++itor)
+        if (itor.value()->GetUsername() == acUsername)
+            return itor.value().get();
+
+    return nullptr;
+}
+
+
+Player const* PlayerManager::GetByUsername(const String& acUsername) noexcept
+{
+    auto itor = std::begin(m_players);
+    const auto end = std::end(m_players);
+
+    for (; itor != end; ++itor)
+        if (itor.value()->GetUsername() == acUsername)
+            return itor.value().get();
+
+    return nullptr;
+}
+
 uint32_t PlayerManager::Count() const noexcept
 {
     return static_cast<uint32_t>(m_players.size());

--- a/Code/server/Game/PlayerManager.cpp
+++ b/Code/server/Game/PlayerManager.cpp
@@ -102,7 +102,6 @@ Player* PlayerManager::GetByUsername(const String& acUsername) const noexcept
     return nullptr;
 }
 
-
 Player const* PlayerManager::GetByUsername(const String& acUsername) noexcept
 {
     auto itor = std::begin(m_players);

--- a/Code/server/Game/PlayerManager.h
+++ b/Code/server/Game/PlayerManager.h
@@ -44,6 +44,9 @@ struct PlayerManager
     Player* GetById(uint32_t aId) noexcept;
     Player const* GetById(uint32_t aId) const noexcept;
 
+    Player* GetByUsername(const String& acUsername) const noexcept;
+    Player const* GetByUsername(const String& acUsername) noexcept;
+
     uint32_t Count() const noexcept;
 
     template <class T> void ForEach(const T& acFunctor) noexcept

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -858,10 +858,12 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
         return;
     }
 
+    bool adminPasswordUsed = acRequest->Token == sAdminPassword.value() && !sAdminPassword.empty();
+
     // check if the proper server password was supplied.
-    if (acRequest->Token == sPassword.value() || (acRequest->Token == sAdminPassword.value() && !sAdminPassword.empty()))
+    if (acRequest->Token == sPassword.value() || adminPasswordUsed)
     {
-        if (acRequest->Token == sAdminPassword.value() && !sAdminPassword.empty())
+        if (adminPasswordUsed)
         {
             m_adminSessions.insert(aConnectionId);
             spdlog::warn("New admin session for {:x} '{}'", aConnectionId, remoteAddress);

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -26,105 +26,102 @@ constexpr size_t kMaxServerNameLength = 128u;
 
 // -- Cvars --
 Console::Setting uServerPort{"GameServer:uPort", "Which port to host the server on", 10578u};
-Console::Setting uMaxPlayerCount{
-    "GameServer:uMaxPlayerCount",
-    "Maximum number of players allowed on the server (going over the default of 8 is not recommended)", 8u};
+Console::Setting uMaxPlayerCount{"GameServer:uMaxPlayerCount", "Maximum number of players allowed on the server (going over the default of 8 is not recommended)", 8u};
 Console::Setting bPremiumTickrate{"GameServer:bPremiumMode", "Use premium tick rate", true};
 
-Console::StringSetting sServerName{"GameServer:sServerName", "Name that shows up in the server list",
-                                   "Dedicated Together Server"};
+Console::StringSetting sServerName{"GameServer:sServerName", "Name that shows up in the server list", "Dedicated Together Server"};
 Console::StringSetting sAdminPassword{"GameServer:sAdminPassword", "Admin authentication password", ""};
 Console::StringSetting sPassword{"GameServer:sPassword", "Server password", ""};
 
 // Gameplay
 // TODO: to make this easier for users, use game names for difficulty instead of int
 Console::Setting uDifficulty{"Gameplay:uDifficulty", "In game difficulty (0 to 5)", 4u};
-Console::Setting bEnableGreetings{
-    "Gameplay:bEnableGreetings",
-    "Enables NPC greetings (disabled by default since they can be spammy with dialogue sync)", false};
+Console::Setting bEnableGreetings{"Gameplay:bEnableGreetings", "Enables NPC greetings (disabled by default since they can be spammy with dialogue sync)", false};
 Console::Setting bEnablePvp{"Gameplay:bEnablePvp", "Enables pvp", false};
-Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes",
-                                  "Sync chests and displays in player homes and other NoResetZones", false};
+Console::Setting bSyncPlayerHomes{"Gameplay:bSyncPlayerHomes", "Sync chests and displays in player homes and other NoResetZones", false};
 Console::Setting bEnableDeathSystem{"Gameplay:bEnableDeathSystem", "Enables the custom multiplayer death system", true};
-Console::Setting uTimeScale{
-    "Gameplay:uTimeScale",
-    "How many seconds pass ingame for every real second (0 to 1000). Changing this can make the game unstable", 20u};
-Console::Setting bSyncPlayerCalendar{
-    "Gameplay:bSyncPlayerCalendar",
-    "Syncs up all player calendars to be the same day, month, and year. This uses the date of the player with the furthest ahead date at connection.", false};
-Console::Setting bAutoPartyJoin{
-    "Gameplay:bAutoPartyJoin",
-    "Join parties automatically, as long as there is only one party in the server", true};
+Console::Setting uTimeScale{"Gameplay:uTimeScale", "How many seconds pass ingame for every real second (0 to 1000). Changing this can make the game unstable", 20u};
+Console::Setting bSyncPlayerCalendar{"Gameplay:bSyncPlayerCalendar", "Syncs up all player calendars to be the same day, month, and year. This uses the date of the player with the furthest ahead date at connection.", false};
+Console::Setting bAutoPartyJoin{"Gameplay:bAutoPartyJoin", "Join parties automatically, as long as there is only one party in the server", true};
 // ModPolicy Stuff
-Console::Setting bEnableModCheck{"ModPolicy:bEnableModCheck", "Bypass the checking of mods on the server", false,
-                                 Console::SettingsFlags::kLocked};
-Console::Setting bAllowSKSE{"ModPolicy:bAllowSKSE", "Allow clients with SKSE active to join", true,
-                            Console::SettingsFlags::kLocked};
-Console::Setting bAllowMO2{"ModPolicy:bAllowMO2", "Allow clients running Mod Organizer 2 to join", true,
-                           Console::SettingsFlags::kLocked};
+Console::Setting bEnableModCheck{"ModPolicy:bEnableModCheck", "Bypass the checking of mods on the server", false, Console::SettingsFlags::kLocked};
+Console::Setting bAllowSKSE{"ModPolicy:bAllowSKSE", "Allow clients with SKSE active to join", true, Console::SettingsFlags::kLocked};
+Console::Setting bAllowMO2{"ModPolicy:bAllowMO2", "Allow clients running Mod Organizer 2 to join", true, Console::SettingsFlags::kLocked};
 
 // -- Commands --
-Console::Command<> TogglePremium("TogglePremium", "Toggle Premium Tickrate on/off", [](Console::ArgStack&) {
-    bPremiumTickrate = !bPremiumTickrate;
-    spdlog::get("ConOut")->info("Premium Tickrate has been {}.", bPremiumTickrate == true ? "enabled" : "disabled");
-});
+Console::Command<> TogglePremium(
+    "TogglePremium", "Toggle Premium Tickrate on/off",
+    [](Console::ArgStack&)
+    {
+        bPremiumTickrate = !bPremiumTickrate;
+        spdlog::get("ConOut")->info("Premium Tickrate has been {}.", bPremiumTickrate == true ? "enabled" : "disabled");
+    });
 
-Console::Command<> TogglePvp("TogglePvp", "Toggle PvP on/off", [](Console::ArgStack&) {
-    bEnablePvp = !bEnablePvp;
-    spdlog::get("ConOut")->info("PvP has been {}.", bEnablePvp == true ? "enabled" : "disabled");
-    GameServer::Get()->UpdateSettings();
-});
+Console::Command<> TogglePvp(
+    "TogglePvp", "Toggle PvP on/off",
+    [](Console::ArgStack&)
+    {
+        bEnablePvp = !bEnablePvp;
+        spdlog::get("ConOut")->info("PvP has been {}.", bEnablePvp == true ? "enabled" : "disabled");
+        GameServer::Get()->UpdateSettings();
+    });
 
-Console::Command<int64_t> SetDifficulty("SetDifficulty",
-                                        "Set server difficulty (0 being Novice and 5 being Legendary; default is 4)",
-                                        [](Console::ArgStack& aStack) {
-                                            auto aDiff = aStack.Pop<int64_t>();
+Console::Command<int64_t> SetDifficulty(
+    "SetDifficulty", "Set server difficulty (0 being Novice and 5 being Legendary; default is 4)",
+    [](Console::ArgStack& aStack)
+    {
+        auto aDiff = aStack.Pop<int64_t>();
 
-                                            if (aDiff < 0 || aDiff > 5)
-                                            {
-                                                spdlog::warn("Game difficulty is invalid (should be from 0 to 5, "
-                                                             "current value is {}), setting difficulty to 4 (master).",
-                                                             aDiff);
+        if (aDiff < 0 || aDiff > 5)
+        {
+            spdlog::warn(
+                "Game difficulty is invalid (should be from 0 to 5, "
+                "current value is {}), setting difficulty to 4 (master).",
+                aDiff);
 
-                                                aDiff = 4;
-                                            }
+            aDiff = 4;
+        }
 
-                                            uDifficulty = (uint32_t)aDiff;
+        uDifficulty = (uint32_t)aDiff;
 
-                                            GameServer::Get()->UpdateSettings();
-                                            spdlog::get("ConOut")->info("Difficulty has been set to {}.", aDiff);
-                                        });
+        GameServer::Get()->UpdateSettings();
+        spdlog::get("ConOut")->info("Difficulty has been set to {}.", aDiff);
+    });
 
-Console::Command<> ShowVersion("version", "Show the version the server was compiled with",
-                               [](Console::ArgStack&) { spdlog::get("ConOut")->info("Server " BUILD_COMMIT); });
+Console::Command<> ShowVersion("version", "Show the version the server was compiled with", [](Console::ArgStack&) { spdlog::get("ConOut")->info("Server " BUILD_COMMIT); });
 
-Console::Command<> CrashServer("crash", "Crashes the server, don't use!", [](Console::ArgStack&) {
-    int* i = 0;
-    *i = 42;
-});
+Console::Command<> CrashServer(
+    "crash", "Crashes the server, don't use!",
+    [](Console::ArgStack&)
+    {
+        int* i = 0;
+        *i = 42;
+    });
 
-Console::Command<> ShowMoPoStatus("ShowMOPOStats", "Shows the status of ModPolicy", [](Console::ArgStack&) {
-    auto formatStatus = [](bool aToggle) { return aToggle ? "yes" : "no"; };
+Console::Command<> ShowMoPoStatus(
+    "ShowMOPOStats", "Shows the status of ModPolicy",
+    [](Console::ArgStack&)
+    {
+        auto formatStatus = [](bool aToggle)
+        {
+            return aToggle ? "yes" : "no";
+        };
 
-    spdlog::get("ConOut")->info("Modcheck enabled: {}\nSKSE allowed: {}\nMO2 allowed: {}",
-                                formatStatus(bEnableModCheck), formatStatus(bAllowSKSE), formatStatus(bAllowMO2));
-});
+        spdlog::get("ConOut")->info("Modcheck enabled: {}\nSKSE allowed: {}\nMO2 allowed: {}", formatStatus(bEnableModCheck), formatStatus(bAllowSKSE), formatStatus(bAllowMO2));
+    });
 
 // -- Constants --
-constexpr char kBypassMoPoWarning[]{
-    "ModCheck is disabled. This can lead to desync and other oddities. Make sure you know what you are doing. We "
-    "may not be able to assist you if ModCheck was disabled."};
+constexpr char kBypassMoPoWarning[]{"ModCheck is disabled. This can lead to desync and other oddities. Make sure you know what you are doing. We "
+                                    "may not be able to assist you if ModCheck was disabled."};
 
-constexpr char kMopoRecordsMissing[]{
-    "Failed to start: ModPolicy's ModCheck is enabled, but no mods are installed. Players won't be able "
-    "to join! Please create a Data/ directory, and put a \"loadorder.txt\" file in there."
-    "Check the wiki, which can be found on skyrim-together.com, for more details."};
+constexpr char kMopoRecordsMissing[]{"Failed to start: ModPolicy's ModCheck is enabled, but no mods are installed. Players won't be able "
+                                     "to join! Please create a Data/ directory, and put a \"loadorder.txt\" file in there."
+                                     "Check the wiki, which can be found on skyrim-together.com, for more details."};
 
-constexpr char kCalendarSyncWarning[]{
-    "Calendar sync is enabled. We generally do not recommend that you use this feature."
-    "Calendar sync can cause the calendar to jump ahead or behind, which might mess up the timing of quests."
-    "If you disable this feature again (which is the default setting), the days will still progress, but the"
-    "exact date will differ slightly between clients (which has no impact on gameplay)."};
+constexpr char kCalendarSyncWarning[]{"Calendar sync is enabled. We generally do not recommend that you use this feature."
+                                      "Calendar sync can cause the calendar to jump ahead or behind, which might mess up the timing of quests."
+                                      "If you disable this feature again (which is the default setting), the days will still progress, but the"
+                                      "exact date will differ slightly between clients (which has no impact on gameplay)."};
 
 static uint16_t GetUserTickRate()
 {
@@ -150,8 +147,10 @@ ServerSettings GetSettings()
 }
 
 GameServer::GameServer(Console::ConsoleRegistry& aConsole) noexcept
-    : m_lastFrameTime(std::chrono::high_resolution_clock::now()),
-      m_startTime(std::chrono::high_resolution_clock::now()), m_commands(aConsole), m_requestStop(false)
+    : m_lastFrameTime(std::chrono::high_resolution_clock::now())
+    , m_startTime(std::chrono::high_resolution_clock::now())
+    , m_commands(aConsole)
+    , m_requestStop(false)
 {
     BASE_ASSERT(s_pInstance == nullptr, "Server instance already exists?");
     s_pInstance = this;
@@ -165,19 +164,19 @@ GameServer::GameServer(Console::ConsoleRegistry& aConsole) noexcept
 
     if (uDifficulty.value_as<uint8_t>() > 5)
     {
-        spdlog::warn("Game difficulty is invalid (should be from 0 to 5, current value is {}), setting difficulty to 4 "
-                     "(master).",
-                     uDifficulty.value_as<uint8_t>());
+        spdlog::warn(
+            "Game difficulty is invalid (should be from 0 to 5, current value is {}), setting difficulty to 4 "
+            "(master).",
+            uDifficulty.value_as<uint8_t>());
 
         uDifficulty = 4;
     }
 
     if (!bEnableDeathSystem)
     {
-        spdlog::warn(
-            "The multiplayer death system is disabled on this server. We recommend that you ONLY do this if you have"
-            " a mod that replaces the vanilla death system. You should only disable our death system if you"
-            " absolutely know what you are doing!");
+        spdlog::warn("The multiplayer death system is disabled on this server. We recommend that you ONLY do this if you have"
+                     " a mod that replaces the vanilla death system. You should only disable our death system if you"
+                     " absolutely know what you are doing!");
     }
 
     m_isPasswordProtected = strcmp(sPassword.value(), "") != 0;
@@ -243,10 +242,12 @@ bool GameServer::CheckMoPo()
 
 void GameServer::BindMessageHandlers()
 {
-    auto handlerGenerator = [this](auto& x) {
+    auto handlerGenerator = [this](auto& x)
+    {
         using T = typename std::remove_reference_t<decltype(x)>::Type;
 
-        m_messageHandlers[T::Opcode] = [this](UniquePtr<ClientMessage>& apMessage, ConnectionId_t aConnectionId) {
+        m_messageHandlers[T::Opcode] = [this](UniquePtr<ClientMessage>& apMessage, ConnectionId_t aConnectionId)
+        {
             auto* pPlayer = m_pWorld->GetPlayerManager().GetByConnectionId(aConnectionId);
 
             if (!pPlayer)
@@ -267,17 +268,18 @@ void GameServer::BindMessageHandlers()
     ClientMessageFactory::Visit(handlerGenerator);
 
     // Override authentication request
-    m_messageHandlers[AuthenticationRequest::Opcode] = [this](UniquePtr<ClientMessage>& apMessage,
-                                                              ConnectionId_t aConnectionId) {
+    m_messageHandlers[AuthenticationRequest::Opcode] = [this](UniquePtr<ClientMessage>& apMessage, ConnectionId_t aConnectionId)
+    {
         const auto pRealMessage = CastUnique<AuthenticationRequest>(std::move(apMessage));
         HandleAuthenticationRequest(aConnectionId, pRealMessage);
     };
 
-    auto adminHandlerGenerator = [this](auto& x) {
+    auto adminHandlerGenerator = [this](auto& x)
+    {
         using T = typename std::remove_reference_t<decltype(x)>::Type;
 
-        m_adminMessageHandlers[T::Opcode] = [this](UniquePtr<ClientAdminMessage>& apMessage,
-                                                   ConnectionId_t aConnectionId) {
+        m_adminMessageHandlers[T::Opcode] = [this](UniquePtr<ClientAdminMessage>& apMessage, ConnectionId_t aConnectionId)
+        {
             const auto pRealMessage = CastUnique<T>(std::move(apMessage));
             m_pWorld->GetDispatcher().trigger(AdminPacketEvent<T>(pRealMessage.get(), aConnectionId));
         };
@@ -290,62 +292,73 @@ void GameServer::BindMessageHandlers()
 
 void GameServer::BindServerCommands()
 {
-    m_commands.RegisterCommand<>("uptime", "Show how long the server has been running for", [this](Console::ArgStack&) {
-        Uptime uptime = GetUptime();
-        spdlog::get("ConOut")->info("Server uptime: {}w {}d {}h {}m", uptime.weeks, uptime.days, uptime.hours,
-                                    uptime.minutes);
-    });
-
-    m_commands.RegisterCommand<>("players", "List all players on this server", [&](Console::ArgStack&) {
-        auto out = spdlog::get("ConOut");
-        uint32_t count = m_pWorld->GetPlayerManager().Count();
-        if (count == 0)
+    m_commands.RegisterCommand<>(
+        "uptime", "Show how long the server has been running for",
+        [this](Console::ArgStack&)
         {
-            out->warn("No players on here. Invite some friends!");
-            return;
-        }
-
-        out->info("<------Players-({})--->", count);
-        for (Player* pPlayer : m_pWorld->GetPlayerManager())
-        {
-            out->info("{}: {}", pPlayer->GetId(), pPlayer->GetUsername().c_str());
-        }
-    });
-
-    m_commands.RegisterCommand<>("mods", "List all installed mods on this server", [&](Console::ArgStack&) {
-        auto out = spdlog::get("ConOut");
-        auto& mods = m_pWorld->ctx().at<ModsComponent>().GetServerMods();
-        if (mods.size() == 0)
-        {
-            out->warn("No mods installed");
-            return;
-        }
-
-        out->info("<------Mods-({})--->", mods.size());
-        for (auto& it : mods)
-        {
-            out->info(it.first);
-        }
-    });
-
-    m_commands.RegisterCommand<>("resources", "List all loaded resources on the server", [&](Console::ArgStack&) {
-        auto out = spdlog::get("ConOut");
-        if (!m_pResources || m_pResources->GetManifests().size() == 0)
-        {
-            out->warn("No resources loaded");
-            return;
-        }
-
-        out->info("<------Resources-({})--->", m_pResources->GetManifests().size());
-        m_pResources->ForEachManifest([&](const auto& aManifest) {
-            out->info("{} -> {}", aManifest.Name.c_str(), aManifest.Description.c_str());
+            Uptime uptime = GetUptime();
+            spdlog::get("ConOut")->info("Server uptime: {}w {}d {}h {}m", uptime.weeks, uptime.days, uptime.hours, uptime.minutes);
         });
-    });
+
+    m_commands.RegisterCommand<>(
+        "players", "List all players on this server",
+        [&](Console::ArgStack&)
+        {
+            auto out = spdlog::get("ConOut");
+            uint32_t count = m_pWorld->GetPlayerManager().Count();
+            if (count == 0)
+            {
+                out->warn("No players on here. Invite some friends!");
+                return;
+            }
+
+            out->info("<------Players-({})--->", count);
+            for (Player* pPlayer : m_pWorld->GetPlayerManager())
+            {
+                out->info("{}: {}", pPlayer->GetId(), pPlayer->GetUsername().c_str());
+            }
+        });
+
+    m_commands.RegisterCommand<>(
+        "mods", "List all installed mods on this server",
+        [&](Console::ArgStack&)
+        {
+            auto out = spdlog::get("ConOut");
+            auto& mods = m_pWorld->ctx().at<ModsComponent>().GetServerMods();
+            if (mods.size() == 0)
+            {
+                out->warn("No mods installed");
+                return;
+            }
+
+            out->info("<------Mods-({})--->", mods.size());
+            for (auto& it : mods)
+            {
+                out->info(it.first);
+            }
+        });
+
+    m_commands.RegisterCommand<>(
+        "resources", "List all loaded resources on the server",
+        [&](Console::ArgStack&)
+        {
+            auto out = spdlog::get("ConOut");
+            if (!m_pResources || m_pResources->GetManifests().size() == 0)
+            {
+                out->warn("No resources loaded");
+                return;
+            }
+
+            out->info("<------Resources-({})--->", m_pResources->GetManifests().size());
+            m_pResources->ForEachManifest([&](const auto& aManifest) { out->info("{} -> {}", aManifest.Name.c_str(), aManifest.Description.c_str()); });
+        });
 
     m_commands.RegisterCommand<>("quit", "Stop the server", [&](Console::ArgStack&) { Kill(); });
 
     m_commands.RegisterCommand<int64_t, int64_t>(
-        "SetTime", "Set ingame hour and minute", [&](Console::ArgStack& aStack) {
+        "SetTime", "Set ingame hour and minute",
+        [&](Console::ArgStack& aStack)
+        {
             auto out = spdlog::get("ConOut");
 
             auto hour = aStack.Pop<int64_t>();
@@ -365,7 +378,9 @@ void GameServer::BindServerCommands()
         });
 
     m_commands.RegisterCommand<int64_t, int64_t, int64_t>(
-        "SetDate", "Set ingame day, month, and year", [&](Console::ArgStack& aStack) {
+        "SetDate", "Set ingame day, month, and year",
+        [&](Console::ArgStack& aStack)
+        {
             auto out = spdlog::get("ConOut");
 
             auto day = aStack.Pop<int64_t>();
@@ -385,7 +400,9 @@ void GameServer::BindServerCommands()
         });
 
     m_commands.RegisterCommand<std::string>(
-        "AddAdmin", "Add admin privileges to player", [&](Console::ArgStack& aStack) {
+        "AddAdmin", "Add admin privileges to player",
+        [&](Console::ArgStack& aStack)
+        {
             auto out = spdlog::get("ConOut");
 
             const auto& cUsername = aStack.Pop<String>();
@@ -419,7 +436,9 @@ void GameServer::BindServerCommands()
             }
         });
     m_commands.RegisterCommand<std::string>(
-        "RemoveAdmin", "Remove admin privileges from player", [&](Console::ArgStack& aStack) {
+        "RemoveAdmin", "Remove admin privileges from player",
+        [&](Console::ArgStack& aStack)
+        {
             auto out = spdlog::get("ConOut");
 
             const auto& cUsername = aStack.Pop<String>();
@@ -448,7 +467,9 @@ void GameServer::BindServerCommands()
             }
         });
     m_commands.RegisterCommand<>(
-        "admins", "List all admins", [&](Console::ArgStack&) {
+        "admins", "List all admins",
+        [&](Console::ArgStack&)
+        {
             auto out = spdlog::get("ConOut");
             if (m_adminSessions.size() == 0)
             {
@@ -493,8 +514,7 @@ void GameServer::UpdateInfo()
 
     if (cServerName.length() > kMaxServerNameLength)
     {
-        spdlog::error("sServerName is longer than the limit of {} characters/bytes, and has been cut short",
-                      kMaxServerNameLength);
+        spdlog::error("sServerName is longer than the limit of {} characters/bytes, and has been cut short", kMaxServerNameLength);
         m_info.name = cServerName.substr(0U, kMaxServerNameLength);
     }
     else
@@ -516,9 +536,7 @@ void GameServer::UpdateTimeScale()
 
     if (!timescale_set_successfully)
     {
-        spdlog::warn(
-            "TimeScale is invalid (should be from 0 to 1000, current value is {}), setting TimeScale to 20 (default)",
-            timescale);
+        spdlog::warn("TimeScale is invalid (should be from 0 to 1000, current value is {}), setting TimeScale to 20 (default)", timescale);
 
         uTimeScale = 20u;
     }
@@ -560,15 +578,15 @@ void GameServer::OnConsume(const void* apData, const uint32_t aSize, const Conne
     }
     else
     {*/
-        const ClientMessageFactory factory;
-        auto pMessage = factory.Extract(reader);
-        if (!pMessage)
-        {
-            spdlog::error("Couldn't parse packet from {:x}", aConnectionId);
-            return;
-        }
+    const ClientMessageFactory factory;
+    auto pMessage = factory.Extract(reader);
+    if (!pMessage)
+    {
+        spdlog::error("Couldn't parse packet from {:x}", aConnectionId);
+        return;
+    }
 
-        m_messageHandlers[pMessage->GetOpcode()](pMessage, aConnectionId);
+    m_messageHandlers[pMessage->GetOpcode()](pMessage, aConnectionId);
     //}
 }
 
@@ -584,8 +602,7 @@ void GameServer::OnDisconnection(const ConnectionId_t aConnectionId, EDisconnect
 
     auto* pPlayer = m_pWorld->GetPlayerManager().GetByConnectionId(aConnectionId);
 
-    spdlog::info("Connection ended {:x} - '{}' disconnected", aConnectionId,
-                 (pPlayer != NULL ? pPlayer->GetUsername().c_str() : "NULL"));
+    spdlog::info("Connection ended {:x} - '{}' disconnected", aConnectionId, (pPlayer != NULL ? pPlayer->GetUsername().c_str() : "NULL"));
 
     m_pWorld->GetScriptService().HandlePlayerQuit(aConnectionId, aReason);
 
@@ -642,8 +659,7 @@ void GameServer::Send(const ConnectionId_t aConnectionId, const ServerMessage& a
 
     acServerMessage.Serialize(writer);
 
-    TiltedPhoques::PacketView packet(reinterpret_cast<char*>(buffer.GetWriteData()),
-                                     static_cast<uint32_t>(writer.Size()));
+    TiltedPhoques::PacketView packet(reinterpret_cast<char*>(buffer.GetWriteData()), static_cast<uint32_t>(writer.Size()));
     Server::Send(aConnectionId, &packet);
 
     s_allocator.Reset();
@@ -659,8 +675,7 @@ void GameServer::Send(ConnectionId_t aConnectionId, const ServerAdminMessage& ac
 
     acServerMessage.Serialize(writer);
 
-    TiltedPhoques::PacketView packet(reinterpret_cast<char*>(buffer.GetWriteData()),
-                                     static_cast<uint32_t>(writer.Size()));
+    TiltedPhoques::PacketView packet(reinterpret_cast<char*>(buffer.GetWriteData()), static_cast<uint32_t>(writer.Size()));
     Server::Send(aConnectionId, &packet);
 
     s_allocator.Reset();
@@ -685,8 +700,7 @@ void GameServer::SendToPlayers(const ServerMessage& acServerMessage, const Playe
 }
 
 // NOTE: this doesn't check objects in range, only characters in range.
-bool GameServer::SendToPlayersInRange(const ServerMessage& acServerMessage, const entt::entity acOrigin,
-                                      const Player* apExcludedPlayer) const
+bool GameServer::SendToPlayersInRange(const ServerMessage& acServerMessage, const entt::entity acOrigin, const Player* apExcludedPlayer) const
 {
     if (!m_pWorld->valid(acOrigin))
     {
@@ -718,8 +732,7 @@ bool GameServer::SendToPlayersInRange(const ServerMessage& acServerMessage, cons
     return true;
 }
 
-void GameServer::SendToParty(const ServerMessage& acServerMessage, const PartyComponent& acPartyComponent,
-                             const Player* apExcludeSender) const
+void GameServer::SendToParty(const ServerMessage& acServerMessage, const PartyComponent& acPartyComponent, const Player* apExcludeSender) const
 {
     if (!acPartyComponent.JoinedPartyId.has_value())
     {
@@ -740,8 +753,7 @@ void GameServer::SendToParty(const ServerMessage& acServerMessage, const PartyCo
     }
 }
 
-void GameServer::SendToPartyInRange(const ServerMessage& acServerMessage, const PartyComponent& acPartyComponent,
-                                    const entt::entity acOrigin, const Player* apExcludeSender) const
+void GameServer::SendToPartyInRange(const ServerMessage& acServerMessage, const PartyComponent& acPartyComponent, const entt::entity acOrigin, const Player* apExcludeSender) const
 {
     if (!acPartyComponent.JoinedPartyId.has_value())
     {
@@ -793,8 +805,7 @@ bool GameServer::ValidateAuthParams(ConnectionId_t aConnectionId, const UniquePt
     return false;
 }
 
-void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
-                                             const UniquePtr<AuthenticationRequest>& acRequest)
+void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId, const UniquePtr<AuthenticationRequest>& acRequest)
 {
     const auto info = GetConnectionInfo(aConnectionId);
 
@@ -805,7 +816,8 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
     serverResponse.Version = BUILD_COMMIT;
 
     using RT = AuthenticationResponse::ResponseType;
-    auto sendKick = [&](const RT type) {
+    auto sendKick = [&](const RT type)
+    {
         serverResponse.Type = type;
         Send(aConnectionId, serverResponse);
         // the previous message is a lingering kick, it still gets delivered.
@@ -815,8 +827,7 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
     // to make our testing life a bit easier.
     if (acRequest->Version != BUILD_COMMIT)
     {
-        spdlog::info("New player {:x} '{}' tried to connect with client {} - Version mismatch", aConnectionId,
-                     remoteAddress, acRequest->Version.c_str());
+        spdlog::info("New player {:x} '{}' tried to connect with client {} - Version mismatch", aConnectionId, remoteAddress, acRequest->Version.c_str());
         sendKick(RT::kWrongVersion);
         return;
     }
@@ -839,8 +850,7 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
         if (mo2Problem)
             response += "MO2 ";
 
-        spdlog::info("New player {:x} '{}' tried to connect, but {}{} disallowed - Kicked.", aConnectionId,
-                     remoteAddress, response.c_str(), skseProblem && mo2Problem ? "are" : "is");
+        spdlog::info("New player {:x} '{}' tried to connect, but {}{} disallowed - Kicked.", aConnectionId, remoteAddress, response.c_str(), skseProblem && mo2Problem ? "are" : "is");
 
         serverResponse.SKSEActive = acRequest->SKSEActive;
         serverResponse.MO2Active = acRequest->MO2Active;
@@ -884,8 +894,7 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
             // mods that may exist on the server, but not on the client
             for (const auto& entry : modsComponent.GetServerMods())
             {
-                const auto it = std::find_if(userMods.begin(), userMods.end(),
-                                             [&](const Mods::Entry& it) { return it.Filename == entry.first; });
+                const auto it = std::find_if(userMods.begin(), userMods.end(), [&](const Mods::Entry& it) { return it.Filename == entry.first; });
 
                 if (it == userMods.end())
                 {
@@ -901,9 +910,7 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
                 String text = PrettyPrintModList(modsToRemove.ModList);
                 // "ModPolicy: refusing connection {:x} because essential mods are missing: {}"
                 // for future reference ^
-                spdlog::info(
-                    "ModPolicy: refusing connection {:x} because the following mods are installed on the client: {}",
-                    aConnectionId, text.c_str());
+                spdlog::info("ModPolicy: refusing connection {:x} because the following mods are installed on the client: {}", aConnectionId, text.c_str());
 
                 serverResponse.UserMods.ModList = std::move(modsToRemove.ModList);
                 sendKick(RT::kModsMismatch);
@@ -919,8 +926,7 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
         size_t i = 0;
         for (auto& mod : acRequest->UserMods.ModList)
         {
-            const uint32_t id =
-                mod.IsLite ? modsComponent.AddLite(mod.Filename) : modsComponent.AddStandard(mod.Filename);
+            const uint32_t id = mod.IsLite ? modsComponent.AddLite(mod.Filename) : modsComponent.AddStandard(mod.Filename);
 
             Mods::Entry entry;
             entry.Filename = mod.Filename;
@@ -953,8 +959,7 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
         serverResponse.PlayerId = pPlayer->GetId();
 
         auto modList = PrettyPrintModList(acRequest->UserMods.ModList);
-        spdlog::info("New player '{}' [{:x}] connected with {} mods\n\t: {}", pPlayer->GetUsername().c_str(),
-                     aConnectionId, acRequest->UserMods.ModList.size(), modList.c_str());
+        spdlog::info("New player '{}' [{:x}] connected with {} mods\n\t: {}", pPlayer->GetUsername().c_str(), aConnectionId, acRequest->UserMods.ModList.size(), modList.c_str());
 
         serverResponse.Settings = GetSettings();
 
@@ -1031,8 +1036,7 @@ void GameServer::UpdateTitle() const
     const auto name = m_info.name.empty() ? "Private server" : m_info.name;
     const char* playerText = GetClientCount() <= 1 ? " player" : " players";
 
-    const auto title = fmt::format("{} - {} {} - {} Ticks - " BUILD_BRANCH "@" BUILD_COMMIT, name.c_str(),
-                                   GetClientCount(), playerText, GetTickRate());
+    const auto title = fmt::format("{} - {} {} - {} Ticks - " BUILD_BRANCH "@" BUILD_COMMIT, name.c_str(), GetClientCount(), playerText, GetTickRate());
 
 #if TP_PLATFORM_WINDOWS
     SetConsoleTitleA(title.c_str());

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -78,6 +78,14 @@ struct GameServer final : Server
     {
         return m_isPasswordProtected;
     }
+    void SetPublic(bool aIsPublic) noexcept
+    {
+        m_isPublic = aIsPublic;
+    }
+    bool IsPublic() const noexcept
+    {
+        return m_isPublic;
+    }
 
     template <class T> void ForEachAdmin(const T& aFunctor)
     {
@@ -119,6 +127,7 @@ struct GameServer final : Server
     std::function<void(UniquePtr<ClientAdminMessage>&, ConnectionId_t)> m_adminMessageHandlers[kClientAdminOpcodeMax];
 
     bool m_isPasswordProtected{};
+    bool m_isPublic{};
 
     Info m_info{};
     UniquePtr<Resources::ResourceCollection> m_pResources;

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -58,30 +58,15 @@ struct GameServer final : Server
     void Send(ConnectionId_t aConnectionId, const ServerAdminMessage& acServerMessage) const;
     void SendToLoaded(const ServerMessage& acServerMessage) const;
     void SendToPlayers(const ServerMessage& acServerMessage, const Player* apExcludeSender = nullptr) const;
-    bool SendToPlayersInRange(const ServerMessage& acServerMessage, const entt::entity acOrigin,
-                              const Player* apExcludeSender = nullptr) const;
-    void SendToParty(const ServerMessage& acServerMessage, const PartyComponent& acPartyComponent,
-                     const Player* apExcludeSender = nullptr) const;
-    void SendToPartyInRange(const ServerMessage& acServerMessage, const PartyComponent& acPartyComponent,
-                            const entt::entity acOrigin, const Player* apExcludeSender = nullptr) const;
+    bool SendToPlayersInRange(const ServerMessage& acServerMessage, const entt::entity acOrigin, const Player* apExcludeSender = nullptr) const;
+    void SendToParty(const ServerMessage& acServerMessage, const PartyComponent& acPartyComponent, const Player* apExcludeSender = nullptr) const;
+    void SendToPartyInRange(const ServerMessage& acServerMessage, const PartyComponent& acPartyComponent, const entt::entity acOrigin, const Player* apExcludeSender = nullptr) const;
 
-    const Info& GetInfo() const noexcept
-    {
-        return m_info;
-    }
+    const Info& GetInfo() const noexcept { return m_info; }
 
-    bool IsRunning() const noexcept
-    {
-        return !m_requestStop;
-    }
-    bool IsPasswordProtected() const noexcept
-    {
-        return m_isPasswordProtected;
-    }
-    [[nodiscard]] bool IsPublic() const noexcept
-    {
-        return m_isPublic;
-    }
+    bool IsRunning() const noexcept { return !m_requestStop; }
+    bool IsPasswordProtected() const noexcept { return m_isPasswordProtected; }
+    [[nodiscard]] bool IsPublic() const noexcept { return m_isPublic; }
 
     template <class T> void ForEachAdmin(const T& aFunctor)
     {
@@ -98,30 +83,18 @@ struct GameServer final : Server
     };
     Uptime GetUptime() const noexcept;
 
-    World& GetWorld() const noexcept
-    {
-        return *m_pWorld;
-    }
+    World& GetWorld() const noexcept { return *m_pWorld; }
 
-    [[nodiscard]] const TiltedPhoques::Set<ConnectionId_t>& GetAdminSessions() const noexcept
-    {
-        return m_adminSessions;
-    }
+    [[nodiscard]] const TiltedPhoques::Set<ConnectionId_t>& GetAdminSessions() const noexcept { return m_adminSessions; }
 
-    void AddAdminSession(ConnectionId_t acSession) noexcept
-    {
-        m_adminSessions.insert(acSession);
-    }
+    void AddAdminSession(ConnectionId_t acSession) noexcept { m_adminSessions.insert(acSession); }
 
-    void RemoveAdminSession(ConnectionId_t acSession) noexcept
-    {
-        m_adminSessions.erase(acSession);
-    }
+    void RemoveAdminSession(ConnectionId_t acSession) noexcept { m_adminSessions.erase(acSession); }
 
-    Player* GetAdminByUsername(const String& acUsername)  const noexcept;
+    Player* GetAdminByUsername(const String& acUsername) const noexcept;
     Player const* GetAdminByUsername(const String& acUsername) noexcept;
 
-  protected:
+protected:
     bool ValidateAuthParams(ConnectionId_t aConnectionId, const UniquePtr<AuthenticationRequest>& acRequest);
     void HandleAuthenticationRequest(ConnectionId_t aConnectionId, const UniquePtr<AuthenticationRequest>& acRequest);
 
@@ -131,11 +104,11 @@ struct GameServer final : Server
     void OnConnection(ConnectionId_t aHandle) override;
     void OnDisconnection(ConnectionId_t aConnectionId, EDisconnectReason aReason) override;
 
-  private:
+private:
     void UpdateTitle() const;
     String SanitizeUsername(const String& acUsername) const noexcept;
 
-  private:
+private:
     std::chrono::high_resolution_clock::time_point m_startTime;
     std::chrono::high_resolution_clock::time_point m_lastFrameTime;
     std::function<void(UniquePtr<ClientMessage>&, ConnectionId_t)> m_messageHandlers[kClientOpcodeMax];

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -107,6 +107,11 @@ struct GameServer final : Server
         return *m_pWorld;
     }
 
+    [[nodiscard]] const TiltedPhoques::Set<ConnectionId_t>& GetAdminSessions() const noexcept
+    {
+        return m_adminSessions;
+    }
+
   protected:
     bool ValidateAuthParams(ConnectionId_t aConnectionId, const UniquePtr<AuthenticationRequest>& acRequest);
     void HandleAuthenticationRequest(ConnectionId_t aConnectionId, const UniquePtr<AuthenticationRequest>& acRequest);

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -112,6 +112,13 @@ struct GameServer final : Server
         return m_adminSessions;
     }
 
+    void AddAdminSession(ConnectionId_t acSession) noexcept
+    {
+        m_adminSessions.insert(acSession);
+    }
+
+    void RemoveAdminSession(ConnectionId_t acSession) noexcept;
+
   protected:
     bool ValidateAuthParams(ConnectionId_t aConnectionId, const UniquePtr<AuthenticationRequest>& acRequest);
     void HandleAuthenticationRequest(ConnectionId_t aConnectionId, const UniquePtr<AuthenticationRequest>& acRequest);

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -66,7 +66,6 @@ struct GameServer final : Server
 
     bool IsRunning() const noexcept { return !m_requestStop; }
     bool IsPasswordProtected() const noexcept { return m_isPasswordProtected; }
-    [[nodiscard]] bool IsPublic() const noexcept { return m_isPublic; }
 
     template <class T> void ForEachAdmin(const T& aFunctor)
     {
@@ -115,7 +114,6 @@ private:
     std::function<void(UniquePtr<ClientAdminMessage>&, ConnectionId_t)> m_adminMessageHandlers[kClientAdminOpcodeMax];
 
     bool m_isPasswordProtected{};
-    bool m_isPublic{};
 
     Info m_info{};
     UniquePtr<Resources::ResourceCollection> m_pResources;

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -78,11 +78,7 @@ struct GameServer final : Server
     {
         return m_isPasswordProtected;
     }
-    void SetPublic(bool aIsPublic) noexcept
-    {
-        m_isPublic = aIsPublic;
-    }
-    bool IsPublic() const noexcept
+    [[nodiscard]] bool IsPublic() const noexcept
     {
         return m_isPublic;
     }
@@ -117,7 +113,13 @@ struct GameServer final : Server
         m_adminSessions.insert(acSession);
     }
 
-    void RemoveAdminSession(ConnectionId_t acSession) noexcept;
+    void RemoveAdminSession(ConnectionId_t acSession) noexcept
+    {
+        m_adminSessions.erase(acSession);
+    }
+
+    Player* GetAdminByUsername(const String& acUsername)  const noexcept;
+    Player const* GetAdminByUsername(const String& acUsername) noexcept;
 
   protected:
     bool ValidateAuthParams(ConnectionId_t aConnectionId, const UniquePtr<AuthenticationRequest>& acRequest);
@@ -131,6 +133,7 @@ struct GameServer final : Server
 
   private:
     void UpdateTitle() const;
+    String SanitizeUsername(const String& acUsername) const noexcept;
 
   private:
     std::chrono::high_resolution_clock::time_point m_startTime;

--- a/Code/server/Scripting/GameServer_Bindings.cpp
+++ b/Code/server/Scripting/GameServer_Bindings.cpp
@@ -1,5 +1,6 @@
 
 #include "GameServer.h"
+
 #include <Messages/NotifyChatMessageBroadcast.h>
 #include <regex>
 
@@ -21,6 +22,23 @@ void CreateGameServerBindings(sol::state_view aState)
         notifyMessage.PlayerName = "[Server]";
         notifyMessage.ChatMessage = std::regex_replace(acMessage, escapeHtml, "");
         GameServer::Get()->Send(aConnectionId, notifyMessage);
+    };
+    type["SendGlobalChatMessage"] = [](GameServer& aSelf, const std::string& acMessage) {
+        NotifyChatMessageBroadcast notifyMessage{};
+
+        std::regex escapeHtml{"<[^>]+>\\s+(?=<)|<[^>]+>"};
+        notifyMessage.MessageType = ChatMessageType::kGlobalChat;
+        notifyMessage.PlayerName = "[Server]";
+        notifyMessage.ChatMessage = std::regex_replace(acMessage, escapeHtml, "");
+        GameServer::Get()->SendToPlayers(notifyMessage);
+    };
+    type["SetTime"] = [](GameServer& aSelf, int aHours, int aMinutes,
+                         float aScale = GameServer::Get()->GetWorld().GetCalendarService().GetTimeScale()) -> bool {
+        aHours = std::max(0, std::min(aHours, 23));
+        aMinutes = std::max(0, std::min(aMinutes, 59));
+        aScale = std::max(1.0f, std::min(aScale, 100.0f));
+
+        return GameServer::Get()->GetWorld().GetCalendarService().SetTime(aHours, aMinutes, aScale);
     };
     // type["SendPacket"]
 }

--- a/Code/server/Scripting/Player_Bindings.cpp
+++ b/Code/server/Scripting/Player_Bindings.cpp
@@ -32,6 +32,10 @@ void BindPlayer(sol::state_view aState)
     playerType["SetLevel"] = &Player::SetLevel;
     playerType["SetCellComponent"] = &Player::SetCellComponent;
     playerType["Send"] = &Player::Send;
+    playerType["IsPartyLeader"] = [](Player& aSelf) {
+        return GameServer::Get()->GetWorld().GetPartyService().IsPlayerLeader(
+            PlayerManager::Get()->GetByConnectionId(aSelf.GetConnectionId()));
+    };
 }
 
 void BindPlayerManager(sol::state_view aState)

--- a/Code/server/Scripting/ScriptBindings.cpp
+++ b/Code/server/Scripting/ScriptBindings.cpp
@@ -44,6 +44,13 @@ void CreateMathBindings(sol::state_view);
 void CreatePlayerBindings(sol::state_view);
 void CreateComponentBindings(sol::state_view);
 void CreateGameServerBindings(sol::state_view);
+void CreateCalendarServiceBindings(sol::state_view);
+void CreatePartyServiceBindings(sol::state_view);
+void CreateCharacterServiceBindings(sol::state_view);
+void CreatePlayerServiceBindings(sol::state_view);
+void CreateQuestServiceBindings(sol::state_view);
+void CreateScriptServiceBindings(sol::state_view);
+void CreateWorldBindings(sol::state_view);
 
 sol::table BindModsComponent(sol::state_view aState)
 {
@@ -98,6 +105,16 @@ void CreateScriptBindings(sol::state& aState)
     CreateComponentBindings(aState);
 
     CreateGameServerBindings(aState);
+
+    // services
+    CreateCalendarServiceBindings(aState);
+    CreatePartyServiceBindings(aState);
+    CreateCharacterServiceBindings(aState);
+    CreatePlayerServiceBindings(aState);
+    CreateQuestServiceBindings(aState);
+    CreateScriptServiceBindings(aState);
+
+    CreateWorldBindings(aState);
     BindModsComponent(aState);
 }
 } // namespace Script

--- a/Code/server/Scripting/Services/CalendarService_Bindings.cpp
+++ b/Code/server/Scripting/Services/CalendarService_Bindings.cpp
@@ -1,0 +1,13 @@
+﻿#include "GameServer.h"
+
+namespace Script
+{
+void CreateCalendarServiceBindings(sol::state_view aState)
+{
+    auto calendarType =
+        aState.new_usertype<CalendarService>("CalendarService", sol::meta_function::construct, sol::no_constructor);
+
+    calendarType["get"] = []() -> CalendarService& { return GameServer::Get()->GetWorld().GetCalendarService(); };
+    calendarType["GetTimeScale"] = []() { return GameServer::Get()->GetWorld().GetCalendarService().GetTimeScale(); };
+}
+} // namespace Script

--- a/Code/server/Scripting/Services/CharacterService_Bindings.cpp
+++ b/Code/server/Scripting/Services/CharacterService_Bindings.cpp
@@ -1,0 +1,12 @@
+﻿#include "GameServer.h"
+
+namespace Script
+{
+void CreateCharacterServiceBindings(sol::state_view aState)
+{
+    auto characterType =
+        aState.new_usertype<CharacterService>("CharacterService", sol::meta_function::construct, sol::no_constructor);
+
+    characterType["get"] = []() -> CharacterService& { return GameServer::Get()->GetWorld().GetCharacterService(); };
+}
+} // namespace Script

--- a/Code/server/Scripting/Services/PartyService_Bindings.cpp
+++ b/Code/server/Scripting/Services/PartyService_Bindings.cpp
@@ -1,0 +1,18 @@
+﻿#include "GameServer.h"
+
+namespace Script
+{
+void CreatePartyServiceBindings(sol::state_view aState)
+{
+    auto partyType =
+        aState.new_usertype<PartyService>("PartyService", sol::meta_function::construct, sol::no_constructor);
+
+    partyType["get"] = []() -> PartyService& { return GameServer::Get()->GetWorld().GetPartyService(); };
+    partyType["IsPlayerInParty"] = [](PartyService& aService, uint32_t aConnID) -> bool {
+        Player* player = PlayerManager::Get()->GetByConnectionId(aConnID);
+        if (player == nullptr)
+            return false;
+        return aService.IsPlayerInParty(player);
+    };
+}
+} // namespace Script

--- a/Code/server/Scripting/Services/PlayerService_Bindings.cpp
+++ b/Code/server/Scripting/Services/PlayerService_Bindings.cpp
@@ -1,0 +1,12 @@
+﻿#include "GameServer.h"
+
+namespace Script
+{
+void CreatePlayerServiceBindings(sol::state_view aState)
+{
+    auto playerType =
+        aState.new_usertype<PlayerService>("PlayerService", sol::meta_function::construct, sol::no_constructor);
+
+    playerType["get"] = []() -> PlayerService& { return GameServer::Get()->GetWorld().GetPlayerService(); };
+}
+} // namespace Script

--- a/Code/server/Scripting/Services/QuestService_Bindings.cpp
+++ b/Code/server/Scripting/Services/QuestService_Bindings.cpp
@@ -1,0 +1,12 @@
+﻿#include "GameServer.h"
+
+namespace Script
+{
+void CreateQuestServiceBindings(sol::state_view aState)
+{
+    auto questType =
+        aState.new_usertype<QuestService>("QuestService", sol::meta_function::construct, sol::no_constructor);
+
+    questType["get"] = []() -> QuestService& { return GameServer::Get()->GetWorld().GetQuestService(); };
+}
+} // namespace Script

--- a/Code/server/Scripting/Services/ScriptService_Bindings.cpp
+++ b/Code/server/Scripting/Services/ScriptService_Bindings.cpp
@@ -1,0 +1,12 @@
+﻿#include "GameServer.h"
+
+namespace Script
+{
+void CreateScriptServiceBindings(sol::state_view aState)
+{
+    auto scriptType =
+        aState.new_usertype<ScriptService>("ScriptService", sol::meta_function::construct, sol::no_constructor);
+
+    scriptType["get"] = []() -> ScriptService& { return GameServer::Get()->GetWorld().GetScriptService(); };
+}
+} // namespace Script

--- a/Code/server/Scripting/World_Bindings.cpp
+++ b/Code/server/Scripting/World_Bindings.cpp
@@ -1,0 +1,13 @@
+﻿#include "GameServer.h"
+#include "World.h"
+
+namespace Script
+{
+void CreateWorldBindings(sol::state_view aState)
+{
+    auto type =
+        aState.new_usertype<World>("World", sol::meta_function::construct, sol::no_constructor);
+
+    type["get"] = []() -> World& { return GameServer::Get()->GetWorld(); };
+}
+} // namespace Script

--- a/Code/server/Services/CalendarService.cpp
+++ b/Code/server/Services/CalendarService.cpp
@@ -74,6 +74,8 @@ bool CalendarService::SetTime(int aHours, int aMinutes, float aScale) noexcept
         m_dateTime.m_timeModel.Time = static_cast<float>(aHours) + minutes;
 
         SendTimeResync();
+
+        GameServer::Get()->GetWorld().GetScriptService().HandleSetTime(aHours, aMinutes, aScale);
         return true;
     }
     return false;

--- a/Code/server/Services/CalendarService.cpp
+++ b/Code/server/Services/CalendarService.cpp
@@ -10,7 +10,8 @@
 
 #include "Game/Player.h"
 
-CalendarService::CalendarService(World& aWorld, entt::dispatcher& aDispatcher) : m_world(aWorld)
+CalendarService::CalendarService(World& aWorld, entt::dispatcher& aDispatcher)
+    : m_world(aWorld)
 {
     m_updateConnection = aDispatcher.sink<UpdateEvent>().connect<&CalendarService::OnUpdate>(this);
     m_joinConnection = aDispatcher.sink<PlayerJoinEvent>().connect<&CalendarService::OnPlayerJoin>(this);

--- a/Code/server/Services/CommandService.cpp
+++ b/Code/server/Services/CommandService.cpp
@@ -4,13 +4,37 @@
 #include <GameServer.h>
 #include <World.h>
 
+#include <Messages/SetTimeCommandRequest.h>
+#include <Messages/NotifySetTimeResult.h>
 #include <Messages/TeleportCommandRequest.h>
 #include <Messages/TeleportCommandResponse.h>
 
 CommandService::CommandService(World& aWorld, entt::dispatcher& aDispatcher) noexcept
     : m_world(aWorld)
 {
+    m_setTimeConnection = aDispatcher.sink<PacketEvent<SetTimeCommandRequest>>().connect<&CommandService::OnSetTimeCommand>(this);
     m_teleportConnection = aDispatcher.sink<PacketEvent<TeleportCommandRequest>>().connect<&CommandService::OnTeleportCommandRequest>(this);
+}
+
+void CommandService::OnSetTimeCommand(const PacketEvent<SetTimeCommandRequest>& acMessage) const noexcept
+{
+    NotifySetTimeResult response{};
+
+    if (GameServer::Get()->IsPublic())
+    {
+        response.Result = NotifySetTimeResult::SetTimeResult::kPublicServer;
+        acMessage.pPlayer->Send(response);
+
+        return;
+    }
+
+    const auto cHours = static_cast<int>(acMessage.Packet.Hours);
+    const auto cMinutes = static_cast<int>(acMessage.Packet.Minutes);
+
+    m_world.GetCalendarService().SetTime(cHours, cMinutes, m_world.GetCalendarService().GetTimeScale());
+
+    response.Result = NotifySetTimeResult::SetTimeResult::kSuccess;
+    acMessage.pPlayer->Send(response);
 }
 
 void CommandService::OnTeleportCommandRequest(const PacketEvent<TeleportCommandRequest>& acMessage) const noexcept

--- a/Code/server/Services/CommandService.h
+++ b/Code/server/Services/CommandService.h
@@ -4,6 +4,7 @@
 
 struct World;
 struct TeleportCommandRequest;
+struct SetTimeCommandRequest;
 
 /**
  * @brief Processes incoming commands.
@@ -16,6 +17,7 @@ struct CommandService
     TP_NOCOPYMOVE(CommandService);
 
 protected:
+    void OnSetTimeCommand(const PacketEvent<SetTimeCommandRequest>& acMessage) const noexcept;
     /**
      * @brief Returns the location of the target player of the teleport command.
      */
@@ -24,5 +26,6 @@ protected:
 private:
     World& m_world;
 
+    entt::scoped_connection m_setTimeConnection;
     entt::scoped_connection m_teleportConnection;
 };

--- a/Code/server/Services/OverlayService.cpp
+++ b/Code/server/Services/OverlayService.cpp
@@ -55,7 +55,9 @@ void sendPlayerMessage(const ChatMessageType acType, const String acContent, Pla
                 spdlog::error("{}: SendToPlayersInRange failed", __FUNCTION__);
         }
         break;
-
+    case kSetTime:
+        GameServer::Get()->SendToPlayers(notifyMessage);
+        break;
     default: spdlog::error("{} is not a known MessageType", static_cast<uint64_t>(notifyMessage.MessageType)); break;
     }
 }

--- a/Code/server/Services/OverlayService.cpp
+++ b/Code/server/Services/OverlayService.cpp
@@ -55,9 +55,6 @@ void sendPlayerMessage(const ChatMessageType acType, const String acContent, Pla
                 spdlog::error("{}: SendToPlayersInRange failed", __FUNCTION__);
         }
         break;
-    case kSetTime:
-        GameServer::Get()->SendToPlayers(notifyMessage);
-        break;
     default: spdlog::error("{} is not a known MessageType", static_cast<uint64_t>(notifyMessage.MessageType)); break;
     }
 }

--- a/Code/server/Services/ScriptService.cpp
+++ b/Code/server/Services/ScriptService.cpp
@@ -196,6 +196,11 @@ void ScriptService::HandlePlayerQuit(ConnectionId_t aConnectionId, Server::EDisc
     CallEvent("onPlayerQuit", aConnectionId, reason);
 }
 
+std::tuple<bool, String> ScriptService::HandleSetTime(int aHours, int aMinutes, float aTimeScale) noexcept
+{
+    return CallCancelableEvent("onSetTime", aHours, aMinutes, aTimeScale);
+}
+
 #if 0
 void ScriptService::RegisterExtensions(ScriptContext& aContext)
 {

--- a/Code/server/Services/ScriptService.h
+++ b/Code/server/Services/ScriptService.h
@@ -33,6 +33,8 @@ struct ScriptService
 
     void HandlePlayerQuit(ConnectionId_t aConnectionId, Server::EDisconnectReason aReason) noexcept;
 
+    std::tuple<bool, String> HandleSetTime(int aHours, int aMinutes, float aTimeScale) noexcept;
+
   protected:
     // void RegisterExtensions(ScriptContext& aContext) override;
 

--- a/Code/server/Services/ServerListService.cpp
+++ b/Code/server/Services/ServerListService.cpp
@@ -30,8 +30,6 @@ ServerListService::ServerListService(World& aWorld, entt::dispatcher& aDispatche
     if (!bAnnounceServer)
         spdlog::warn("bAnnounceServer is set to false. The server will not show up as a public server. "
                      "If you are just playing with friends, this is probably what you want.");
-
-    GameServer::Get()->SetPublic(bAnnounceServer);
 }
 
 void ServerListService::OnUpdate(const UpdateEvent& acEvent) noexcept

--- a/Code/server/Services/ServerListService.cpp
+++ b/Code/server/Services/ServerListService.cpp
@@ -30,6 +30,8 @@ ServerListService::ServerListService(World& aWorld, entt::dispatcher& aDispatche
     if (!bAnnounceServer)
         spdlog::warn("bAnnounceServer is set to false. The server will not show up as a public server. "
                      "If you are just playing with friends, this is probably what you want.");
+
+    GameServer::Get()->SetPublic(bAnnounceServer);
 }
 
 void ServerListService::OnUpdate(const UpdateEvent& acEvent) noexcept

--- a/Code/server/World.cpp
+++ b/Code/server/World.cpp
@@ -21,8 +21,8 @@
 
 World::World()
 {
-    //m_spAdminService = std::make_shared<AdminService>(*this, m_dispatcher);
-    //spdlog::default_logger()->sinks().push_back(std::static_pointer_cast<spdlog::sinks::sink>(m_spAdminService));
+    m_spAdminService = std::make_shared<AdminService>(*this, m_dispatcher);
+    spdlog::default_logger()->sinks().push_back(std::static_pointer_cast<spdlog::sinks::sink>(m_spAdminService));
 
     ctx().emplace<CharacterService>(*this, m_dispatcher);
     ctx().emplace<PlayerService>(*this, m_dispatcher);

--- a/Code/server/World.cpp
+++ b/Code/server/World.cpp
@@ -21,8 +21,8 @@
 
 World::World()
 {
-    m_spAdminService = std::make_shared<AdminService>(*this, m_dispatcher);
-    spdlog::default_logger()->sinks().push_back(std::static_pointer_cast<spdlog::sinks::sink>(m_spAdminService));
+    //m_spAdminService = std::make_shared<AdminService>(*this, m_dispatcher);
+    //spdlog::default_logger()->sinks().push_back(std::static_pointer_cast<spdlog::sinks::sink>(m_spAdminService));
 
     ctx().emplace<CharacterService>(*this, m_dispatcher);
     ctx().emplace<PlayerService>(*this, m_dispatcher);

--- a/Code/skyrim_ui/src/app/services/chat.service.ts
+++ b/Code/skyrim_ui/src/app/services/chat.service.ts
@@ -9,7 +9,6 @@ export enum MessageTypes {
   PLAYER_DIALOGUE = 2,
   PARTY_CHAT = 3,
   LOCAL_CHAT = 4,
-  SET_TIME = 5,
 }
 
 export interface ChatMessage {
@@ -49,13 +48,6 @@ export class ChatService {
   }
 
   /**
-   * Send system message to the Server. Does not add anything to the local mesesage list.
-   */
-  public sendSystemMessage(translationKey: string, params: Record<string, any> = undefined,) {
-      skyrimtogether.sendMessage(MessageTypes.SYSTEM_MESSAGE, translationKey, { params });
-  }
-
-  /**
    * Pushes a message to the chat window, without sending anything to the Server.
    */
   public pushMessage(message: ChatMessage) {
@@ -80,13 +72,8 @@ export class ChatService {
     type: MessageTypes,
     content: string,
     senderName: string | undefined = undefined,
-    params: Record<string, any> = undefined,
   ): void {
-    if (type === MessageTypes.SET_TIME) {
-      this.pushSystemMessage(content, { params });
-    } else {
-      this.messageList.next({ type, content, senderName });
-    }
+    this.messageList.next({ type, content, senderName });
   }
 
   private CommandHandler: CommandHandler;

--- a/Code/skyrim_ui/src/app/services/chat.service.ts
+++ b/Code/skyrim_ui/src/app/services/chat.service.ts
@@ -9,6 +9,7 @@ export enum MessageTypes {
   PLAYER_DIALOGUE = 2,
   PARTY_CHAT = 3,
   LOCAL_CHAT = 4,
+  SET_TIME = 5,
 }
 
 export interface ChatMessage {
@@ -48,6 +49,13 @@ export class ChatService {
   }
 
   /**
+   * Send system message to the Server. Does not add anything to the local mesesage list.
+   */
+  public sendSystemMessage(translationKey: string, params: Record<string, any> = undefined,) {
+      skyrimtogether.sendMessage(MessageTypes.SYSTEM_MESSAGE, translationKey, { params });
+  }
+
+  /**
    * Pushes a message to the chat window, without sending anything to the Server.
    */
   public pushMessage(message: ChatMessage) {
@@ -72,8 +80,13 @@ export class ChatService {
     type: MessageTypes,
     content: string,
     senderName: string | undefined = undefined,
+    params: Record<string, any> = undefined,
   ): void {
-    this.messageList.next({ type, content, senderName });
+    if (type === MessageTypes.SET_TIME) {
+      this.pushSystemMessage(content, { params });
+    } else {
+      this.messageList.next({ type, content, senderName });
+    }
   }
 
   private CommandHandler: CommandHandler;

--- a/Code/skyrim_ui/src/app/services/chat/commands.ts
+++ b/Code/skyrim_ui/src/app/services/chat/commands.ts
@@ -1,5 +1,4 @@
-import { formatNumber, getLocaleDateTimeFormat } from '@angular/common';
-import { ChatService, MessageTypes } from '../chat.service';
+import { ChatService } from '../chat.service';
 
 export interface Command {
   readonly name: string;
@@ -39,15 +38,8 @@ export class CommandHandler {
         return;
       }
       skyrimtogether.setTime(hoursNum, minutesNum);
-      skyrimtogether.sendMessage(
-        MessageTypes.SET_TIME, 
-        'COMPONENT.CHAT.SET_TIME_RESPONSE', 
-        { 
-          cmds,
-          hours: formatNumber(hoursNum, 'en-US', "2.0-0"),
-          minutes: formatNumber(minutesNum, 'en-US', "2.0-0"),
-        },
-      );
+      // TODO (Toe Knee): Ideally send a localizable response string here,
+      // currently relies on user making it themselves with serverside scripting
     },
   }
 

--- a/Code/skyrim_ui/src/app/services/chat/commands.ts
+++ b/Code/skyrim_ui/src/app/services/chat/commands.ts
@@ -1,3 +1,4 @@
+import { formatNumber, getLocaleDateTimeFormat } from '@angular/common';
 import { ChatService, MessageTypes } from '../chat.service';
 
 export interface Command {
@@ -15,12 +16,46 @@ export class CommandHandler {
         { cmds },
       );
     },
-  };
+  }
+  
+  private SetTime: Command = {
+    name: 'settime', 
+    executor: async (args) => {
+      const cmds = [...this.commands.keys()].join(', ');
+      if (args.length != 2) {
+        this.chatService.pushSystemMessage(
+          'COMPONENT.CHAT.SET_TIME_ARGUMENT_COUNT', 
+          { cmds },
+        );
+        return;
+      }
+      const hoursNum = parseInt(args[0]);
+      const minutesNum = parseInt(args[1]);
+      if (hoursNum < 0 || hoursNum > 23 || minutesNum < 0 || minutesNum > 59) {
+        this.chatService.pushSystemMessage(
+          'COMPONENT.CHAT.SET_TIME_INVALID_ARGUMENTS',
+          { cmds },
+        );
+        return;
+      }
+      skyrimtogether.setTime(hoursNum, minutesNum);
+      skyrimtogether.sendMessage(
+        MessageTypes.SET_TIME, 
+        'COMPONENT.CHAT.SET_TIME_RESPONSE', 
+        { 
+          cmds,
+          hours: formatNumber(hoursNum, 'en-US', "2.0-0"),
+          minutes: formatNumber(minutesNum, 'en-US', "2.0-0"),
+        },
+      );
+    },
+  }
 
   private readonly commands = new Map<string, Command>();
 
   public constructor(private readonly chatService: ChatService) {
     this.register(this.Help);
+    this.register(this.SetTime);
   }
 
   public readonly COMMAND_PREFIX = '/';
@@ -39,7 +74,7 @@ export class CommandHandler {
       command.executor(args);
     } else {
       this.chatService.pushSystemMessage('SERVICE.COMMANDS.COMMAND_NOT_FOUND', {
-        cmd: inputWithoutPrefix,
+        cmd: commandName,
       });
     }
   }

--- a/Code/skyrim_ui/src/app/services/chat/commands.ts
+++ b/Code/skyrim_ui/src/app/services/chat/commands.ts
@@ -28,16 +28,16 @@ export class CommandHandler {
         );
         return;
       }
-      const hoursNum = parseInt(args[0]);
-      const minutesNum = parseInt(args[1]);
-      if (hoursNum < 0 || hoursNum > 23 || minutesNum < 0 || minutesNum > 59) {
+      const hours = parseInt(args[0]);
+      const minutes = parseInt(args[1]);
+      if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59 || Number.isNaN(hours) || Number.isNaN(minutes)) {
         this.chatService.pushSystemMessage(
           'COMPONENT.CHAT.SET_TIME_INVALID_ARGUMENTS',
           { cmds },
         );
         return;
       }
-      skyrimtogether.setTime(hoursNum, minutesNum);
+      skyrimtogether.setTime(hours, minutes);
       // TODO (Toe Knee): Ideally send a localizable response string here,
       // currently relies on user making it themselves with serverside scripting
     },

--- a/Code/skyrim_ui/src/app/services/error.service.ts
+++ b/Code/skyrim_ui/src/app/services/error.service.ts
@@ -12,7 +12,8 @@ export interface ErrorEvent {
     | 'server_full'
     | 'no_reason'
     | 'bad_uGridsToLoad'
-    | 'non_default_install';
+    | 'non_default_install'
+    | 'set_time_public_server';
   data?: Record<any, any>;
 }
 

--- a/Code/skyrim_ui/src/assets/i18n/en.json
+++ b/Code/skyrim_ui/src/assets/i18n/en.json
@@ -3,7 +3,10 @@
     "CHAT": {
       "SEND": "Send",
       "MESSAGE": "Message",
-      "MESSAGE_TOO_LONG": "You cannot send a message longer than {{chatMessageLengthLimit}} characters."
+      "MESSAGE_TOO_LONG": "You cannot send a message longer than {{chatMessageLengthLimit}} characters.",
+      "SET_TIME_ARGUMENT_COUNT": "Wrong arguments, usage: /settime HH MM, example: /settime 15 32.",
+      "SET_TIME_INVALID_ARGUMENTS": "The hours must be between 0 and 23, and the minutes between 0 and 59.",
+      "SET_TIME_RESPONSE": "Time set to {{hours}}:{{minutes}}"
     },
     "CONNECT": {
       "INFO": {
@@ -148,7 +151,7 @@
     },
     "COMMANDS": {
       "AVAILABLE_COMMANDS": "Available chat commands: {{cmds}}",
-      "COMMAND_NOT_FOUND": "'{{cmd}}' is not recognized as a command."
+      "COMMAND_NOT_FOUND": "'{{cmd}}' is not a recognized command."
     },
     "GROUP": {
       "LEVEL_UP": "{{name}} has reached level {{level}}.",
@@ -166,6 +169,7 @@
         "WRONG_PASSWORD": "The password you entered is incorrect.",
         "NO_REASON": "The server refused connection without reason.",
         "SERVER_FULL": "This server is full.",
+        "SET_TIME_PUBLIC_SERVER": "The SetTime chat command is not allowed in public servers.",
         "BAD_UGRIDSTOLOAD": "It seems that your Skyrim.ini file has a non-default value for 'uGridsToLoad'. THIS IS A VERY BAD IDEA, and will most likely break the mod. Please set this setting back to its default (5), or remove the Skyrim.ini file and launch Skyrim vanilla once to generate a new file. The settings 'uExterior Cell Buffer' and 'uInterior Cell Buffer' should also be left at the default setting. If you do not know how to do this, please refer to our wiki or ask on our Discord server/Reddit sub for help.",
         "NON_DEFAULT_INSTALL": "It seems that your installation is not purely vanilla, i.e. it has Creation Club content (Anniversary Update or otherwise) or other mods.\nWe do NOT recommend playing with mods.\nWe recommend that you uninstall and disable these mods (instructions can be found on the wiki).\n\nFor the best experience, you should have the following mod list:<strong>\nSkyrim.esm\nUpdate.esm\nDawnguard.esm\nHearthFires.esm\nDragonborn.esm\n_ResourcePack.esl\nSkyrimTogether.esp</strong>"
       }

--- a/Code/skyrim_ui/src/assets/i18n/en.json
+++ b/Code/skyrim_ui/src/assets/i18n/en.json
@@ -150,7 +150,8 @@
     },
     "COMMANDS": {
       "AVAILABLE_COMMANDS": "Available chat commands: {{cmds}}",
-      "COMMAND_NOT_FOUND": "'{{cmd}}' is not a recognized command."
+      "COMMAND_NOT_FOUND": "'{{cmd}}' is not a recognized command.",
+      "NOT_ADMIN": "You must be an admin to use that command."
     },
     "GROUP": {
       "LEVEL_UP": "{{name}} has reached level {{level}}.",
@@ -168,7 +169,6 @@
         "WRONG_PASSWORD": "The password you entered is incorrect.",
         "NO_REASON": "The server refused connection without reason.",
         "SERVER_FULL": "This server is full.",
-        "SET_TIME_PUBLIC_SERVER": "The SetTime chat command is not allowed in public servers.",
         "BAD_UGRIDSTOLOAD": "It seems that your Skyrim.ini file has a non-default value for 'uGridsToLoad'. THIS IS A VERY BAD IDEA, and will most likely break the mod. Please set this setting back to its default (5), or remove the Skyrim.ini file and launch Skyrim vanilla once to generate a new file. The settings 'uExterior Cell Buffer' and 'uInterior Cell Buffer' should also be left at the default setting. If you do not know how to do this, please refer to our wiki or ask on our Discord server/Reddit sub for help.",
         "NON_DEFAULT_INSTALL": "It seems that your installation is not purely vanilla, i.e. it has Creation Club content (Anniversary Update or otherwise) or other mods.\nWe do NOT recommend playing with mods.\nWe recommend that you uninstall and disable these mods (instructions can be found on the wiki).\n\nFor the best experience, you should have the following mod list:<strong>\nSkyrim.esm\nUpdate.esm\nDawnguard.esm\nHearthFires.esm\nDragonborn.esm\n_ResourcePack.esl\nSkyrimTogether.esp</strong>"
       }

--- a/Code/skyrim_ui/src/assets/i18n/en.json
+++ b/Code/skyrim_ui/src/assets/i18n/en.json
@@ -5,8 +5,7 @@
       "MESSAGE": "Message",
       "MESSAGE_TOO_LONG": "You cannot send a message longer than {{chatMessageLengthLimit}} characters.",
       "SET_TIME_ARGUMENT_COUNT": "Wrong arguments, usage: /settime HH MM, example: /settime 15 32.",
-      "SET_TIME_INVALID_ARGUMENTS": "The hours must be between 0 and 23, and the minutes between 0 and 59.",
-      "SET_TIME_RESPONSE": "Time set to {{hours}}:{{minutes}}"
+      "SET_TIME_INVALID_ARGUMENTS": "The hours must be between 0 and 23, and the minutes between 0 and 59."
     },
     "CONNECT": {
       "INFO": {

--- a/Code/skyrim_ui/src/typings.d.ts
+++ b/Code/skyrim_ui/src/typings.d.ts
@@ -94,6 +94,8 @@ declare namespace SkyrimTogetherTypes {
   type PartyLeftCallback = (inviterId: number) => void;
 
   type PartyInviteReceivedCallback = (inviterId: number) => void;
+
+  type SetTimeCallback = (translationKey: string, params: Record<string, any>) => void;
 }
 
 /** Global Skyrim: Together object. */
@@ -217,6 +219,10 @@ interface SkyrimTogether {
   on(
     event: 'partyInviteReceived',
     callback: SkyrimTogetherTypes.PartyInviteReceivedCallback,
+  ): void;
+
+  on(event: 'setTime',
+    callback: SkyrimTogetherTypes.SetTimeCallback,
   ): void;
 
   /** Remove listener from when the application is first initialized. */
@@ -367,6 +373,16 @@ interface SkyrimTogether {
    * Send message to server.
    */
   sendMessage(type: number, message: string): void;
+
+  /**
+   * Send localizable system message to server.
+   */
+  sendMessage(type: number, translationKey: string, params: Record<string, any>): void;
+
+  /**
+   * Send a request to the server for changing the in-game time.
+   */
+  setTime(hours: number, minutes: number): void;
 
   /**
    * Deactivate UI and release control.

--- a/Code/skyrim_ui/src/typings.d.ts
+++ b/Code/skyrim_ui/src/typings.d.ts
@@ -94,8 +94,6 @@ declare namespace SkyrimTogetherTypes {
   type PartyLeftCallback = (inviterId: number) => void;
 
   type PartyInviteReceivedCallback = (inviterId: number) => void;
-
-  type SetTimeCallback = (translationKey: string, params: Record<string, any>) => void;
 }
 
 /** Global Skyrim: Together object. */
@@ -219,10 +217,6 @@ interface SkyrimTogether {
   on(
     event: 'partyInviteReceived',
     callback: SkyrimTogetherTypes.PartyInviteReceivedCallback,
-  ): void;
-
-  on(event: 'setTime',
-    callback: SkyrimTogetherTypes.SetTimeCallback,
   ): void;
 
   /** Remove listener from when the application is first initialized. */
@@ -373,11 +367,6 @@ interface SkyrimTogether {
    * Send message to server.
    */
   sendMessage(type: number, message: string): void;
-
-  /**
-   * Send localizable system message to server.
-   */
-  sendMessage(type: number, translationKey: string, params: Record<string, any>): void;
 
   /**
    * Send a request to the server for changing the in-game time.

--- a/Code/tp_process/ProcessHandler.cpp
+++ b/Code/tp_process/ProcessHandler.cpp
@@ -16,6 +16,7 @@ void ProcessHandler::OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<C
     m_pCoreObject->SetValue("connect", CefV8Value::CreateFunction("connect", m_pOverlayHandler), V8_PROPERTY_ATTRIBUTE_NONE);
     m_pCoreObject->SetValue("disconnect", CefV8Value::CreateFunction("disconnect", m_pOverlayHandler), V8_PROPERTY_ATTRIBUTE_NONE);
     m_pCoreObject->SetValue("sendMessage", CefV8Value::CreateFunction("sendMessage", m_pOverlayHandler), V8_PROPERTY_ATTRIBUTE_NONE);
+    m_pCoreObject->SetValue("setTime", CefV8Value::CreateFunction("setTime", m_pOverlayHandler),V8_PROPERTY_ATTRIBUTE_NONE);
     m_pCoreObject->SetValue("deactivate", CefV8Value::CreateFunction("deactivate", m_pOverlayHandler), V8_PROPERTY_ATTRIBUTE_NONE);
     m_pCoreObject->SetValue("launchParty", CefV8Value::CreateFunction("launchParty", m_pOverlayHandler), V8_PROPERTY_ATTRIBUTE_NONE);
     m_pCoreObject->SetValue("leaveParty", CefV8Value::CreateFunction("leaveParty", m_pOverlayHandler), V8_PROPERTY_ATTRIBUTE_NONE);


### PR DESCRIPTION
It is about the same if not the same as the [previous PR](https://github.com/tiltedphoques/TiltedEvolution/pull/510) for it from cosi.
Adds a `/settime` chat command that can be used on any server that is not public. 

Ideally, there would be some feedback from the server that it succeeded or failed besides the time change (e.g. a localized chat message, but that turned out to be too complex for me).

EDIT:
Since admins should be the only ones allowed to use the /settime chat command, there are now two different ways of becoming an admin; either by joining the server using the admin password specified in the STServer.ini file, or using the new /AddAdmin console command.
Unfortunately, spaces in names seem to be nearly impossible to deal with without replacing the characters and re-checking for the name over and over again. For the sake of this PR, you can't /AddAdmin or /RemoveAdmin on a name with an underscore in it as that is what is used to replace since spaces are more likely to be in names rather than underscores.

Three new console commands:

/AddAdmin <username>: add the player with the username given to the adminSessions Set
ex.
/AddAdmin Toe_Knee = Toe Knee
/AddAdmin ToeKnee = ToeKnee
/RemoveAdmin <username>: remove the player with the username given from the adminSessions Set
/admins: list out all admins


The PR also now includes a fix for a crash with the ConsoleRegistry's manual resize once it reaches a size() of 10 (it tried to erase m_commandHistory.end()).