### PR TITLE
Game exe path command line argument

### DIFF
--- a/Code/immersive_launcher/Launcher.cpp
+++ b/Code/immersive_launcher/Launcher.cpp
@@ -10,10 +10,12 @@
 #include "Utils/FileVersion.inl"
 
 #include "oobe/PathSelection.h"
+#include "oobe/PathArgument.h"
 #include "oobe/SupportChecks.h"
 #include "steam/SteamLoader.h"
 
 #include "base/dialogues/win/TaskDialog.h"
+#include "utils/Registry.h"
 
 #include <BranchInfo.h>
 
@@ -64,11 +66,7 @@ void SetMaxstdio()
 int StartUp(int argc, char** argv)
 {
     bool askSelect = (GetAsyncKeyState(VK_SPACE) & 0x8000);
-    for (int i = 1; i < argc; i++)
-    {
-        if (std::strcmp(argv[i], "-r") == 0)
-            askSelect = true;
-    }
+    HandleArguments(argc, argv, askSelect);
 
     // TODO(Force): Make some InitSharedResources func.
     g_SharedWindowIcon = LoadIconW(GetModuleHandleW(nullptr), MAKEINTRESOURCEW(102));
@@ -140,6 +138,29 @@ void InitClient()
 {
     // Jump into client code.
     RunTiltedApp();
+}
+
+bool HandleArguments(int aArgc, char** aArgv, bool& aAskSelect)
+{
+    for (int i = 1; i < aArgc; i++)
+    {
+        if (std::strcmp(aArgv[i], "-r") == 0)
+            aAskSelect = true;
+        else if (std::strcmp(aArgv[i], "--exePath") == 0)
+        {
+            if (!aArgv[i + 1])
+            {
+                DIE_NOW(L"No exe path specified");
+            }
+
+            if (!oobe::PathArgument(aArgv[i + 1]))
+            {
+                DIE_NOW(L"Failed to parse path argument");
+            }
+        }
+    }
+
+    return true;
 }
 } // namespace launcher
 

--- a/Code/immersive_launcher/Launcher.cpp
+++ b/Code/immersive_launcher/Launcher.cpp
@@ -66,7 +66,8 @@ void SetMaxstdio()
 int StartUp(int argc, char** argv)
 {
     bool askSelect = (GetAsyncKeyState(VK_SPACE) & 0x8000);
-    HandleArguments(argc, argv, askSelect);
+    if (!HandleArguments(argc, argv, askSelect))
+        return -1;
 
     // TODO(Force): Make some InitSharedResources func.
     g_SharedWindowIcon = LoadIconW(GetModuleHandleW(nullptr), MAKEINTRESOURCEW(102));
@@ -150,12 +151,14 @@ bool HandleArguments(int aArgc, char** aArgv, bool& aAskSelect)
         {
             if (!aArgv[i + 1])
             {
-                DIE_NOW(L"No exe path specified");
+                Die(L"No exe path specified", true);
+                return false;
             }
 
             if (!oobe::PathArgument(aArgv[i + 1]))
             {
-                DIE_NOW(L"Failed to parse path argument");
+                Die(L"Failed to parse path argument", true);
+                return false;
             }
         }
     }

