### PR TITLE
Fixed French Typo

### DIFF
--- a/Code/skyrim_ui/src/assets/i18n/fr.json
+++ b/Code/skyrim_ui/src/assets/i18n/fr.json
@@ -105,7 +105,7 @@
     },
     "SETTINGS": {
       "AUDIO": "Audio",
-      "MUTE_UI": "Intéface silencieuse",
+      "MUTE_UI": "Interface silencieuse",
       "UI_VOLUME": "Volume de l'interface",
       "PARTY": "Groupe",
       "SHOW_PARTY": "Afficher le groupe",


### PR DESCRIPTION
Interface is spelled the same in French, not sure how the "é" and the missing "r" happened there, as it's spelled correctly on the line right under.