### PR TITLE
Fix actor enable issue by using EnableImpl

### DIFF
--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -440,7 +440,10 @@ void CharacterService::OnCharacterSpawn(const CharacterSpawnRequest& acMessage) 
     spdlog::info("CharacterSpawnRequest, server id: {:X}, form id: {:X}", acMessage.ServerId, pActor->formID);
 
     if (pActor->IsDisabled())
-        pActor->Enable();
+    {
+        spdlog::warn("Disabled actor is being re-enabled: {:X}", pActor->formID);
+        pActor->EnableImpl();
+    }
 
     pActor->GetExtension()->SetRemote(true);
 


### PR DESCRIPTION
This PR fixes an issue where disabled actors could not be properly enabled.
﻿
Previously, `pActor->Enable()` was used, but it did not correctly activate disabled actors.  
By replacing it with `pActor->EnableImpl()`, the actor is now properly enabled and becomes active in the world.