--- a/Code/immersive_launcher/Launcher.cpp
+++ b/Code/immersive_launcher/Launcher.cpp
@@ -149,14 +149,16 @@ bool HandleArguments(int aArgc, char** aArgv, bool& aAskSelect)
             aAskSelect = true;
         else if (std::strcmp(aArgv[i], "--exePath") == 0)
         {
-            if (!aArgv[i + 1])
+            if(i + 1 >= aArgc)
             {
+                SetLastError(ERROR_BAD_PATHNAME);
                 Die(L"No exe path specified", true);
                 return false;
             }
 
             if (!oobe::PathArgument(aArgv[i + 1]))
             {
+                SetLastError(ERROR_BAD_ARGUMENTS);
                 Die(L"Failed to parse path argument", true);
                 return false;
             }

--- a/Code/immersive_launcher/Launcher.cpp
+++ b/Code/immersive_launcher/Launcher.cpp
@@ -149,7 +149,7 @@ bool HandleArguments(int aArgc, char** aArgv, bool& aAskSelect)
             aAskSelect = true;
         else if (std::strcmp(aArgv[i], "--exePath") == 0)
         {
-            if(i + 1 >= aArgc)
+            if (i + 1 >= aArgc)
             {
                 SetLastError(ERROR_BAD_PATHNAME);
                 Die(L"No exe path specified", true);

--- a/Code/immersive_launcher/Launcher.h
+++ b/Code/immersive_launcher/Launcher.h
@@ -30,4 +30,7 @@ bool LoadProgram(LaunchContext&);
 int StartUp(int argc, char** argv);
 
 void InitClient();
+
+bool HandleArguments(int, char**, bool&);
+
 } // namespace launcher

--- a/Code/immersive_launcher/oobe/PathArgument.cpp
+++ b/Code/immersive_launcher/oobe/PathArgument.cpp
@@ -37,6 +37,10 @@ bool ValidatePath(const std::wstring& acPath)
     {
         errorText += acPath.substr(acPath.find_last_of('\\') + 1, acPath.back()) + L" is not an executable file\n";
     }
+    else if (!acPath.ends_with(TARGET_NAME L".exe"))
+    {
+        errorText += TARGET_NAME L".exe not found\n";
+    }
 
     if (!std::filesystem::exists(g_exePath) || !std::filesystem::exists(g_titlePath))
     {

--- a/Code/immersive_launcher/oobe/PathArgument.cpp
+++ b/Code/immersive_launcher/oobe/PathArgument.cpp
@@ -43,7 +43,6 @@ bool ValidatePath(const std::wstring& acPath)
         errorText += TARGET_NAME L".exe not found\n";
     }
 
-
     if (!std::filesystem::exists(acPath) || !std::filesystem::exists(titlePath))
     {
         SetLastError(ERROR_BAD_PATHNAME);

--- a/Code/immersive_launcher/oobe/PathArgument.cpp
+++ b/Code/immersive_launcher/oobe/PathArgument.cpp
@@ -68,8 +68,7 @@ bool PathArgument(const std::string& acPath)
     }
 
     // Write to registry so oobe::SelectInstall can handle the rest
-    bool result = Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitlePath", g_titlePath) && 
-        Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitleExe", g_exePath);
+    bool result = Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitlePath", g_titlePath) && Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitleExe", g_exePath);
 
     if (!result)
     {

--- a/Code/immersive_launcher/oobe/PathArgument.cpp
+++ b/Code/immersive_launcher/oobe/PathArgument.cpp
@@ -30,26 +30,30 @@ bool ValidatePath(const std::wstring& acPath)
 
     if (acPath.find_last_of('\\') == std::string::npos || acPath.ends_with(*"\\"))
     {
+        SetLastError(ERROR_BAD_PATHNAME);
         errorText += L"Invalid path\n";
     }
 
     if (!acPath.ends_with(L".exe"))
     {
+        SetLastError(ERROR_BAD_ARGUMENTS);
         errorText += acPath.substr(acPath.find_last_of('\\') + 1, acPath.back()) + L" is not an executable file\n";
     }
     else if (!acPath.ends_with(TARGET_NAME L".exe"))
     {
+        SetLastError(ERROR_FILE_NOT_FOUND);
         errorText += TARGET_NAME L".exe not found\n";
     }
 
     if (!std::filesystem::exists(g_exePath) || !std::filesystem::exists(g_titlePath))
     {
+        SetLastError(ERROR_BAD_PATHNAME);
         errorText += L"Path does not exist\n";
     }
 
     if (!errorText.empty())
     {
-        errorText += L"Path: " + acPath;
+        errorText += L"\nPath: " + acPath;
         DIE_NOW(errorText.c_str())
     }
 

--- a/Code/immersive_launcher/oobe/PathArgument.cpp
+++ b/Code/immersive_launcher/oobe/PathArgument.cpp
@@ -1,0 +1,77 @@
+﻿#include "PathArgument.h"
+
+#include "TargetConfig.h"
+
+#include "Utils/Error.h"
+#include "utils/Registry.h"
+
+#include <filesystem>
+
+std::wstring g_titlePath;
+std::wstring g_exePath;
+
+namespace oobe
+{
+using namespace TiltedPhoques;
+
+namespace
+{
+constexpr wchar_t kTiltedRegistryPath[] = LR"(Software\TiltedPhoques\TiltedEvolution\)" SHORT_NAME;
+
+#define DIE_NOW(err)    \
+    {                   \
+        Die(err, true); \
+        return false;   \
+    }
+
+bool ValidatePath(const std::wstring& acPath)
+{
+    std::wstring errorText{};
+
+    if (acPath.find_last_of('\\') == std::string::npos || acPath.ends_with(*"\\"))
+    {
+        errorText += L"Invalid path\n";
+    }
+
+    if (!acPath.ends_with(L".exe"))
+    {
+        errorText += acPath.substr(acPath.find_last_of('\\') + 1, acPath.back()) + L" is not an executable file\n";
+    }
+
+    if (!std::filesystem::exists(g_exePath) || !std::filesystem::exists(g_titlePath))
+    {
+        errorText += L"Path does not exist\n";
+    }
+
+    if (!errorText.empty())
+    {
+        errorText += L"Path: " + acPath;
+        DIE_NOW(errorText.c_str())
+    }
+
+    return true;
+}
+} // namespace
+
+bool PathArgument(const std::string& acPath)
+{
+    g_exePath = std::wstring(acPath.begin(), acPath.end());
+    g_titlePath = g_exePath.substr(0, g_exePath.find_last_of('\\'));
+
+    if (!ValidatePath(g_exePath))
+    {
+        DIE_NOW(L"Failed to validate path")
+    }
+
+    // Write to registry so oobe::SelectInstall can handle the rest
+    bool result = Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitlePath", g_titlePath) && 
+        Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitleExe", g_exePath);
+
+    if (!result)
+    {
+        DIE_NOW(L"Failed to write to registry")
+    }
+
+    return true;
+}
+} // namespace oobe

--- a/Code/immersive_launcher/oobe/PathArgument.cpp
+++ b/Code/immersive_launcher/oobe/PathArgument.cpp
@@ -23,7 +23,7 @@ constexpr wchar_t kTiltedRegistryPath[] = LR"(Software\TiltedPhoques\TiltedEvolu
 
 bool ValidatePath(const std::wstring& acPath)
 {
-    const std::wstring titlePath = acPath.substr(0, acPath.find_last_of('\\'));
+    const std::wstring cTitlePath = acPath.substr(0, acPath.find_last_of('\\'));
     std::wstring errorText{};
 
     if (acPath.find_last_of('\\') == std::string::npos || acPath.ends_with(*"\\"))
@@ -43,7 +43,7 @@ bool ValidatePath(const std::wstring& acPath)
         errorText += TARGET_NAME L".exe not found\n";
     }
 
-    if (!std::filesystem::exists(acPath) || !std::filesystem::exists(titlePath))
+    if (!std::filesystem::exists(acPath) || !std::filesystem::exists(cTitlePath))
     {
         SetLastError(ERROR_BAD_PATHNAME);
         errorText += L"Path does not exist\n";
@@ -61,16 +61,16 @@ bool ValidatePath(const std::wstring& acPath)
 
 bool PathArgument(const std::string& acPath)
 {
-    const std::wstring exePath = std::wstring(acPath.begin(), acPath.end());
-    const std::wstring titlePath = exePath.substr(0, exePath.find_last_of('\\'));
+    const std::wstring cExePath = std::wstring(acPath.begin(), acPath.end());
+    const std::wstring cTitlePath = cExePath.substr(0, cExePath.find_last_of('\\'));
 
-    if (!ValidatePath(exePath))
+    if (!ValidatePath(cExePath))
     {
         DIE_NOW(L"Failed to validate path")
     }
 
     // Write to registry so oobe::SelectInstall can handle the rest
-    const bool result = Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitlePath", titlePath) && Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitleExe", exePath);
+    const bool result = Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitlePath", cTitlePath) && Registry::WriteString<wchar_t>(HKEY_CURRENT_USER, kTiltedRegistryPath, L"TitleExe", cExePath);
 
     if (!result)
     {

--- a/Code/immersive_launcher/oobe/PathArgument.h
+++ b/Code/immersive_launcher/oobe/PathArgument.h
@@ -1,0 +1,8 @@
+﻿#pragma once
+
+#include <string>
+
+namespace oobe
+{
+bool PathArgument(const std::string& acPath);
+}


### PR DESCRIPTION
Adds the game exe portion of https://github.com/tiltedphoques/TiltedEvolution/issues/627
I am not sure how SKSE wouldn't be loaded if it is installed correctly so I will leave that for a different PR if it is necessary.

ex. 
`SkyrimTogether.exe --exePath C:\Path\To\Game\SkyrimSE.exe`
or
`SkyrimTogether.exe --exePath "C:\Path\With a space\SkyrimSE.exe"`