### PR TITLE
Fix potential crash originating from HookSpellCast

### DIFF
--- a/Code/client/Games/Skyrim/Magic/ActorMagicCaster.cpp
+++ b/Code/client/Games/Skyrim/Magic/ActorMagicCaster.cpp
@@ -18,8 +18,12 @@ void TP_MAKE_THISCALL(HookSpellCast, ActorMagicCaster, bool abSuccess, int32_t a
 {
     spdlog::debug("HookSpellCast, abSuccess: {}, auiTargetCount: {}, apSpell: {:X}", abSuccess, auiTargetCount, (uint64_t)apSpell);
 
-    // TODO(cosideci): why is this here?
+    // Note: these if guards is how the game does it too
+    if (!apThis->pCasterActor)
+        return;
     if (!abSuccess)
+        return;
+    if (!apSpell && !apThis->pCurrentSpell)
         return;
 
     if (apThis->pCasterActor->GetExtension()->IsRemote())

--- a/Code/client/Games/Skyrim/Magic/ActorMagicCaster.h
+++ b/Code/client/Games/Skyrim/Magic/ActorMagicCaster.h
@@ -28,4 +28,6 @@ struct ActorMagicCaster : MagicCaster
     uint32_t uiFlags;
 };
 
+static_assert(offsetof(ActorMagicCaster, pCasterActor) == 0xB8);
+static_assert(offsetof(ActorMagicCaster, pMagicNode) == 0xC0);
 static_assert(sizeof(ActorMagicCaster) == 0x100);


### PR DESCRIPTION
This is how the game does its checks:

<img width="697" height="291" alt="image" src="https://github.com/user-attachments/assets/51816552-3961-48e9-acf5-d13b9648ae9e" />

thx @absol89 for the crash log