### PR TITLE
Support Quest Item Synchronization and Party Member Progression

### DIFF
--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -674,7 +674,7 @@ int32_t Actor::GetGoldAmount() const noexcept
     return TiltedPhoques::ThisCall(s_getGoldAmount, this);
 }
 
-void Actor::SetActorInventory(const Inventory& aInventory) noexcept
+void Actor::SetActorInventory(const Inventory& acInventory) noexcept
 {
     spdlog::info("Setting inventory for actor {:X}", formID);
 
@@ -682,8 +682,27 @@ void Actor::SetActorInventory(const Inventory& aInventory) noexcept
     // as RemoveAllItems() unequips every item if needed.
     // Placing this UnEquipAll() here seems to trigger a Skyrim bug/race.
 
-    SetInventory(aInventory);
-    SetMagicEquipment(aInventory.CurrentMagicEquipment);
+    Inventory currentInventory = GetActorInventory();
+    bool isQuestNpc = false;
+
+    if (!this->GetExtension()->IsPlayer())
+    {
+        for (const auto& entry : currentInventory.Entries)
+        {
+            if (entry.IsQuestItem)
+            {
+                isQuestNpc = true;
+                break;
+            }
+        }
+    }
+
+    if (isQuestNpc)
+        SetInitQuestInventory(currentInventory, acInventory);
+    else
+        SetInventory(acInventory);
+
+    SetMagicEquipment(acInventory.CurrentMagicEquipment);
 }
 
 void Actor::SetMagicEquipment(const MagicEquipment& acEquipment) noexcept

--- a/Code/client/Games/Skyrim/TESObjectREFR.cpp
+++ b/Code/client/Games/Skyrim/TESObjectREFR.cpp
@@ -781,6 +781,56 @@ void TESObjectREFR::SetInventory(const Inventory& aInventory) noexcept
     }
 }
 
+Vector<uint32_t> TESObjectREFR::RemoveNoQuestItems(Inventory& aCurrentInventory) noexcept
+{
+    ScopedEquipOverride equipOverride_;
+
+    Vector<uint32_t> questEntries{};
+
+    auto& modSystem = World::Get().GetModSystem();
+
+    for (auto& entry : aCurrentInventory.Entries)
+    {
+        if (entry.IsQuestItem)
+        {
+            uint32_t gameId = modSystem.GetGameId(entry.BaseId);
+            questEntries.emplace_back(gameId);
+            continue;
+        }
+
+        if (entry.Count <= 0)
+            continue;
+
+        entry.Count = -entry.Count;
+        AddOrRemoveItem(entry, true);
+    }
+
+    return questEntries;
+}
+
+void TESObjectREFR::SetInitQuestInventory(Inventory& aCurrentInventory, const Inventory& acSourceInventory) noexcept
+{
+    spdlog::debug("Setting inventory for {:X}", formID);
+
+    ScopedInventoryOverride _;
+
+    // Remove all non-quest items first
+    Vector<uint32_t> nonQuestItemIds = RemoveNoQuestItems(aCurrentInventory);
+    auto& modSystem = World::Get().GetModSystem();
+
+    for (const auto& entry : acSourceInventory.Entries)
+    {
+        uint32_t gameId = modSystem.GetGameId(entry.BaseId);
+
+        // If the item is not in the list of quest items, add it
+        if (std::find(nonQuestItemIds.begin(), nonQuestItemIds.end(), gameId) == nonQuestItemIds.end())
+        {
+            if (entry.Count != 0)
+                AddOrRemoveItem(entry, true);
+        }
+    }
+}
+
 void TESObjectREFR::AddOrRemoveItem(const Inventory::Entry& arEntry, bool aIsSettingInventory) noexcept
 {
     ModSystem& modSystem = World::Get().GetModSystem();

--- a/Code/client/Games/Skyrim/TESObjectREFR.h
+++ b/Code/client/Games/Skyrim/TESObjectREFR.h
@@ -179,6 +179,7 @@ struct TESObjectREFR : TESForm
     uint32_t GetAnimationVariableInt(BSFixedString* apVariableName) noexcept;
 
     void RemoveAllItems() noexcept;
+    Vector<uint32_t> RemoveNoQuestItems(Inventory& aCurrentInventory) noexcept;
     void Delete() const noexcept;
     void Disable() const noexcept;
     void Enable() const noexcept;
@@ -207,6 +208,7 @@ struct TESObjectREFR : TESForm
     bool IsItemInInventory(uint32_t aFormID) const noexcept;
 
     void SetInventory(const Inventory& acContainer) noexcept;
+    void SetInitQuestInventory(Inventory& aCurrentInventory, const Inventory& acSourceInventory) noexcept;
     void AddOrRemoveItem(const Inventory::Entry& arEntry, bool aIsSettingInventory = false) noexcept;
     void UpdateItemList(TESForm* pUnkForm) noexcept;
 

--- a/Code/client/Services/Generic/ObjectService.cpp
+++ b/Code/client/Services/Generic/ObjectService.cpp
@@ -185,7 +185,24 @@ void ObjectService::OnAssignObjectsResponse(const AssignObjectsResponse& acMessa
         }
 
         if (pObject->baseForm->formType == FormType::Container)
-            pObject->SetInventory(objectData.CurrentInventory);
+        {
+            Inventory currentInventory = pObject->GetInventory();
+            bool isQuestObjectFound = false;
+
+            for (const auto& entry : currentInventory.Entries)
+            {
+                if (entry.IsQuestItem)
+                {
+                    isQuestObjectFound = true;
+                    break;
+                }
+            }
+
+            if (isQuestObjectFound)
+                pObject->SetInitQuestInventory(currentInventory, objectData.CurrentInventory);
+            else
+                pObject->SetInventory(objectData.CurrentInventory);
+        }
     }
 }
 

