### PR TITLE
Fix/excess logging bugs, resubmitted

### DIFF
--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -685,11 +685,17 @@ void CharacterService::OnBeastFormChange(const BeastFormChangeEvent& acEvent) co
 
     Actor* pActor = Utils::GetByServerId<Actor>(serverId);
     if (!pActor)
+    {
+        spdlog::warn(__FUNCTION__ ": could not find actor for server id {:X}", serverId);
         return;
+    }
 
     TESNPC* pNpc = Cast<TESNPC>(pActor->baseForm);
     if (!pNpc)
+    {
+        spdlog::warn(__FUNCTION__ ": could not find actor baseform for server id {:X}", serverId);
         return;
+    }
 
     pNpc->Serialize(&request.AppearanceBuffer);
     request.ChangeFlags = pNpc->GetChangeFlags();

--- a/Code/client/Services/Generic/MagicService.cpp
+++ b/Code/client/Services/Generic/MagicService.cpp
@@ -296,33 +296,35 @@ void MagicService::OnAddTargetEvent(const AddTargetEvent& acEvent) noexcept
 
     if (!m_world.GetModSystem().GetServerModId(acEvent.SpellID, request.SpellId.ModId, request.SpellId.BaseId))
     {
-        spdlog::error("{}: Could not find spell with form {:X}", __FUNCTION__, acEvent.SpellID);
+        spdlog::error("{}: could not find server ID for spell with formID {:X}, discarding", __FUNCTION__, acEvent.SpellID);
         return;
     }
 
     if (!m_world.GetModSystem().GetServerModId(acEvent.EffectID, request.EffectId.ModId, request.EffectId.BaseId))
     {
-        spdlog::error("{}: Could not find effect with form {:X}", __FUNCTION__, acEvent.EffectID);
+        spdlog::error("{}: could not find server ID for effect with formID {:X}, discarding", __FUNCTION__, acEvent.EffectID);
         return;
     }
 
     request.Magnitude = acEvent.Magnitude;
 
+    // Because it takes time to create Actors, the Caster or Target may not
+    // exist on the server yet, or server may not have told us yet. Have to queue to compensate.
     auto view = m_world.view<FormIdComponent>();
     const auto it = std::find_if(std::begin(view), std::end(view), [id = acEvent.TargetID, view](auto entity) { return view.get<FormIdComponent>(entity).Id == id; });
 
     if (it == std::end(view))
     {
-        spdlog::warn("Form id not found for magic add target, form id: {:X}", acEvent.TargetID);
-        m_queuedEffects[acEvent.TargetID] = request;
+        spdlog::warn("{}: server entity for target formID not found, formID: {:X}, queueing", __FUNCTION__, acEvent.TargetID);
+        m_queuedEffects.push(MagicAddTargetEventQueue(acEvent));
         return;
     }
 
     std::optional<uint32_t> serverIdRes = Utils::GetServerId(*it);
     if (!serverIdRes.has_value())
     {
-        spdlog::warn("Server id not found for magic add target, form id: {:X}", acEvent.TargetID);
-        m_queuedEffects[acEvent.TargetID] = request;
+        spdlog::warn("{}: server ID for target formID not found, formID: {:X}, queueing", __FUNCTION__, acEvent.TargetID);
+        m_queuedEffects.push(MagicAddTargetEventQueue(acEvent));
         return;
     }
 
@@ -332,8 +334,8 @@ void MagicService::OnAddTargetEvent(const AddTargetEvent& acEvent) noexcept
 
     if (casterIt == std::end(view))
     {
-        spdlog::warn("Form id not found for magic add target, form id: {:X}", acEvent.CasterID);
-        m_queuedEffects[acEvent.TargetID] = request;
+        spdlog::warn("{}: server entity for caster formID not found, formID: {:X}, queueing", __FUNCTION__, acEvent.CasterID);
+        m_queuedEffects.push(MagicAddTargetEventQueue(acEvent));  
         return;
     }
 
