### PR TITLE
Fix: Don't process actions when graph is not ready

### DIFF
--- a/Code/client/Systems/AnimationSystem.cpp
+++ b/Code/client/Systems/AnimationSystem.cpp
@@ -28,6 +28,13 @@ void AnimationSystem::Update(World& aWorld, Actor* apActor, RemoteAnimationCompo
     const auto it = std::begin(actions);
     if (it != std::end(actions) && it->Tick <= aTick)
     {
+        // Check if animation graph is ready before attempting to play animations
+        if (!apActor->animationGraphHolder.IsReady())
+        {
+            // Animation graph not ready, keep the action in queue and try again later
+            return;
+        }
+
         const auto& first = *it;
 
         const auto actionId = first.ActionId;


### PR DESCRIPTION
AnimationSystem::Update did not check if the animation graph was ready, but removed it from the vector of pending actions anyway, resulting in dropped actions.

By checking if the graph is ready and returning early if it is not, we save those actions for when we can actually try to play them back.
While this doesn't fix magic casting animations, I am working on a fix that depends on this, as the start of casting being dropped would break subesequent actions, and, therefore, the entire animation.