### PR TITLE
Nix development env for linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         arch: [x64]
         mode: [debug]
 
@@ -25,41 +25,16 @@ jobs:
         git submodule sync --recursive
         git submodule update --init --force --recursive --depth=1
 
-    # Install dependencies
-    - name: Update apt repositories
-      run: sudo apt-get update
-      
-    - name: Install GCC12
-      shell: bash
-      run:  |
-          sudo apt update
-          sudo apt install gcc-12 g++-12
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 110 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
-          
-    # Install xmake
-    - name: Setup xmake
-      uses: xmake-io/github-action-setup-xmake@v1
+    - name: Setup development environment with nix
+      uses: cachix/install-nix-action@v27
       with:
-        xmake-version: '2.9.3'
+        github_access_token: ${{ secrets.GH_TOKEN }}
 
-    # Update xmake repository (in order to have the file that will be cached)
-    - name: Update xmake repository
-      run: xmake repo --update
+    - run: nix flake check
 
-    # Setup compilation mode and install project dependencies
-    - name: Configure xmake and install dependencies
-      run: xmake config --arch=${{ matrix.arch }} --mode=${{ matrix.mode }} --yes
+    # Kickoff install in its own step - it will be cached anyway
+    - name: Fetch build tools
+      run: nix develop
 
-    # Build the game
     - name: Build
-      run: xmake
-    
-    # Create install
-    #- name: Install
-    # run: xmake install -o packaged
-
-    # Upload artifacts
-    #- uses: actions/upload-artifact@v2
-    #  with:
-    #    name: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.mode }}
-    #    path: packaged/bin/**
+      run: nix develop --command bash -c 'xmake config --arch=${{ matrix.arch }} --mode=${{ matrix.mode }} --yes && xmake'

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ distrib_releasedbg/
 new_addresses.txt
 
 packaged/*
+
+makefile

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "msvc-llvm-nix": {
+      "locked": {
+        "lastModified": 1711618918,
+        "narHash": "sha256-nQLD+vZZFvIG6rSHr2XxGSmdTxNLeyvIEMs9jFw/YX4=",
+        "owner": "roblabla",
+        "repo": "msvc-llvm-nix",
+        "rev": "c98ac7ea24ccb7d1c053d5683c8a47151bfb1b03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "roblabla",
+        "repo": "msvc-llvm-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "msvc-llvm-nix": "msvc-llvm-nix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -18,28 +18,13 @@
         "type": "github"
       }
     },
-    "msvc-llvm-nix": {
-      "locked": {
-        "lastModified": 1711618918,
-        "narHash": "sha256-nQLD+vZZFvIG6rSHr2XxGSmdTxNLeyvIEMs9jFw/YX4=",
-        "owner": "roblabla",
-        "repo": "msvc-llvm-nix",
-        "rev": "c98ac7ea24ccb7d1c053d5683c8a47151bfb1b03",
-        "type": "github"
-      },
-      "original": {
-        "owner": "roblabla",
-        "repo": "msvc-llvm-nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720957393,
-        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "lastModified": 1723991338,
+        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
         "type": "github"
       },
       "original": {
@@ -52,7 +37,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "msvc-llvm-nix": "msvc-llvm-nix",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,13 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    msvc-llvm-nix.url = "github:roblabla/msvc-llvm-nix";
   };
 
-  outputs = { self, nixpkgs, flake-utils, msvc-llvm-nix }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [
-            msvc-llvm-nix.overlay
+           # msvc-llvm-nix.overlay
         ];
         pkgs = import nixpkgs {
           inherit system overlays;
@@ -27,7 +26,8 @@
             cmake
             xmake
             gnumake
-            msvc-toolchain
+            stdenv.cc.cc.lib
+            #msvc-toolchain
           ];
 
           shellHook = ''
@@ -43,6 +43,9 @@
             unset CFLAGS
             unset CXXFLAGS
             unset LDFLAGS
+            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [
+                pkgs.stdenv.cc.cc
+            ]}
             echo "C++ development environment loaded"
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
             xmake
             gnumake
             stdenv.cc.cc.lib
+            mold
             #msvc-toolchain
           ];
 
@@ -46,6 +47,10 @@
             export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [
                 pkgs.stdenv.cc.cc
             ]}
+            export CC="${pkgs.gcc14}/bin/gcc"
+            export CXX="${pkgs.gcc14}/bin/g++"
+            export LD="${pkgs.mold}/bin/mold"
+
             echo "C++ development environment loaded"
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "Tilted C++ development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    msvc-llvm-nix.url = "github:roblabla/msvc-llvm-nix";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, msvc-llvm-nix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [
+            msvc-llvm-nix.overlay
+        ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          config.allowUnfree = true;  # In case MSVC toolchain is unfree
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            gcc14
+            gdb
+            libclang
+            cmake
+            xmake
+            gnumake
+            msvc-toolchain
+          ];
+
+          shellHook = ''
+            # Unset environment variables, required for xmake to find
+            # the linker/compiler that we provide here
+            unset CC
+            unset CXX
+            unset LD
+            unset AR
+            unset AS
+            unset RANLIB
+            unset STRIP
+            unset CFLAGS
+            unset CXXFLAGS
+            unset LDFLAGS
+            echo "C++ development environment loaded"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
This adds a nix development environment to the Linux server. You can get into a shell that has the correct xmake and so on installed by running nix develop at the root of the project, assuming you have the nix package manager installed. This should also stabilise the linux build experience.

Once in the linux shell, you can just run xmake as usual.