### PR TITLE
Fix UI state when focusing window with UI visible

### DIFF
--- a/Code/client/Services/Generic/InputService.cpp
+++ b/Code/client/Services/Generic/InputService.cpp
@@ -400,6 +400,14 @@ LRESULT CALLBACK InputService::WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPAR
         }
         ProcessKeyboard(virtualKey, scancode, KEYEVENT_CHAR, false, false);
     }
+    // If the player tabs out/in with UI visible, this WndProc doesn't run during mouse or keyboard events.
+    // When player tabs in, force the UI state
+    else if (uMsg == WM_SETFOCUS && s_pOverlay->GetActive())
+    {
+        TiltedPhoques::DInputHook::Get().SetEnabled(true);
+        s_pOverlay->SetActive(true);
+        pRenderer->SetCursorVisible(true);
+    }
     else if (uMsg == WM_INPUTLANGCHANGE)
     {
         s_currentACP = GetRealACP();


### PR DESCRIPTION
Currently, when focusing the window (aka tabbing in) with the UI visible you cannot interact with the UI and must close/reopen to interact with it.
This PR forces the UI state when the WM_SETFOCUS message is sent to InputService to fix the above.