### PR TITLE
Fix quest operator== that can rarely cause failure to progress quest

### DIFF
--- a/Code/encoding/Messages/NotifyQuestUpdate.h
+++ b/Code/encoding/Messages/NotifyQuestUpdate.h
@@ -15,7 +15,7 @@ struct NotifyQuestUpdate final : ServerMessage
     void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
     void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
 
-    bool operator==(const NotifyQuestUpdate& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && Id == acRhs.Id && Stage == acRhs.Stage && Status == acRhs.Stage; }
+    bool operator==(const NotifyQuestUpdate& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && Id == acRhs.Id && Stage == acRhs.Stage && Status == acRhs.Status; }
 
     enum StatusCode : uint8_t
     {

--- a/Code/encoding/Messages/RequestQuestUpdate.h
+++ b/Code/encoding/Messages/RequestQuestUpdate.h
@@ -15,7 +15,7 @@ struct RequestQuestUpdate final : ClientMessage
     void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
     void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
 
-    bool operator==(const RequestQuestUpdate& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && Id == acRhs.Id && Stage == acRhs.Stage && Status == acRhs.Stage; }
+    bool operator==(const RequestQuestUpdate& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && Id == acRhs.Id && Stage == acRhs.Stage && Status == acRhs.Status; }
 
     enum StatusCode : uint8_t
     {


### PR DESCRIPTION
Self explanatory?

Found by @miredirex working on misc. quest sync.