### PR TITLE
Update: Guard against BGSKewordForm::Contains() bug, which returns true when there are zero keywords

### DIFF
--- a/Code/client/Games/Skyrim/Forms/MagicItem.cpp
+++ b/Code/client/Games/Skyrim/Forms/MagicItem.cpp
@@ -3,36 +3,25 @@
 bool MagicItem::IsWardSpell() const noexcept
 {
     BGSKeyword* pMagicWard = Cast<BGSKeyword>(TESForm::GetById(0x1ea69));
-    bool truth = keyword.count > 0;
-    if (!truth)
+    if (keyword.count == 0)
         spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID, this->fullName.value.AsAscii());
-    else
-        truth=keyword.Contains(pMagicWard);
-    return truth;
+    return keyword.count > 0 && keyword.Contains(pMagicWard);
 }
 
 bool MagicItem::IsInvisibilitySpell() const noexcept
 {
     BGSKeyword* pMagicInvisibility = Cast<BGSKeyword>(TESForm::GetById(0x1ea6f));
-    bool truth = keyword.count > 0;
-    if (truth)
-        truth = keyword.Contains(pMagicInvisibility);
-    else
-        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID,
-                     this->fullName.value.AsAscii());
-    return truth;
+    if (keyword.count == 0)
+        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID, this->fullName.value.AsAscii());
+    return keyword.count > 0 && keyword.Contains(pMagicInvisibility);
 }
 
 bool MagicItem::IsHealingSpell() const noexcept
 {
     BGSKeyword* pMagicRestoreHealth = Cast<BGSKeyword>(TESForm::GetById(0x1ceb0));
-    bool truth = keyword.count > 0;
-    if (truth)
-        truth = keyword.Contains(pMagicRestoreHealth);
-    else
-        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID,
-                     this->fullName.value.AsAscii());
-    return truth;
+    if (keyword.count == 0)
+        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID, this->fullName.value.AsAscii());
+    return keyword.count > 0 && keyword.Contains(pMagicRestoreHealth);
 }
 
 bool MagicItem::IsBuffSpell() const noexcept

--- a/Code/client/Games/Skyrim/Magic/EffectItem.cpp
+++ b/Code/client/Games/Skyrim/Magic/EffectItem.cpp
@@ -36,12 +36,8 @@ bool EffectItem::IsVampireLordEffect() const noexcept
 bool EffectItem::IsNightVisionEffect() const noexcept
 {
     BGSKeyword* pMagicNightEye = Cast<BGSKeyword>(TESForm::GetById(0xad7c6));
-    bool truth = pEffectSetting->keywordForm.count > 0;
-    if (truth)
-         truth = pEffectSetting->keywordForm.Contains(pMagicNightEye);
-    else
-        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}",
-                     pEffectSetting->formID, pEffectSetting->fullName.value.AsAscii());
-    return truth;
+    if (pEffectSetting->keywordForm.count == 0)
+        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", pEffectSetting->formID, pEffectSetting->fullName.value.AsAscii());
+    return pEffectSetting->keywordForm.count > 0 && pEffectSetting->keywordForm.Contains(pMagicNightEye);
 }
 


### PR DESCRIPTION
Update to the previous version of this PR. It is functionally identical, the code is just less ugly.

@Force67, I updated the code because ugly bothers me. Then I saw you had already speedily merged the prior version, so thank you for that. I'm submitting this as a PR because a) I already updated the branch, so why not; and b) so you can choose to merge or ignore as you like.