### PR TITLE
Update mimalloc to 2.2.4

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -52,7 +52,7 @@ if is_plat("windows") then
 end
 
 -- dependencies' dependencies version pinning
-add_requireconfs("*.mimalloc", { version = "2.1.7", override = true })
+add_requireconfs("*.mimalloc", { version = "2.2.4", override = true })
 add_requireconfs("*.cmake", { version = "3.30.2", override = true })
 add_requireconfs("*.openssl", { version = "1.1.1-w", override = true })
 add_requireconfs("*.zlib", { version = "v1.3.1", override = true })


### PR DESCRIPTION
Latest v2 build has some relevant fixes to us which may help memory corruption crashes.

Update: a few of us have been running this for a couple of weeks now, seems much more stable and definitely not worse. It's in v1.7.1.34 and .33 of the fork.

Bonus, mimalloc warnings are now gone (though that may be removing the warnings as opposed to fixes).