### PR TITLE
Fix cell-change crash from SetActorInventory() calling s_unequipAll followed by s_removeAllItems

### DIFF
--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -395,7 +395,9 @@ void Actor::SetActorInventory(const Inventory& aInventory) noexcept
 {
     spdlog::info("Setting inventory for actor {:X}", formID);
 
-    UnEquipAll();
+    // The UnEquipAll() that used to be here is redundant,
+    // as RemoveAllItems() unequips every item if needed.
+    // Placing this UnEquipAll() here seems to trigger a Skyrim bug/race.
 
     SetInventory(aInventory);
     SetMagicEquipment(aInventory.CurrentMagicEquipment);

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -512,27 +512,9 @@ void CharacterService::OnRemoteSpawnDataReceived(const NotifySpawnData& acMessag
     if (!pActor)
         return;
 
-    // Only accept spawn position and inventory updates if not for local player
-    // The remote system is simply not authoritative for this info, and trying
-    // to take it from the remote can result in concurrent update corruption
-    // That's the real problem, either s_pRemoveAllItems or s_unequipAll
-    // have async behavior themselves or undocumented behavior that
-    // causes concurrency issues.
-    if (pActor->GetExtension()->IsPlayer() && !pActor->GetExtension()->IsRemote())
-    {
-#if TP_SKYRIM64
-        auto pNpc = Cast<TESNPC>(pActor);
-        auto pName = pNpc ? static_cast<const char*>(pNpc->fullName.value) : "";
-        spdlog::warn(__FUNCTION__ ": rejecting non-authoritative remote spawn update for local player pActor{:X}, formID{:X}, name \"{}\"",
-                     (uintptr_t)pActor, pActor->formID, pName);
-#endif
-    }
-    else
-    {
-        pActor->SetActorValues(acMessage.NewActorData.InitialActorValues);
-        pActor->SetActorInventory(acMessage.NewActorData.InitialInventory);
-        m_weaponDrawUpdates[pActor->formID] = {acMessage.NewActorData.IsWeaponDrawn};
-    }
+    pActor->SetActorValues(acMessage.NewActorData.InitialActorValues);
+    pActor->SetActorInventory(acMessage.NewActorData.InitialInventory);
+    m_weaponDrawUpdates[pActor->formID] = {acMessage.NewActorData.IsWeaponDrawn};
 
     if (pActor->IsDead() != acMessage.NewActorData.IsDead)
         acMessage.NewActorData.IsDead ? pActor->Kill() : pActor->Respawn();

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -512,13 +512,18 @@ void CharacterService::OnRemoteSpawnDataReceived(const NotifySpawnData& acMessag
     if (!pActor)
         return;
 
-    // Only accept spawn position and inventory updates if not for local player
-    // The remote system is simply not authoritative for this info, and trying
-    // to take it from the remote can result in concurrent update corruption
-    // That's the real problem, either s_pRemoveAllItems or s_unequipAll
-    // have async behavior themselves or undocumented behavior that
+    // Only accept spawn position and inventory updates for REMOTE Npcs.
+    // The remote system is simply not authoritative for local Npc info, and trying 
+    // to take it from the remote can result in concurrent update corruption. 
+    // This is true whether it is a local Player (and therefor remote from the
+    // Leader), or a local NPC that is with their leader or is owned instead by 
+    // the local player and their own data, possibly out-of-date, is looping
+    // back in OnRemoteSpawnDataReceived
+    // 
+    // The underlying problem, either s_pRemoveAllItems or s_unequipAll 
+    // have async behavior themselves or undocumented behavior that 
     // causes concurrency issues.
-    if (pActor->GetExtension()->IsPlayer() && !pActor->GetExtension()->IsRemote())
+    if (!pActor->GetExtension()->IsRemote())
     {
 #if TP_SKYRIM64
         auto pNpc = Cast<TESNPC>(pActor);

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -512,9 +512,27 @@ void CharacterService::OnRemoteSpawnDataReceived(const NotifySpawnData& acMessag
     if (!pActor)
         return;
 
-    pActor->SetActorValues(acMessage.NewActorData.InitialActorValues);
-    pActor->SetActorInventory(acMessage.NewActorData.InitialInventory);
-    m_weaponDrawUpdates[pActor->formID] = {acMessage.NewActorData.IsWeaponDrawn};
+    // Only accept spawn position and inventory updates if not for local player
+    // The remote system is simply not authoritative for this info, and trying
+    // to take it from the remote can result in concurrent update corruption
+    // That's the real problem, either s_pRemoveAllItems or s_unequipAll
+    // have async behavior themselves or undocumented behavior that
+    // causes concurrency issues.
+    if (pActor->GetExtension()->IsPlayer() && !pActor->GetExtension()->IsRemote())
+    {
+#if TP_SKYRIM64
+        auto pNpc = Cast<TESNPC>(pActor);
+        auto pName = pNpc ? static_cast<const char*>(pNpc->fullName.value) : "";
+        spdlog::warn(__FUNCTION__ ": rejecting non-authoritative remote spawn update for local player pActor{:X}, formID{:X}, name \"{}\"",
+                     (uintptr_t)pActor, pActor->formID, pName);
+#endif
+    }
+    else
+    {
+        pActor->SetActorValues(acMessage.NewActorData.InitialActorValues);
+        pActor->SetActorInventory(acMessage.NewActorData.InitialInventory);
+        m_weaponDrawUpdates[pActor->formID] = {acMessage.NewActorData.IsWeaponDrawn};
+    }
 
     if (pActor->IsDead() != acMessage.NewActorData.IsDead)
         acMessage.NewActorData.IsDead ? pActor->Kill() : pActor->Respawn();

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -512,18 +512,13 @@ void CharacterService::OnRemoteSpawnDataReceived(const NotifySpawnData& acMessag
     if (!pActor)
         return;
 
-    // Only accept spawn position and inventory updates for REMOTE Npcs.
-    // The remote system is simply not authoritative for local Npc info, and trying 
-    // to take it from the remote can result in concurrent update corruption. 
-    // This is true whether it is a local Player (and therefor remote from the
-    // Leader), or a local NPC that is with their leader or is owned instead by 
-    // the local player and their own data, possibly out-of-date, is looping
-    // back in OnRemoteSpawnDataReceived
-    // 
-    // The underlying problem, either s_pRemoveAllItems or s_unequipAll 
-    // have async behavior themselves or undocumented behavior that 
+    // Only accept spawn position and inventory updates if not for local player
+    // The remote system is simply not authoritative for this info, and trying
+    // to take it from the remote can result in concurrent update corruption
+    // That's the real problem, either s_pRemoveAllItems or s_unequipAll
+    // have async behavior themselves or undocumented behavior that
     // causes concurrency issues.
-    if (!pActor->GetExtension()->IsRemote())
+    if (pActor->GetExtension()->IsPlayer() && !pActor->GetExtension()->IsRemote())
     {
 #if TP_SKYRIM64
         auto pNpc = Cast<TESNPC>(pActor);


### PR DESCRIPTION
This fixes a cell change crash provoked by bugs in Actor::SetActorInventory(), but really a bug in the downcall to EquipManager::UnequipAll() which invokes skyrim-native TUnequipAll.

SetActorInventory() effectively calls UnequipAll(), RemoveAllItems(), then sets the new inventory with AddRemoveItem(). But the RemoveAllItems() script _also_ Unequips() each item, which seems to trigger a bug because the UnequipAll is still animating unequips. 

First fix is comment out the unequipall.

Second fix is remove as many SetActorInventory() calls as possible. In particular, when you set the inventory on a local Actor, you don't also have to set it again when the change reflects back to you in OnRemoteSpawnDataReceived(). That's just a more elaborate way of provoking overlapping Unequips (basically, back-to-back RemoveAllItems())

Partially addresses https://github.com/tiltedphoques/TiltedEvolution/issues/723 (0x140443C43 crash site)