@@ -352,40 +354,39 @@ void MagicService::OnAddTargetEvent(const AddTargetEvent& acEvent) noexcept
 
 void MagicService::OnNotifyAddTarget(const NotifyAddTarget& acMessage) noexcept
 {
-    Actor* pActor = Utils::GetByServerId<Actor>(acMessage.TargetId);
-    if (!pActor)
-    {
-        spdlog::warn(__FUNCTION__ ": could not find actor server id {:X}", acMessage.TargetId);
-        m_queuedRemoteEffects[acMessage.TargetId] = acMessage;
-        return;
-    }
-
     const uint32_t cSpellId = World::Get().GetModSystem().GetGameId(acMessage.SpellId);
     if (cSpellId == 0)
     {
-        spdlog::error("{}: failed to retrieve spell id, GameId base: {:X}, mod: {:X}", __FUNCTION__, acMessage.SpellId.BaseId, acMessage.SpellId.ModId);
+        spdlog::error("{}: failed to retrieve formID of server spell id, GameId base: {:X}, mod: {:X}, discarding", __FUNCTION__, acMessage.SpellId.BaseId, acMessage.SpellId.ModId);
         return;
     }
 
     MagicItem* pSpell = Cast<MagicItem>(TESForm::GetById(cSpellId));
     if (!pSpell)
     {
-        spdlog::error("{}: Failed to retrieve spell by id {:X}", __FUNCTION__, cSpellId);
+        spdlog::error("{}: failed to retrieve spell by formID {:X}, discarding", __FUNCTION__, cSpellId);
         return;
     }
 
     const uint32_t cEffectId = World::Get().GetModSystem().GetGameId(acMessage.EffectId);
     if (cEffectId == 0)
     {
-        spdlog::error("{}: failed to retrieve effect id, GameId base: {:X}, mod: {:X}", __FUNCTION__, acMessage.EffectId.BaseId, acMessage.EffectId.ModId);
+        spdlog::error("{}: failed to retrieve formID of server effect id, GameId base: {:X}, mod: {:X}, discarding", __FUNCTION__, acMessage.EffectId.BaseId, acMessage.EffectId.ModId);
         return;
     }
 
     EffectItem* pEffect = pSpell->GetEffect(cEffectId);
-
     if (!pEffect)
     {
-        spdlog::error("{}: Failed to retrieve effect by id {:X}", __FUNCTION__, cEffectId);
+        spdlog::error("{}: failed to retrieve effect by formID {:X}", __FUNCTION__, cEffectId);
+        return;
+    }
+
+    Actor* pActor = Utils::GetByServerId<Actor>(acMessage.TargetId);
+    if (!pActor)
+    {
+        spdlog::warn("{}: could not find targetted Actor for serverID {:X}, queueing", __FUNCTION__, acMessage.TargetId);
+        m_queuedRemoteEffects.push(acMessage);
         return;
     }
 
@@ -494,47 +495,78 @@ void MagicService::ApplyQueuedEffects() noexcept
 
     lastSendTimePoint = now;
 
-    Vector<uint32_t> markedForRemoval{};
-
-    for (auto [formId, request] : m_queuedEffects)
+    // Search queued events
+    while (!m_queuedEffects.empty())
     {
-        auto view = m_world.view<FormIdComponent>();
-        const auto it = std::find_if(std::begin(view), std::end(view), [id = formId, view](auto entity) { return view.get<FormIdComponent>(entity).Id == id; });
+        AddTargetEvent target = m_queuedEffects.front().Target();
+        Actor* pCaster = Cast<Actor>(TESForm::GetById(target.CasterID));
+        Actor* pTarget = Cast<Actor>(TESForm::GetById(target.TargetID));
+        auto pTargetName = !pTarget ? "" : pTarget->baseForm->GetName();
+        auto pCasterName = !pCaster ? "" : pCaster->baseForm->GetName();
 
-        if (it == std::end(view))
-            continue;
+        // Check for and skip expired (timed out) events, that Actor isn't likely to exist anymore.
+        if (m_queuedEffects.front().Expired())
+            spdlog::warn("{}: removing expired AddTargetEvent from queue: caster {}({:X}), spell {:X}, effect {:X}, target {}({:X})",
+                         __FUNCTION__, pCasterName, target.CasterID, target.SpellID, target.EffectID, pTargetName, target.TargetID);
+        else
+        {
+            // Process queued target events. If caster and target now have server IDs, this should work.
+            // If they don't, stop processing the list until next iteration.
+            auto view = m_world.view<FormIdComponent>();
+            const auto it = std::find_if(std::begin(view), std::end(view), [id = target.TargetID, view](auto entity) { return view.get<FormIdComponent>(entity).Id == id; });
 
-        entt::entity entity = *it;
+            if (it == std::end(view))
+            {
+                //spdlog::warn("{}: server entity for AddTargetEvent target formID still not found: caster {}({:X}), spell {:X}, effect {:X}, target {}({:X})",
+                //             __FUNCTION__, pCasterName, target.CasterID, target.SpellID, target.EffectID, pTargetName, target.TargetID);
+                break;
+            }
 
-        std::optional<uint32_t> serverIdRes = Utils::GetServerId(entity);
-        if (!serverIdRes.has_value())
-            continue;
+            entt::entity entity = *it;
+            std::optional<uint32_t> serverIdRes = Utils::GetServerId(entity);
+            if (!serverIdRes.has_value())
+            {
+                spdlog::warn("{}: serverID for AddTargetEvent target formID still not found: caster {}({:X}), spell {:X}, effect {:X}, target {}({:X})",
+                             __FUNCTION__, pCasterName, target.CasterID, target.SpellID, target.EffectID, pTargetName, target.TargetID);
+                break;
+            }
 
-        request.TargetId = serverIdRes.value();
+            // At this point, it will succeed or fail, but not queue another one ad infinitum
+            spdlog::warn("{}: retrying AddTargetEvent for caster {}({:X}), spell {:X}, effect {:X}, target {}({:X})", 
+                             __FUNCTION__, pCasterName, target.CasterID, target.SpellID, target.EffectID, pTargetName, target.TargetID);
+            OnAddTargetEvent(target);        
+        }
 
-        m_transport.Send(request);
-
-        markedForRemoval.push_back(formId);
+        m_queuedEffects.pop();
     }
 
-    for (uint32_t formId : markedForRemoval)
-        m_queuedEffects.erase(formId);
-
-    markedForRemoval.clear();
-
-    for (const auto& [serverId, notify] : m_queuedRemoteEffects)
+    // Same again for remote events
+    while (!m_queuedRemoteEffects.empty())
     {
-        Actor* pActor = Utils::GetByServerId<Actor>(serverId);
-        if (!pActor)
-            continue;
+        NotifyAddTarget target = m_queuedRemoteEffects.front().Target();
+        Actor* pTarget = Utils::GetByServerId<Actor>(target.TargetId); 
+        Actor* pCaster = Utils::GetByServerId<Actor>(target.CasterId); 
+        auto pTargetName = !pTarget ? "" : pTarget->baseForm->GetName();
+        auto pCasterName = !pCaster ? "" : pCaster->baseForm->GetName(); 
 
-        OnNotifyAddTarget(notify);
+        if (m_queuedRemoteEffects.front().Expired())
+            spdlog::warn("{}: removing expired NotifyAddTarget event from queue: caster {}({:X}), spell {:X}, effect {:X}, target {}({:X})",
+                            __FUNCTION__, pCasterName, target.CasterId, target.SpellId, target.EffectId, pTargetName, target.TargetId);
+        else
+        {
+            if (!pTarget)
+            {
+                //spdlog::warn("{}: Actor for target serverID still not found for NotifyAddTarget: caster {}({:X}), spell {:X}, effect {:X}, target {}({:X})",
+                //             __FUNCTION__, pCasterName, target.CasterId, target.SpellId, target.EffectId, pTargetName, target.TargetId);
+                break;
+            }
+            spdlog::warn("{}: retrying NotifyAddTarget for caster {}({:X}), spell {:X}, effect {:X}, target {}({:X})",
+                         __FUNCTION__, pCasterName, target.CasterId, target.SpellId, target.EffectId, pTargetName,target.TargetId);
+            OnNotifyAddTarget(target);
+        }
 
-        markedForRemoval.push_back(serverId);
+        m_queuedRemoteEffects.pop();
     }
-
-    for (uint32_t serverId : markedForRemoval)
-        m_queuedRemoteEffects.erase(serverId);
 }
 
 void MagicService::StartRevealingOtherPlayers() noexcept

