### PR TITLE
Guard against BGSKeywordForm::Contains() bug, which returns true when there are zero keywords

### DIFF
--- a/Code/client/Games/Skyrim/Forms/MagicItem.cpp
+++ b/Code/client/Games/Skyrim/Forms/MagicItem.cpp
@@ -3,19 +3,36 @@
 bool MagicItem::IsWardSpell() const noexcept
 {
     BGSKeyword* pMagicWard = Cast<BGSKeyword>(TESForm::GetById(0x1ea69));
-    return keyword.Contains(pMagicWard);
+    bool truth = keyword.count > 0;
+    if (!truth)
+        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID, this->fullName.value.AsAscii());
+    else
+        truth=keyword.Contains(pMagicWard);
+    return truth;
 }
 
 bool MagicItem::IsInvisibilitySpell() const noexcept
 {
     BGSKeyword* pMagicInvisibility = Cast<BGSKeyword>(TESForm::GetById(0x1ea6f));
-    return keyword.Contains(pMagicInvisibility);
+    bool truth = keyword.count > 0;
+    if (truth)
+        truth = keyword.Contains(pMagicInvisibility);
+    else
+        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID,
+                     this->fullName.value.AsAscii());
+    return truth;
 }
 
 bool MagicItem::IsHealingSpell() const noexcept
 {
     BGSKeyword* pMagicRestoreHealth = Cast<BGSKeyword>(TESForm::GetById(0x1ceb0));
-    return keyword.Contains(pMagicRestoreHealth);
+    bool truth = keyword.count > 0;
+    if (truth)
+        truth = keyword.Contains(pMagicRestoreHealth);
+    else
+        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID,
+                     this->fullName.value.AsAscii());
+    return truth;
 }
 
 bool MagicItem::IsBuffSpell() const noexcept

--- a/Code/client/Games/Skyrim/Magic/EffectItem.cpp
+++ b/Code/client/Games/Skyrim/Magic/EffectItem.cpp
@@ -36,6 +36,12 @@ bool EffectItem::IsVampireLordEffect() const noexcept
 bool EffectItem::IsNightVisionEffect() const noexcept
 {
     BGSKeyword* pMagicNightEye = Cast<BGSKeyword>(TESForm::GetById(0xad7c6));
-    return pEffectSetting->keywordForm.Contains(pMagicNightEye);
+    bool truth = pEffectSetting->keywordForm.count > 0;
+    if (truth)
+         truth = pEffectSetting->keywordForm.Contains(pMagicNightEye);
+    else
+        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}",
+                     pEffectSetting->formID, pEffectSetting->fullName.value.AsAscii());
+    return truth;
 }
 


### PR DESCRIPTION
As the title says. Bethesda bug.

BGSKeywordForm::Contains(pKeywordList) returns true if the keyword list is zero length. This PR checks for the condition and returns false.

There are only 4 places in STR that invoke this function, so I took the simple approach of just fixing them rather than the more-invasive wrapper class to fix it.

I left in the logging to find places that are triggering the bug, but they are at ::debug level. 

The places this will happen is when a Magic item, effect, Health item/effect has no keywords defined on the relevant formID. That probably is never supposed to happen, but it does.