### PR TITLE
Feat/tweak quest scope plus server option n logging

### DIFF
--- a/Code/encoding/Messages/NotifyQuestUpdate.cpp
+++ b/Code/encoding/Messages/NotifyQuestUpdate.cpp
@@ -7,6 +7,7 @@ void NotifyQuestUpdate::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) con
     Id.Serialize(aWriter);
     aWriter.WriteBits(Stage, 16);
     aWriter.WriteBits(Status, 8);
+    aWriter.WriteBits(ClientQuestType, 8);
 }
 
 void NotifyQuestUpdate::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
@@ -20,4 +21,7 @@ void NotifyQuestUpdate::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) n
 
     aReader.ReadBits(tmp, 8);
     Status = tmp & 0xFF;
+
+    aReader.ReadBits(tmp, 8);
+    ClientQuestType = tmp & 0xFF;
 }

--- a/Code/encoding/Messages/NotifyQuestUpdate.h
+++ b/Code/encoding/Messages/NotifyQuestUpdate.h
@@ -15,7 +15,7 @@ struct NotifyQuestUpdate final : ServerMessage
     void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
     void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
 
-    bool operator==(const NotifyQuestUpdate& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && Id == acRhs.Id && Stage == acRhs.Stage && Status == acRhs.Stage; }
+    bool operator==(const NotifyQuestUpdate& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && Id == acRhs.Id && Stage == acRhs.Stage && Status == acRhs.Stage && ClientQuestType == acRhs.ClientQuestType; }
 
     enum StatusCode : uint8_t
     {
@@ -27,4 +27,5 @@ struct NotifyQuestUpdate final : ServerMessage
     GameId Id;
     uint16_t Stage;
     uint8_t Status;
+    uint8_t ClientQuestType;
 };

--- a/Code/encoding/Messages/RequestQuestUpdate.cpp
+++ b/Code/encoding/Messages/RequestQuestUpdate.cpp
@@ -7,6 +7,7 @@ void RequestQuestUpdate::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) co
     Id.Serialize(aWriter);
     aWriter.WriteBits(Stage, 16);
     aWriter.WriteBits(Status, 8);
+    aWriter.WriteBits(ClientQuestType, 8);
 }
 
 void RequestQuestUpdate::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
@@ -20,4 +21,7 @@ void RequestQuestUpdate::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) 
 
     aReader.ReadBits(tmp, 8);
     Status = tmp & 0xFF;
+
+    aReader.ReadBits(tmp, 8);
+    ClientQuestType = tmp & 0xFF;
 }

--- a/Code/encoding/Messages/RequestQuestUpdate.h
+++ b/Code/encoding/Messages/RequestQuestUpdate.h
@@ -15,7 +15,7 @@ struct RequestQuestUpdate final : ClientMessage
     void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
     void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
 
-    bool operator==(const RequestQuestUpdate& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && Id == acRhs.Id && Stage == acRhs.Stage && Status == acRhs.Stage; }
+    bool operator==(const RequestQuestUpdate& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && Id == acRhs.Id && Stage == acRhs.Stage && Status == acRhs.Stage && ClientQuestType == acRhs.ClientQuestType; }
 
     enum StatusCode : uint8_t
     {
@@ -27,4 +27,5 @@ struct RequestQuestUpdate final : ClientMessage
     GameId Id;
     uint16_t Stage;
     uint8_t Status;
+    uint8_t ClientQuestType;
 };

--- a/Code/encoding/Structs/GameId.h
+++ b/Code/encoding/Structs/GameId.h
@@ -15,6 +15,7 @@ struct GameId
 
     void Serialize(TiltedPhoques::Buffer::Writer& aWriter) const noexcept;
     void Deserialize(TiltedPhoques::Buffer::Reader& aReader) noexcept;
+    inline uint64_t LogFormat() const noexcept { return static_cast<uint64_t>(ModId) << 32 | BaseId; }
 
     uint32_t BaseId;
     uint32_t ModId;

--- a/Code/server/Services/CharacterService.cpp
+++ b/Code/server/Services/CharacterService.cpp
@@ -40,6 +40,7 @@
 #include <Messages/NotifyActorTeleport.h>
 #include <Messages/NotifyRelinquishControl.h>
 
