### PR TITLE
Fix missing weapon equip animation

### DIFF
--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -19,6 +19,7 @@ struct ActorExtension
     void SetPlayer(bool aSet) noexcept;
 
     ActionEvent LatestAnimation{};
+    ActionEvent LatestWeapEquipAnimation{};
     size_t GraphDescriptorHash = 0;
 
   private:

--- a/Code/client/Games/Animation.cpp
+++ b/Code/client/Games/Animation.cpp
@@ -52,7 +52,12 @@ uint8_t TP_MAKE_THISCALL(HookPerformAction, ActorMediator, TESActionData* apActi
 
         // Save for later
         if (res)
+        {
             pExtension->LatestAnimation = action;
+            
+            if(apAction->action->formID == 0x132AF)
+                pExtension->LatestWeapEquipAnimation = action;
+        }
 
         World::Get().GetRunner().Trigger(action);
 

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -323,9 +323,15 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         spdlog::info("Received local actor, form id: {:X}", pActor->formID);
 
         m_world.emplace_or_replace<LocalComponent>(cEntity, acMessage.ServerId);
-        m_world.emplace_or_replace<LocalAnimationComponent>(cEntity);
+        auto& localAnimationComponent = m_world.emplace_or_replace<LocalAnimationComponent>(cEntity);
 
         pActor->GetExtension()->SetRemote(false);
+
+        if(pActor->GetExtension()->LatestWeapEquipAnimation.ActionId != 0)
+        {
+            localAnimationComponent.Append(pActor->GetExtension()->LatestWeapEquipAnimation);
+            pActor->GetExtension()->LatestWeapEquipAnimation = ActionEvent();
+        }
     }
     else
     {


### PR DESCRIPTION
This Pull Request addresses an issue where summoned creatures, such as Daedric Princes, were missing their local weapon equip animations upon summoning during combat. 