### PR TITLE
Better logging for debugging distributed multithreaded apps.

### DIFF
--- a/Code/client/TiltedOnlineApp.cpp
+++ b/Code/client/TiltedOnlineApp.cpp
@@ -35,7 +35,7 @@ TiltedOnlineApp::TiltedOnlineApp()
     auto rotatingLogger = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logPath / "tp_client.log", 1048576 * 5, 3);
     // rotatingLogger->set_level(spdlog::level::debug);
     auto console = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    console->set_pattern("%^[%H:%M:%S] [%l]%$ %v");
+    console->set_pattern("%^[%H:%M:%S.%e] [%l] [tid %t] %$ %v");
 
     auto logger = std::make_shared<spdlog::logger>("", spdlog::sinks_init_list{console, rotatingLogger});
     set_default_logger(logger);

--- a/Code/server_runner/main.cpp
+++ b/Code/server_runner/main.cpp
@@ -73,7 +73,7 @@ struct LogInstance
 
         auto fileOut = std::make_shared<sinks::rotating_file_sink_mt>(std::string("logs/") + kLogFileName, kLogFileSizeCap, 3);
         auto serverOut = std::make_shared<sinks::stdout_color_sink_mt>();
-        serverOut->set_pattern("%^[%H:%M:%S] [%l]%$ %v");
+        serverOut->set_pattern("%^[%H:%M:%S.%e] [%l] [tid %t] %$ %v");
         auto globalOut = std::make_shared<logger>("", sinks_init_list{serverOut, fileOut});
         globalOut->set_level(level::from_str(sLogLevel.value()));
 


### PR DESCRIPTION
Change spdlog::set_pattern() to provide more useful logs/tracing for distributed, multithread debugging. 

Adds milliseconds and thread IDs to the logs. 

If you do single-system, multi-clients and server all on the same system, you could actually send all logs to one file and they will be interleaved correctly (mostly). Thread IDs might collide, but not on the same system.