### PR TITLE
Fix "Show selected entity in world" rendering issues (part of the F3 debugger)

### DIFF
--- a/Code/client/Games/Skyrim/Forms/TESForm.h
+++ b/Code/client/Games/Skyrim/Forms/TESForm.h
@@ -95,6 +95,8 @@ struct TESForm : BaseFormComponent
     virtual void sub_36();
     virtual void ActivateReference();
     virtual void sub_38();
+    virtual void unk_39();
+    virtual void unk_3A();
 
     // void CopyFromEx(TESForm* rhs);
     void Save_Reversed(uint32_t aChangeFlags, Buffer::Writer& aWriter);

--- a/Code/client/Games/Skyrim/TESObjectREFR.h
+++ b/Code/client/Games/Skyrim/TESObjectREFR.h
@@ -9,6 +9,7 @@
 #include <Games/Misc/Lock.h>
 #include <Games/Magic/MagicSystem.h>
 #include <Magic/MagicCaster.h>
+#include <Magic/MagicTarget.h>
 #include <Structs/Inventory.h>
 #include <ExtraData/ExtraDataList.h>
 
@@ -62,8 +63,6 @@ struct TESObjectREFR : TESForm
     static void GetItemFromExtraData(Inventory::Entry& arEntry, ExtraDataList* apExtraDataList) noexcept;
     static ExtraDataList* GetExtraDataFromItem(const Inventory::Entry& arEntry) noexcept;
 
-    virtual void sub_39();
-    virtual void sub_3A();
     virtual void sub_3B();
     virtual void sub_3C();
     virtual void sub_3D();
@@ -98,7 +97,7 @@ struct TESObjectREFR : TESForm
     virtual void AddObjectToContainer(TESBoundObject* apObj, ExtraDataList* aspExtra, int32_t aicount, TESObjectREFR* apOldContainer);
     virtual void sub_5B();
     virtual MagicCaster* GetMagicCaster(MagicSystem::CastingSource aeSource);
-    virtual void sub_5D();
+    virtual MagicTarget* GetMagicTarget();
     virtual void sub_5E();
     virtual void sub_5F();
     virtual void sub_60();
@@ -120,9 +119,9 @@ struct TESObjectREFR : TESForm
     virtual NiNode* GetNiNode();
     virtual void sub_71();
     virtual void sub_72();
-    virtual void sub_73();
     virtual NiPoint3 GetBoundMin();
     virtual NiPoint3 GetBoundMax();
+    virtual void sub_75();
     virtual void sub_76();
     virtual void sub_77();
     virtual void sub_78();

--- a/Code/client/Services/Debug/Views/ComponentView.cpp
+++ b/Code/client/Services/Debug/Views/ComponentView.cpp
@@ -37,14 +37,14 @@ static __declspec(noinline) bool DrawInWorldSpace(TESObjectREFR* apRefr, ImVec2&
 {
     // Attach at the head ish.
     auto pos = apRefr->position;
-    pos.z -= apRefr->GetHeight();
+    pos.z += apRefr->GetHeight();
 
     NiPoint3 screenPoint{};
     HUDMenuUtils::WorldPtToScreenPt3(pos, screenPoint);
     // Calculate window collision bounds.
     auto* pViewport = BSGraphics::GetMainWindow();
 
-    // translate to screen
+    // Translate to screen
     const ImVec2 screenPos = ImVec2{
         (pViewport->uiWindowWidth * screenPoint.x),
         (pViewport->uiWindowHeight * (1.0f - screenPoint.y)),

--- a/Code/client/Services/Debug/Views/ComponentView.cpp
+++ b/Code/client/Services/Debug/Views/ComponentView.cpp
@@ -43,44 +43,28 @@ static __declspec(noinline) bool DrawInWorldSpace(TESObjectREFR* apRefr, ImVec2&
     HUDMenuUtils::WorldPtToScreenPt3(pos, screenPoint);
     // Calculate window collision bounds.
     auto* pViewport = BSGraphics::GetMainWindow();
-    const NiRect<float> bounds = {
-        static_cast<float>(pViewport->iWindowX),
-        static_cast<float>(pViewport->iWindowX + pViewport->uiWindowWidth),
-        static_cast<float>(pViewport->iWindowY),
-        static_cast<float>(pViewport->iWindowY + pViewport->uiWindowHeight),
-    };
 
     // translate to screen
     const ImVec2 screenPos = ImVec2{
-        (pViewport->uiWindowWidth * screenPoint.x) + bounds.left,
-        (pViewport->uiWindowHeight * (1.0f - screenPoint.y)) + bounds.top,
+        (pViewport->uiWindowWidth * screenPoint.x),
+        (pViewport->uiWindowHeight * (1.0f - screenPoint.y)),
     };
 
-    // implements HUDMarkerData::CalculateFloatingMarkerPositionAndVisiblity from FO4
-    auto IsVisible = [](const ImVec2& aVec2, const NiRect<float>& aScreenBounds, const float zCoordGame)
-    {
-        if (aVec2.x >= aScreenBounds.left && aVec2.x <= aScreenBounds.right)
-        {
-            if (aVec2.y >= aScreenBounds.top &&
-                aVec2.y <= aScreenBounds.bottom
-                /*Not too sure about the Z coord check*/
-                && zCoordGame >= 0)
-                return true;
-        }
-        return false;
+    const ImVec2 windowSize = {
+        static_cast<float>(pViewport->uiWindowWidth),
+        static_cast<float>(pViewport->uiWindowHeight),
     };
 
-    // Obviously it would be much smarter to attach the player name tag to the head bone,
-    // because the player animation also influences the pos for example when jumping,
-    // but the bounding box is fixed.
-    // and offset it slightly above.
-    // But this is just a demo...
-    if (IsVisible(screenPos, bounds, screenPoint.z))
+    auto IsVisible = [](const ImVec2& acVec2, const ImVec2& acScreenSize, float z) {
+        return (acVec2.x > 0 && acVec2.x <= acScreenSize.x) &&
+               (acVec2.y > 0 && acVec2.y <= acScreenSize.y) && z >= 0;
+    };
+
+    if (IsVisible(screenPos, windowSize, screenPoint.z))
     {
         outViewPos = screenPos;
         return true;
     }
-
     outViewPos = {};
     return false;
 }


### PR DESCRIPTION
Also known as "draw components in world space" in the code

What's fixed:
- fixed incorrect position calculations when using multiple game windows
- fixed `GetHeight()` returning abnormal values