+#include <Setting.h>
 namespace
 {
 Console::Setting bEnableXpSync{"Gameplay:bEnableXpSync", "Syncs combat XP within the party", true};

--- a/Code/server/Services/InventoryService.cpp
+++ b/Code/server/Services/InventoryService.cpp
@@ -11,6 +11,7 @@
 #include <Messages/NotifyEquipmentChanges.h>
 #include <Messages/DrawWeaponRequest.h>
 
+#include <Setting.h>
 namespace
 {
 Console::Setting bEnableItemDrops{"Gameplay:bEnableItemDrops", "(Experimental) Syncs dropped items by players", false};

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -19,6 +19,7 @@
 #include <Messages/PartyKickRequest.h>
 #include <Messages/NotifyPlayerJoined.h>
 
+#include <Setting.h>
 namespace
 {
 Console::Setting bAutoPartyJoin{"Gameplay:bAutoPartyJoin", "Join parties automatically, as long as there is only one party in the server", true};
@@ -149,7 +150,7 @@ void PartyService::OnPartyChangeLeader(const PacketEvent<PartyChangeLeaderReques
 
     if (!pNewLeader)
     {
-        spdlog::error("[PartyService]: Player {} does not exist¨. Cannot change paty leader", message.PartyMemberPlayerId);
+        spdlog::error("[PartyService]: Player {} does not exist. Cannot change party leader", message.PartyMemberPlayerId);
         return;
     }
 

--- a/Code/server/Services/PlayerService.cpp
+++ b/Code/server/Services/PlayerService.cpp
@@ -18,6 +18,7 @@
 #include <Messages/NotifyPlayerLevel.h>
 #include <Messages/NotifyPlayerCellChanged.h>
 
+#include <Setting.h>
 namespace
 {
 Console::Setting fGoldLossFactor{"Gameplay:fGoldLossFactor", "Factor of the amount of gold lost on death", 0.0f};

--- a/Code/server/Services/QuestService.cpp
+++ b/Code/server/Services/QuestService.cpp
@@ -7,6 +7,13 @@
 #include <Messages/RequestQuestUpdate.h>
 #include <Messages/NotifyQuestUpdate.h>
 
+#include <Setting.h>
+namespace
+{
+Console::Setting bEnableMiscQuestSync{"Gameplay:bEnableMiscQuestSync", "(Experimental) Syncs miscellaneous quests when possible", false};
+
+}
+
 QuestService::QuestService(World& aWorld, entt::dispatcher& aDispatcher)
     : m_world(aWorld)
 {
@@ -22,11 +29,25 @@ void QuestService::OnQuestChanges(const PacketEvent<RequestQuestUpdate>& acMessa
     auto& questComponent = pPlayer->GetQuestLogComponent();
     auto& entries = questComponent.QuestContent.Entries;
 
+    const auto& partyComponent = acMessage.pPlayer->GetParty();
+    if (!partyComponent.JoinedPartyId.has_value())
+        return;
+
     auto questIt = std::find_if(entries.begin(), entries.end(), [&message](const auto& e) { return e.Id == message.Id; });
 
     NotifyQuestUpdate notify{};
     notify.Id = message.Id;
     notify.Stage = message.Stage;
+    notify.Status = message.Status;
+    notify.ClientQuestType = message.ClientQuestType;
+
+    if (notify.ClientQuestType == 0 ||  notify.ClientQuestType == 6) // Types None or Miscellaneous. Hard-coded to avoid client header file.
+    {
+        if (!bEnableMiscQuestSync)
+            return;
+        spdlog::info(__FUNCTION__ ": syncing type none/misc quest to party, gameId {:X} questStage {} questStatus {} questType {}", 
+                     notify.Id.LogFormat(), notify.Stage, notify.Status, notify.ClientQuestType);
+    }
 
     if (message.Status == RequestQuestUpdate::Started || message.Status == RequestQuestUpdate::StageUpdate)
     {
@@ -41,7 +62,7 @@ void QuestService::OnQuestChanges(const PacketEvent<RequestQuestUpdate>& acMessa
 
             if (message.Status == RequestQuestUpdate::Started)
             {
-                spdlog::debug("Started quest: {:X}:{:X}, stage: {}", message.Id.ModId, message.Id.BaseId, message.Stage);
+                spdlog::debug("Started quest: {:X} stage: {}", message.Id.LogFormat(), message.Stage);
 
                 notify.Status = NotifyQuestUpdate::Started;
             }
@@ -52,7 +73,7 @@ void QuestService::OnQuestChanges(const PacketEvent<RequestQuestUpdate>& acMessa
         }
         else
         {
-            spdlog::debug("Updated quest: {:X}:{:X}, stage: {}", message.Id.ModId, message.Id.BaseId, message.Stage);
+            spdlog::debug("Updated quest: {:X}, stage: {}", message.Id.LogFormat(), message.Id.BaseId, message.Stage);
 
             auto& record = *questIt;
             record.Id = message.Id;
@@ -63,19 +84,15 @@ void QuestService::OnQuestChanges(const PacketEvent<RequestQuestUpdate>& acMessa
     }
     else if (message.Status == RequestQuestUpdate::Stopped)
     {
-        spdlog::debug("Stopped quest: {:X}:{:X}, stage: {}", message.Id.ModId, message.Id.BaseId, message.Stage);
+        spdlog::debug("Stopped quest: {:X}, stage: {}", message.Id.LogFormat(), message.Id.BaseId, message.Stage);
 
         if (questIt != entries.end())
             entries.erase(questIt);
         else
-            spdlog::warn("Unable to delete quest object {:X}:{:X}", message.Id.ModId, message.Id.BaseId);
+            spdlog::warn("Unable to delete quest object {:X}", message.Id.LogFormat(), message.Id.BaseId);
 
         notify.Status = NotifyQuestUpdate::Stopped;
     }
-
-    const auto& partyComponent = acMessage.pPlayer->GetParty();
-    if (!partyComponent.JoinedPartyId.has_value())
-        return;
 
     GameServer::Get()->SendToParty(notify, partyComponent, acMessage.GetSender());
 }


### PR DESCRIPTION
This is an update to @otsffs PR #788, which is included with this PR and so supersedes it. 
Credit to @otsffs for miscellaneous quest sync support. His original branch was merged to preserve the credit chain.

This version of the PR adds server-side support to make syncing miscellaneous quests an optional server feature, with a default setting of false (sync is disabled). All the testing we've done shows the bugs attributed to this feature (mostly, duplication of NPCs) are in fact caused by  mods or are in the base Skyrim + STR v1.7.1. We haven't found any issues with the PR.

Still, there are known exceptions, misc. quests that should not be synced. The code suppresses sync of the ones we know about, but more may be discovered. So it is prudent to leave this as an experimental feature that players enable at their own risk.

A component had to be changed to pass the quest type to the server to support the feature flag. That caused most of the changed files in the server support commit, that and the added logging logic so if another exception does come up we can find it.

@absol89 @miredirex and others have also been involved in beating up the original PR. It's solid.