### PR TITLE
Revert force bUseFaceGenPreprocessedHeads = false

### DIFF
--- a/Code/client/TiltedOnlineApp.cpp
+++ b/Code/client/TiltedOnlineApp.cpp
@@ -76,11 +76,17 @@ bool TiltedOnlineApp::EndMain()
 
 void TiltedOnlineApp::Update()
 {
-    // Every frame make sure we won't use preprocessed facegen
-    POINTER_SKYRIMSE(uint32_t, bUseFaceGenPreprocessedHeads, 378620);
-
-    *bUseFaceGenPreprocessedHeads = 0;
-
+    // Reverting a change that used to be here to disable bUseFaceGenPreprocessedHeads==true (which is 
+    // the default) handling. Extensive testing over months by multiple parties showed that enabling 
+    // the flag introduces no issues WITH PROPERLY GENERATED CHARACTERS (in-game character generation 
+    // or showracemenu). The shortcut of  "coc riverwood" from the main menu skips proper character generation.
+    // 
+    // Plus, having it on  has some benefits like helping with neck seams. Comment to avoid revisiting.
+    // 
+    // There are still some issues to track down, like hair color and maybe face tint not syncing correctly,
+    // but they are unrelated and unchanged by this flag.
+    // 
+ 
     // Make sure the window stays active
     POINTER_SKYRIMSE(uint32_t, bAlwaysActive, 380768);
 


### PR DESCRIPTION
Closes #92
Closes #448 

Testing assists by @absol89, @miredirex, Vende. None of us have seen any issues, and it fixes things like neck seams and black faces. 

More technical version:

Reverting a change that forced bUseFaceGenPreprocessedHeads=false (the Skyrim default is true). Extensive testing over months by multiple parties showed that enabling the flag introduces no issues _with properly generated characters_ (in-game character generation or showracemenu). The popular testing shortcut of  "coc riverwood" from the main menu skips proper character generation.

Plus, having the flag on has some benefits like helping with neck seams.

The original behavior of the flag is restored, so if any issues do crop up it can be disabled in the [General] section of Skyrimprefs.ini.

~~There are still some issues to track down, like hair color and maybe face tint not syncing correctly, but they are unrelated and unchanged by this flag.~~ That turns out to not be an issue. Where it was observed, it was caused by deleting mods which caused the color "preset" to be come a "custom color." Custom colors do not sync.
