### PR TITLE
Reduce unnecessary recompiles.

### DIFF
--- a/Code/client/TiltedOnlineApp.h
+++ b/Code/client/TiltedOnlineApp.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <BranchInfo.h>
+
 #include <d3d11.h>
 
 #include "CrashHandler.h"

--- a/xmake.lua
+++ b/xmake.lua
@@ -82,7 +82,17 @@ before_build(function (target)
     bool_to_number[branch == "master"], 
     bool_to_number[branch == "bluedove"], 
     bool_to_number[branch == "prerel"])
-    io.writefile("build/BranchInfo.h", contents)
+
+    -- fix always-compiles problem by updating the file only if content has changed.
+    local filepath = "build/BranchInfo.h"
+    local old_content = nil
+    if os.exists(filepath) then
+        old_content = io.readfile(filepath)
+    end
+    if old_content ~= contents then
+        print("Updating file:", filepath)
+        io.writefile(filepath, contents)
+    end
 end)
 
 if is_mode("debug") then


### PR DESCRIPTION
Fix xmake.lua to not update build/BranchInfo.h if it is unchanged.

Remove unneeded dependency causing unnecessary recompiles.