### PR TITLE
feat: Enable compatibility with SkyrimSoulsRE to fix menu-related crashes

### DIFF
--- a/Code/client/Games/Skyrim/Interface/UI.cpp
+++ b/Code/client/Games/Skyrim/Interface/UI.cpp
@@ -2,6 +2,7 @@
 #include <Games/Skyrim/Interface/UI.h>
 #include <Misc/BSFixedString.h>
 #include <TiltedOnlinePCH.h>
+#include "immersive_launcher/stubs/DllBlocklist.h"
 
 #include <World.h>
 
@@ -84,7 +85,7 @@ static void* (*UI_AddToActiveQueue)(UI*, IMenu*, void*);
 static void* UI_AddToActiveQueue_Hook(UI* apSelf, IMenu* apMenu, void* apFoundItem /*In reality a reference*/)
 {
     // if the menu is empty we let the real function handle it.
-    if (!apMenu || !World::Get().GetTransport().IsConnected())
+    if (!apMenu || !World::Get().GetTransport().IsConnected() || stubs::g_IsSoulsREActive)
         return UI_AddToActiveQueue(apSelf, apMenu, apFoundItem);
 
 #if 0

--- a/Code/immersive_launcher/stubs/DllBlocklist.cpp
+++ b/Code/immersive_launcher/stubs/DllBlocklist.cpp
@@ -18,7 +18,6 @@ namespace stubs
     // for causing crashes and incompatibility with ST
     const wchar_t* const kDllBlocklist[] = {
         L"EngineFixes.dll",          // Skyrim Engine Fixes, breaks our hooks
-        L"SkyrimSoulsRE.dll",        // Our mod implements this with special handling
         L"crashhandler64.dll",       // Stream crash handler, breaks heap
         L"fraps64.dll",              // Breaks tilted ui
         L"SpecialK64.dll",           // breaks rendering
@@ -229,6 +228,15 @@ bool IsDllBlocked(std::wstring_view dllName)
             return true;
         }
     }
+
+    return false;
+}
+
+bool IsSoulsRE(std::wstring_view dllName)
+{
+    const wchar_t *dllEntry = L"SkyrimSoulsRE.dll";
+    if (std::wcscmp(dllName.data(), dllEntry) == 0)
+        return true;
 
     return false;
 }

--- a/Code/immersive_launcher/stubs/DllBlocklist.h
+++ b/Code/immersive_launcher/stubs/DllBlocklist.h
@@ -6,4 +6,10 @@ namespace stubs
 {
 // Returns true if the module name is found in the hard block list.
 bool IsDllBlocked(std::wstring_view dllName);
+
+// Returns true if the module is a Skyrim Souls RE related DLL.
+bool IsSoulsRE(std::wstring_view dllName);
+
+// Global flag indicating whether Skyrim Souls RE is active.
+bool g_IsSoulsREActive{};
 } // namespace stubs

--- a/Code/immersive_launcher/stubs/FileMapping.cpp
+++ b/Code/immersive_launcher/stubs/FileMapping.cpp
@@ -274,7 +274,11 @@ NTSTATUS WINAPI TP_LdrLoadDll(const wchar_t* apPath, uint32_t* apFlags, UNICODE_
     size_t pos = fileName.find_last_of(L'\\');
     if (pos != std::wstring_view::npos && (pos + 1) != fileName.length())
     {
-        if (stubs::IsDllBlocked(&fileName[pos + 1]))
+        const wchar_t *name = &fileName[pos + 1];
+        if (stubs::IsSoulsRE(name))
+            stubs::g_IsSoulsREActive = true;
+        
+        if (stubs::IsDllBlocked(name))
         {
             // invalid image hash
             // this signals windows to *NOT TRY* loading it again at a later time.


### PR DESCRIPTION
Enable compatibility with the SkyrimSoulsRE mod. If the SkyrimSoulsRE mod is not installed, menu pausing will be managed by SkyrimTogetherReborn. If SkyrimSoulsRE is installed, it will take over the management of menu pausing.

Currently, non-paused menus in SkyrimTogetherReborn are causing several crashes. Known crashes include:

1. 100% crash when binding potions to the same hotkey in the Preferences menu.
2. High probability of crashing when swapping equipment or items with a follower.

Integrating the SkyrimSoulsRE mod resolves these two specific issues and may fix additional menu-related crashes. If the SkyrimSoulsRE mod's configuration is set to match the current list of non-paused menus in SkyrimTogetherReborn, this change should theoretically introduce no additional risks.