### PR TITLE
Fix cell-change crash caused by use-after-free of BGSAttackDataMap

### DIFF
--- a/Code/client/Games/Skyrim/Components/BGSAttackDataForm.h
+++ b/Code/client/Games/Skyrim/Components/BGSAttackDataForm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Components/BaseFormComponent.h>
+#include <Games/Skyrim/NetImmerse/NiPointer.h>
 
 struct BGSAttackDataMap : NiRefObject
 {
@@ -8,5 +9,5 @@ struct BGSAttackDataMap : NiRefObject
 
 struct BGSAttackDataForm : BaseFormComponent
 {
-    BGSAttackDataMap* attackDataMap;
+    NiPointer<BGSAttackDataMap> attackDataMap;
 };


### PR DESCRIPTION
Assigned here during `TESNPC::Initialize()`
https://github.com/tiltedphoques/TiltedEvolution/blob/20b44d3ca2b1a65b601cd1534ac745eebe9bd859/Code/client/Games/Forms.cpp#L55-L71

^ Notice how `attackDataMap` is taken from the PlayerCharacter singleton and assigned to a remote player's TESNPC. When that TESNPC unloads, the game (supposedly) tries to deallocate its resources, including this map

Changed raw pointer to a `NiPointer` which uses refcount, saving us from the crash

Partially addresses #723 (0x140443C43 crash site)