--- a/Code/client/Services/MagicService.h
+++ b/Code/client/Services/MagicService.h
@@ -2,9 +2,11 @@
 
 #include <Games/Events.h>
 #include <Events/EventDispatcher.h>
+#include <Events/AddTargetEvent.h>
 #include <Messages/AddTargetRequest.h>
 #include <Messages/NotifyAddTarget.h>
 #include <Messages/NotifyRemoveSpell.h>
+#include <chrono>
 
 struct World;
 struct TransportService;
@@ -100,9 +102,53 @@ private:
     /**
      * @brief The queued magic effects.
      * @see ApplyQueuedEffects
+     * Tracks effects queued for incompletely constructed actors / targets
+     * There may be multiple. There may be sequencing between the targets
+     * that matters. And, the objects might also be destroyed
+     * before application, so they must time out
      */
-    Map<uint32_t, AddTargetRequest> m_queuedEffects;
-    Map<uint32_t, NotifyAddTarget> m_queuedRemoteEffects;
+    class MagicQueue
+    {
+      public:
+        MagicQueue() = default;
+        MagicQueue(const MagicQueue&) = default;
+        bool Expired() const { return std::chrono::steady_clock::now() > m_expiration; }
+
+      private:
+        const std::chrono::steady_clock::duration   m_queueLimit{std::chrono::seconds(4)};
+        const std::chrono::steady_clock::time_point m_expiration{std::chrono::steady_clock::now() + m_queueLimit};
+    };
+
+    class MagicAddTargetEventQueue : public MagicQueue
+    {
+      public:
+        MagicAddTargetEventQueue() = default;
+        MagicAddTargetEventQueue(const AddTargetEvent& aTarget) : m_TargetEvent(aTarget) {};
+        const AddTargetEvent& Target() const 
+        {
+            return m_TargetEvent;
+        }
+    
+      private:
+        AddTargetEvent m_TargetEvent;
+    };
+
+    class MagicNotifyAddTargetQueue : public MagicQueue
+    {
+      public:
+        MagicNotifyAddTargetQueue() = default;
+        MagicNotifyAddTargetQueue(const NotifyAddTarget& aTarget) : m_NotifyAddTarget(aTarget) {};
+        const NotifyAddTarget& Target() const
+        {
+            return m_NotifyAddTarget;
+        }
+
+      private:
+        NotifyAddTarget m_NotifyAddTarget;
+    };
+
+    std::queue<MagicAddTargetEventQueue>  m_queuedEffects;
+    std::queue<MagicNotifyAddTargetQueue> m_queuedRemoteEffects;
 
     bool m_revealingOtherPlayers = false;
 

