### PR TITLE
CI update: correct artifact versioning, tags trigger, xmake deps caching

### DIFF
--- a/.github/workflows/windows-playable-build.yml
+++ b/.github/workflows/windows-playable-build.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
@@ -30,11 +32,19 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --force --recursive --depth=1
 
+      - name: Cache xmake dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/AppData/Local/.xmake/packages
+          key: ${{ runner.os }}-xmake-${{ hashFiles('**/xmake.lua') }}
+
       # Install xmake
       - name: Setup xmake
         uses: xmake-io/github-action-setup-xmake@v1
         with:
           xmake-version: 2.9.5
+          actions-cache-folder: '.xmake-cache' # This doesn't cache dependencies, only xmake itself
+          actions-cache-key: ${{ matrix.os }}
 
       - name: Configure xmake and install dependencies
         run: xmake config --arch=${{ matrix.arch }} --mode=${{ matrix.mode }} --yes -vD
@@ -80,11 +90,11 @@ jobs:
 
       # Upload artifact
 
-      - name: Store short commit hash
-        run: echo "SHORT_SHA=$("${{ github.sha }}".SubString(0, 8))" >> $env:GITHUB_ENV
+      - name: Store version string
+        run: echo "STR_VERSION=$(git describe --tags)" >> $env:GITHUB_ENV
 
       - name: Upload playable build
         uses: actions/upload-artifact@v4
         with:
-          name: Skyrim Together Build (${{ env.SHORT_SHA }})
+          name: Skyrim Together Build (${{ env.STR_VERSION }})
           path: str-build/


### PR DESCRIPTION
- Added trigger on a tag push (that I completely forgot about in the previous PR)
- Artifact's version string now matches the one in `BuildInfo.h` and in-game
- Attempt at xmake deps caching

@maximegmd @RobbeBryssinck during my research on xmake caching I saw that `actions/cache` didn't stay for long in your repos (including both TiltedEvolution and CyberEngineTweaks) and eventually was commented out/removed. Why? Any pitfalls I'm not aware of?