--- a/Code/client/Services/Generic/PlayerService.cpp
+++ b/Code/client/Services/Generic/PlayerService.cpp
@@ -153,7 +153,7 @@ void PlayerService::OnPlayerDialogueEvent(const PlayerDialogueEvent& acEvent) co
         return;
 
     const auto& partyService = m_world.GetPartyService();
-    if (!partyService.IsInParty() || !partyService.IsLeader())
+    if (!partyService.IsInParty())
         return;
 
     PlayerDialogueRequest request{};

--- a/Code/client/Services/Generic/QuestService.cpp
+++ b/Code/client/Services/Generic/QuestService.cpp
@@ -54,7 +54,7 @@ void QuestService::OnConnected(const ConnectedEvent&) noexcept
 
 BSTEventResult QuestService::OnEvent(const TESQuestStartStopEvent* apEvent, const EventDispatcher<TESQuestStartStopEvent>*)
 {
-    if (ScopedQuestOverride::IsOverriden() || !m_world.Get().GetPartyService().IsLeader())
+    if (ScopedQuestOverride::IsOverriden() || !m_world.Get().GetPartyService().IsInParty())
         return BSTEventResult::kOk;
 
     spdlog::info("Quest start/stop event: {:X}", apEvent->formId);
@@ -86,7 +86,7 @@ BSTEventResult QuestService::OnEvent(const TESQuestStartStopEvent* apEvent, cons
 
 BSTEventResult QuestService::OnEvent(const TESQuestStageEvent* apEvent, const EventDispatcher<TESQuestStageEvent>*)
 {
-    if (ScopedQuestOverride::IsOverriden() || !m_world.Get().GetPartyService().IsLeader())
+    if (ScopedQuestOverride::IsOverriden() || !m_world.Get().GetPartyService().IsInParty())
         return BSTEventResult::kOk;
 
     spdlog::info("Quest stage event: {:X}, stage: {}", apEvent->formId, apEvent->stageId);


### PR DESCRIPTION
**1. Quest Item Synchronization:**
Fixed an issue where quest items were incorrectly removed from inventories.
Ensured quest items are identified via IsQuestItem and properly retained and synchronized across relevant actor inventories.
**2. Party Member Quest Progression Support:**
Implemented functionality allowing party members to accept quests by interacting with NPCs.
Enabled party members to obtain quest items and use them to advance quest progress.