--- a/Code/client/Utils.cpp
+++ b/Code/client/Utils.cpp
@@ -21,7 +21,7 @@ std::optional<uint32_t> GetServerId(entt::entity aEntity) noexcept
     else
     {
         const auto* pFormIdComponent = World::Get().try_get<FormIdComponent>(aEntity);
-        spdlog::warn("{}: This entity has neither a local or remote component: {:X}, form id: {:X}", __FUNCTION__, to_integral(aEntity), pFormIdComponent ? pFormIdComponent->Id : 0);
+        spdlog::debug("{}: This entity has neither a local or remote component: {:X}, form id: {:X}", __FUNCTION__, to_integral(aEntity), pFormIdComponent ? pFormIdComponent->Id : 0);
         return std::nullopt;
     }
 

--- a/Code/client/Utils.cpp
+++ b/Code/client/Utils.cpp
@@ -21,7 +21,7 @@ std::optional<uint32_t> GetServerId(entt::entity aEntity) noexcept
     else
     {
         const auto* pFormIdComponent = World::Get().try_get<FormIdComponent>(aEntity);
-        spdlog::warn("This entity has neither a local or remote component: {:X}, form id: {:X}", to_integral(aEntity), pFormIdComponent ? pFormIdComponent->Id : 0);
+        spdlog::warn("{}: This entity has neither a local or remote component: {:X}, form id: {:X}", __FUNCTION__, to_integral(aEntity), pFormIdComponent ? pFormIdComponent->Id : 0);
         return std::nullopt;
     }
 

--- a/Code/client/Utils.h
+++ b/Code/client/Utils.h
@@ -53,7 +53,7 @@ template <class T> T* GetByServerId(const uint32_t acServerId) noexcept
         }
     }
 
-    spdlog::warn("Form not found for server id {:X}", acServerId);
+    spdlog::warn("{}: form not found for server id {:X}", __FUNCTION__, acServerId);
     return nullptr;
 }
 

--- a/Code/client/Utils.h
+++ b/Code/client/Utils.h
@@ -53,7 +53,7 @@ template <class T> T* GetByServerId(const uint32_t acServerId) noexcept
         }
     }
 
-    spdlog::warn("{}: form not found for server id {:X}", __FUNCTION__, acServerId);
+    spdlog::debug("{}: form not found for server id {:X}", __FUNCTION__, acServerId);
     return nullptr;
 }
 


### PR DESCRIPTION
Resubmitting. This fixes infinite logging and ultimately huge logs and game slowing to a crawl when spells and effects are sent to the server before an Actor is fully created.

Merge readiness: good for review, a fair amount of testing done. The logs might want some adjustments before merge, they are Warnings to make them stand out in the sea of logs, can be turned down after some more mileage (maybe to debug level).

The old code captured just the last, most recent effect, threw the rest away, and then retried forever to apply the effect. Except sometimes that Actor (server or local) will never exist; that happens in fast windows like ownership changes. Mostly on cell changes, some on spawning.

First fix timed out those dead entries.

New fix implements a proper queue per Actor to maintain all the effects, still with timeouts for when it will never succeed. The logging shows a dozen or more effects isn't unusual, so this should be a big help.