### PR TITLE
Exception handling fix so SetUnhandledExceptionFilter works

### DIFF
--- a/Code/client/CrashHandler.cpp
+++ b/Code/client/CrashHandler.cpp
@@ -31,14 +31,13 @@ LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 
     // Check for severe, not continuable and not software-originated exception
     if (pExceptionInfo->ExceptionRecord->ExceptionCode >= 0x80000000 &&
+        pExceptionInfo->ExceptionRecord->ExceptionCode != 0xE06D7363 && // Sigh. C++ exceptions forgot the SOFTWARE_ORIGINATE flag.
         (pExceptionInfo->ExceptionRecord->ExceptionFlags & EXCEPTION_SOFTWARE_ORIGINATE) == 0 && 
         alreadyCrashed++ == 0)
     {
         spdlog::critical (__FUNCTION__ ": crash occurred!"); 
         
-        auto present = IsDebuggerPresent() ? "already" : "not";
-        spdlog::error(__FUNCTION__ ": debugger is {} present at critical exception time, code{:x}, address{}, flags {:x} ",
-                      present,
+        spdlog::error(__FUNCTION__ ": exception code is {:x}, at address {}, flags {:x} ",
                       pExceptionInfo->ExceptionRecord->ExceptionCode,
                       pExceptionInfo->ExceptionRecord->ExceptionAddress,
                       pExceptionInfo->ExceptionRecord->ExceptionFlags);

--- a/Code/client/CrashHandler.cpp
+++ b/Code/client/CrashHandler.cpp
@@ -26,7 +26,7 @@ LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
     auto retval = EXCEPTION_CONTINUE_SEARCH;
 
     // Serialize 
-    static std::mutex singleThreaded;;
+    static std::mutex singleThreaded;
     const std::lock_guard lock{singleThreaded};
 
     // Check for severe, not continuable and not software-originated exception

--- a/Code/client/CrashHandler.cpp
+++ b/Code/client/CrashHandler.cpp
@@ -30,9 +30,7 @@ LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
     const std::lock_guard lock{singleThreaded};
 
     // Check for severe, not continuable and not software-originated exception
-    if (pExceptionInfo->ExceptionRecord->ExceptionCode >= 0x80000000 &&
-        pExceptionInfo->ExceptionRecord->ExceptionCode != 0xE06D7363 && // Sigh. C++ exceptions forgot the SOFTWARE_ORIGINATE flag.
-        (pExceptionInfo->ExceptionRecord->ExceptionFlags & EXCEPTION_SOFTWARE_ORIGINATE) == 0 && 
+    if (pExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION &&
         alreadyCrashed++ == 0)
     {
         spdlog::critical (__FUNCTION__ ": crash occurred!"); 

--- a/Code/client/CrashHandler.h
+++ b/Code/client/CrashHandler.h
@@ -2,9 +2,16 @@
 
 class CrashHandler
 {
-public:
+    PVOID m_handler;
+    static LPTOP_LEVEL_EXCEPTION_FILTER m_pUnhandled; // For remembering "original" UnhandledExceptionFilter
+
+  public:
     CrashHandler();
     ~CrashHandler();
 
     static void RemovePreviousDump(std::filesystem::path path);
+    static inline LPTOP_LEVEL_EXCEPTION_FILTER GetOriginalUnhandledExceptionFilter()
+    {
+        return m_pUnhandled;
+    }
 };

--- a/Code/client/TiltedOnlineApp.h
+++ b/Code/client/TiltedOnlineApp.h
@@ -37,10 +37,6 @@ protected:
 
 private:
     void ApplyNvidiaFix() noexcept;
-#if (!IS_MASTER)
     CrashHandler m_crashHandler;
-#else
-    //ScopedCrashHandler m_crashHandler;
-#endif
     ID3D11Device* m_pDevice = nullptr;
 };


### PR DESCRIPTION
Enables various crashloggers to work with STR.

CrashHandler is always constructed now, but is IS_MASTER aware and disables minidumps when IS_MASTER is true. Unless you turn the flag back on with a debugger.