### PR TITLE
Fix Incorrect Dragon Soul Absorption Prompt and Potential Absorption Bug

### DIFF
--- a/Code/client/Services/Generic/ActorValueService.cpp
+++ b/Code/client/Services/Generic/ActorValueService.cpp
@@ -124,8 +124,13 @@ void ActorValueService::BroadcastActorValues() noexcept
         RequestActorMaxValueChanges requestMaxValueChanges;
         requestMaxValueChanges.Id = localComponent.Id;
 
+        bool isPlayer = pActor->GetExtension() && pActor->GetExtension()->IsPlayer();
+
         for (int i = 0; i < ActorValueInfo::kActorValueCount; i++)
         {
+            if (isPlayer && i == ActorValueInfo::kDragonSouls)
+                continue;
+            
             float newValue = pActor->GetActorValue(i);
             float oldValue = actorValuesComponent.CurrentActorValues.ActorValuesList[i];
             if (newValue != oldValue)


### PR DESCRIPTION
By disabling the synchronization of dragon soul counts between players, this PR resolves incorrect absorption prompts and the bug preventing players from absorbing dragon souls.