### PR TITLE
Prevent multiple triggers of quest stage change

### DIFF
--- a/Code/client/Games/Skyrim/Forms/TESQuest.cpp
+++ b/Code/client/Games/Skyrim/Forms/TESQuest.cpp
@@ -99,7 +99,7 @@ bool TESQuest::SetStage(uint16_t newStage)
 
 void TESQuest::ScriptSetStage(uint16_t stageIndex)
 {
-    if (IsStageDone(stageIndex))
+    if (currentStage == stageIndex || IsStageDone(stageIndex))
         return;
 
     using Quest = TESQuest;


### PR DESCRIPTION
This started as a bug hunt for misc. quest syncing, but it effects ALL quest type progression. When the quest stage is set, syncing will cause each player to try to set it, which can cause duplication of steps or unwanted progression.

The fix is to make sure desired quest stage != current quest stage.