### PR TITLE
CI: added conditional step to checkout master on tag push

### DIFF
--- a/.github/workflows/windows-playable-build.yml
+++ b/.github/workflows/windows-playable-build.yml
@@ -32,6 +32,11 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --force --recursive --depth=1
 
+      - name: Checkout master on tag push
+        if: github.ref_type == 'tag'
+        # Checkout only if the tag was pushed to master
+        run: (git rev-parse HEAD) -eq (git rev-parse origin/master) -and (git checkout master)
+
       - name: Cache xmake dependencies
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
By default, github actions checkout tags in a "detached HEAD" state, thus the extra step. Now the CI will build `master@v1.x.x` and not a `HEAD@v1.x.x` build on tag push