### PR TITLE
Fix certain spell type checks that did not check for keywords on effects

### DIFF
--- a/Code/client/Games/Primitives.h
+++ b/Code/client/Games/Primitives.h
@@ -44,6 +44,27 @@ template <class T> struct GameArray
 
     Iterator end() { return Iterator(&data[length]); }
 
+    struct ConstIterator
+    {
+        ConstIterator(const T* apEntry)
+            : m_pEntry(apEntry)
+        {}
+        ConstIterator operator++()
+        {
+            ++m_pEntry;
+            return *this;
+        }
+        bool operator!=(const ConstIterator& acRhs) const { return m_pEntry != acRhs.m_pEntry; }
+        const T& operator*() const { return *m_pEntry; }
+        
+    private:
+        const T* m_pEntry;
+    };
+
+    ConstIterator begin() const { return ConstIterator(&data[0]); }
+
+    ConstIterator end() const { return ConstIterator(&data[length]); }
+
     inline bool Empty() const noexcept { return length == 0; }
 };
 

--- a/Code/client/Games/Skyrim/Forms/MagicItem.cpp
+++ b/Code/client/Games/Skyrim/Forms/MagicItem.cpp
@@ -3,25 +3,51 @@
 bool MagicItem::IsWardSpell() const noexcept
 {
     BGSKeyword* pMagicWard = Cast<BGSKeyword>(TESForm::GetById(0x1ea69));
-    if (keyword.count == 0)
-        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID, this->fullName.value.AsAscii());
-    return keyword.count > 0 && keyword.Contains(pMagicWard);
+
+    if (keyword.count > 0 && keyword.Contains(pMagicWard))
+        return true;
+
+    // Spells typically don't have keywords, so we must check their effects
+    for (const EffectItem* pEffect : listOfEffects)
+    {
+        if (pEffect->pEffectSetting && pEffect->pEffectSetting->keywordForm.count > 0 && 
+            pEffect->pEffectSetting->keywordForm.Contains(pMagicWard))
+            return true;
+    }
+
+    return false;
 }
 
 bool MagicItem::IsInvisibilitySpell() const noexcept
 {
     BGSKeyword* pMagicInvisibility = Cast<BGSKeyword>(TESForm::GetById(0x1ea6f));
-    if (keyword.count == 0)
-        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID, this->fullName.value.AsAscii());
-    return keyword.count > 0 && keyword.Contains(pMagicInvisibility);
+
+    if (keyword.count > 0 && keyword.Contains(pMagicInvisibility))
+        return true;
+    
+    for (const EffectItem* pEffect : listOfEffects)
+    {
+        if (pEffect->pEffectSetting && pEffect->pEffectSetting->keywordForm.count > 0 &&
+            pEffect->pEffectSetting->keywordForm.Contains(pMagicInvisibility))
+            return true;
+    }
+    return false;
 }
 
 bool MagicItem::IsHealingSpell() const noexcept
 {
     BGSKeyword* pMagicRestoreHealth = Cast<BGSKeyword>(TESForm::GetById(0x1ceb0));
-    if (keyword.count == 0)
-        spdlog::debug(__FUNCTION__ ": correcting BGSKeywordForm::Contains() bug for zero-keyword {:x}, {}", this->formID, this->fullName.value.AsAscii());
-    return keyword.count > 0 && keyword.Contains(pMagicRestoreHealth);
+    
+    if (keyword.count > 0 && keyword.Contains(pMagicRestoreHealth))
+        return true;
+
+    for (const EffectItem* pEffect : listOfEffects)
+    {
+        if (pEffect->pEffectSetting && pEffect->pEffectSetting->keywordForm.count > 0 &&
+            pEffect->pEffectSetting->keywordForm.Contains(pMagicRestoreHealth))
+            return true;
+    }
+    return false;
 }
 
 bool MagicItem::IsBuffSpell() const noexcept


### PR DESCRIPTION
Spells themselves typically don't have keywords, which are on their effects.
As a result, returning false if the spell has no keywords leads to the check returning false incorrectly.
Something of note: while the actual use of the checks is unchanged, this actually breaks certain spell VFX which no longer show on remote clients because the spell cast is not replicated for them. This is simply a result of the intended behavior. To sync spell VFX (for example, on self-healing) without replicating the actual spell cast itself, more work is needed.