### PR TITLE
CI: bump xmake version, disable cron runs in forks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup xmake
       uses: xmake-io/github-action-setup-xmake@v1
       with:
-        xmake-version: '2.9.5'
+        xmake-version: '2.9.8'
 
     # Update xmake repository (in order to have the file that will be cached)
     - name: Update xmake repository

--- a/.github/workflows/windows-playable-build.yml
+++ b/.github/workflows/windows-playable-build.yml
@@ -19,6 +19,8 @@ jobs:
         arch: [x64]
         mode: [release]
 
+    if: ${{ github.repository_owner == 'tiltedphoques' || github.event_name != 'schedule' }} # Disable cron runs in forks
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -47,7 +49,7 @@ jobs:
       - name: Setup xmake
         uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: 2.9.5
+          xmake-version: 2.9.8
           actions-cache-folder: '.xmake-cache' # This doesn't cache dependencies, only xmake itself
           actions-cache-key: ${{ matrix.os }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup xmake
       uses: xmake-io/github-action-setup-xmake@v1
       with:
-        xmake-version: '2.9.5'
+        xmake-version: '2.9.8'
 
     # Install node
     #- name: Setup nodejs


### PR DESCRIPTION
Builds started failing on 2.9.5, sol2 wouldn't compile - likely related to https://github.com/xmake-io/xmake-repo/pull/6251. Also disabled scheduled runs in forks (sorry for the emails :sdwut:)