### PR TITLE
Fix: bring back missing 'release' mode to the build config

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -23,7 +23,7 @@ add_vectorexts("sse", "sse2", "sse3", "ssse3")
 add_vectorexts("neon")
 
 -- build configurations
-add_rules("mode.debug", "mode.releasedbg")
+add_rules("mode.debug", "mode.releasedbg", "mode.release")
 
 if has_config("unitybuild") then
     add_rules("c.unity_build")


### PR DESCRIPTION
Previous commit that changed this line: https://github.com/tiltedphoques/TiltedEvolution/commit/a94f7168666b831a6b0447121307453fc23a05a8#diff-1e65723e47b81d67c25a98980a10861a012068422521d2331e559e547a4e79ccL11

Release .exe now builds just fine and the size is smaller