### PR TITLE
Use NiPointer instead of raw pointers in CombatController

### DIFF
--- a/Code/client/Games/Skyrim/Combat/CombatController.h
+++ b/Code/client/Games/Skyrim/Combat/CombatController.h
@@ -42,8 +42,8 @@ struct CombatController
     CombatTargetSelector *pPreviousTargetSelector;
     uint32_t handleCount;
     int32_t unkCC;
-    Actor *pCachedAttacker;
-    Actor *pCachedTarget;
+    NiPointer<Actor> pCachedAttacker;
+    NiPointer<Actor> pCachedTarget;
 };
 
 static_assert(offsetof(CombatController, targetHandle) == 0x2C);

--- a/Code/client/Services/Debug/Views/CombatView.cpp
+++ b/Code/client/Services/Debug/Views/CombatView.cpp
@@ -117,7 +117,7 @@ float CalculateTargetScore(CombatTargetSelector* apThis, CombatTarget* apCombatT
     float score = 0.f;
 
     CombatController* pCombatController = apThis->pCombatController;
-    Actor* pCachedAttacker = pCombatController->pCachedAttacker;
+    Actor* pCachedAttacker = pCombatController->pCachedAttacker.object;
 
     BGSWorldLocation pAttackerWorldLocation{};
     RefrGetWorldLocation(apAttacker, &pAttackerWorldLocation);


### PR DESCRIPTION
This probably never caused any bugs or crashes, but I thought I'd rather update this now than get shot in the foot in the future.