### PR TITLE
Change `D3D11CreateDevice` invocation in NvidiaUtil to a dynamic one

### DIFF
--- a/Code/client/NvidiaUtil.cpp
+++ b/Code/client/NvidiaUtil.cpp
@@ -7,10 +7,19 @@ bool IsNvidiaOverlayLoaded()
 }
 
 // This makes the Nvidia overlay happy.
-// The call to D3D11CreateDevice probably causes some of their
+// The call to `D3D11CreateDevice` probably causes some of their
 // internal hooks to be called and do the required init work before the game window opens.
-HRESULT CreateEarlyDxDevice(ID3D11Device* apOutDevice, D3D_FEATURE_LEVEL* apOutFeatureLevel)
+//
+// We do dynamic invocation in order not to link `d3d11.dll` at compile-time
+HRESULT CreateEarlyDxDevice(ID3D11Device** appOutDevice, D3D_FEATURE_LEVEL* apOutFeatureLevel)
 {
-    return D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, nullptr, 0, D3D11_SDK_VERSION, &apOutDevice,
-                             apOutFeatureLevel, nullptr);
+    HMODULE d3d11Module = GetModuleHandleW(L"d3d11.dll");
+    if (!d3d11Module)
+        return E_FAIL;
+
+    const auto pD3D11CreateDeviceFn =
+        reinterpret_cast<decltype(&D3D11CreateDevice)>(GetProcAddress(d3d11Module, "D3D11CreateDevice"));
+
+    return pD3D11CreateDeviceFn(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, nullptr, 0, D3D11_SDK_VERSION,
+                                appOutDevice, apOutFeatureLevel, nullptr);
 }

--- a/Code/client/NvidiaUtil.h
+++ b/Code/client/NvidiaUtil.h
@@ -5,4 +5,4 @@
 
 bool IsNvidiaOverlayLoaded();
 
-HRESULT CreateEarlyDxDevice(ID3D11Device* apOutDevice, D3D_FEATURE_LEVEL* apOutFeatureLevel);
+HRESULT CreateEarlyDxDevice(ID3D11Device** appOutDevice, D3D_FEATURE_LEVEL* apOutFeatureLevel);

--- a/Code/client/TiltedOnlineApp.cpp
+++ b/Code/client/TiltedOnlineApp.cpp
@@ -59,6 +59,7 @@ bool TiltedOnlineApp::BeginMain()
 
     LoadScriptExender();
 
+    // TODO: Figure out a way to un-blacklist NvCamera64.dll (see DllBlocklist.cpp). Then this hack can be removed
     if (IsNvidiaOverlayLoaded())
         ApplyNvidiaFix();
 
@@ -118,11 +119,11 @@ void TiltedOnlineApp::UninstallHooks()
 
 void TiltedOnlineApp::ApplyNvidiaFix() noexcept
 {
-    auto d3dFeatureLevel = D3D_FEATURE_LEVEL_11_0;
-    HRESULT hr = CreateEarlyDxDevice(m_pDevice, &d3dFeatureLevel);
+    auto d3dFeatureLevelOut = D3D_FEATURE_LEVEL_11_0;
+    HRESULT hr = CreateEarlyDxDevice(&m_pDevice, &d3dFeatureLevelOut);
     if (FAILED(hr))
         spdlog::error("D3D11CreateDevice failed. Detected an NVIDIA GPU, error code={0:x}", hr);
 
-    if (d3dFeatureLevel < D3D_FEATURE_LEVEL_11_0)
+    if (d3dFeatureLevelOut < D3D_FEATURE_LEVEL_11_0)
         spdlog::warn("Unexpected D3D11 feature level detected (< 11.0), may cause issues");
 }


### PR DESCRIPTION
Black screen fix still applies. Dynamic invocation is needed in order not to link `d3d11.dll` at compile-time (compile-time linking breaks ENB and other mods that use d3d11.dll as a proxy)