### PR TITLE
Windows 11 24H2 changed some low-level call hierarchies.

### DIFF
--- a/Code/immersive_launcher/TargetConfig.h
+++ b/Code/immersive_launcher/TargetConfig.h
@@ -25,6 +25,7 @@ static constexpr TargetConfig CurrentTarget{
     L"Skyrim Special Edition", 
     489830, 0x40000000, 35410264};
 #define TARGET_NAME L"SkyrimSE"
+#define TARGET_NAME_A "SkyrimSE"
 #define PRODUCT_NAME L"Skyrim Together"
 #define SHORT_NAME L"Skyrim Special Edition"
 


### PR DESCRIPTION
This is a compatibility change, works on 23H2 and 24H2. Since in 24H2 GetModuleHandle no longer down-calls to LdrGetDllHandleEx, have to hook the GetModuleHandle() routines also.