### PR TITLE
Fix overlays init by using D3D11 device and context provided by the game's renderer

### DIFF
--- a/Code/client/Games/Renderer.cpp
+++ b/Code/client/Games/Renderer.cpp
@@ -30,6 +30,7 @@ ID3D11Device* BGSRenderer::GetDevice()
     return *(s_device.Get());
 }
 
+// unused, never hooked
 static void HookPresent()
 {
     // TODO (Force): refactor this ..
@@ -38,8 +39,7 @@ static void HookPresent()
     return RealRenderPresent();
 }
 
-// TODO (Force): handle lost devices
-
+// unused, never hooked
 static bool HookCreateViewport(void* viewport, ViewportConfig* pConfig, WindowConfig* pWindowConfig, void* a4)
 {
     pConfig->name = "Skyrim Together | " BUILD_BRANCH "@" BUILD_COMMIT;

--- a/Code/client/Games/Skyrim/BSGraphics/BSGraphicsRenderer.cpp
+++ b/Code/client/Games/Skyrim/BSGraphics/BSGraphicsRenderer.cpp
@@ -60,7 +60,9 @@ void Hook_Renderer_Init(Renderer* self, BSGraphics::RendererInitOSData* aOSData,
     // This how the game does it too
     g_RenderWindow = &self->Data.RenderWindowA[0];
 
-    g_sRs->OnDeviceCreation(self->Data.RenderWindowA[0].pSwapChain);
+    const BSGraphics::RendererData& renderer = self->Data;
+
+    g_sRs->OnDeviceCreation(renderer.RenderWindowA[0].pSwapChain, renderer.pForwarder, renderer.pContext);
 }
 
 void (*StopTimer)(int) = nullptr;

--- a/Code/client/Games/Skyrim/BSGraphics/BSGraphicsRenderer.h
+++ b/Code/client/Games/Skyrim/BSGraphics/BSGraphicsRenderer.h
@@ -71,19 +71,20 @@ struct RendererData
     uint32_t uiNewWidth;           // 0x0028
     uint32_t uiNewHeight;          // 0x002C
     uint32_t uiPresentInterval;    // 0x0030
-    ID3D11Device* pDevice;         // 0x0038
+    ID3D11Device* pForwarder;      // 0x0038
     ID3D11DeviceContext* pContext; // 0x0040
 
-    // UNSURE starting from here...
     BSGraphics::RendererWindow RenderWindowA[32]; // V
-    BSGraphics::RenderTarget pRenderTargetsA[101];
-    BSGraphics::DepthStencilTarget pDepthStencilTargetsA[13];
-    BSGraphics::CubeMapRenderTarget pCubeMapRenderTargetsA[2];
-    BSCriticalSection RendererLock;
-    // Invalid...
-    const char* pClassName;
-    HINSTANCE__* hInstance;
+    BSGraphics::RenderTarget pRenderTargetsA[114];
+    BSGraphics::DepthStencilTarget pDepthStencilTargetsA[12];
+    BSGraphics::CubeMapRenderTarget pCubeMapRenderTargetsA[1];
 };
+
+static_assert(offsetof(RendererData, pForwarder) == 0x38);
+static_assert(offsetof(RendererData, RenderWindowA) == 0x48);
+static_assert(offsetof(RendererData, pRenderTargetsA) == 0xA48);
+static_assert(offsetof(RendererData, pDepthStencilTargetsA) == 0x1FA8);
+static_assert(offsetof(RendererData, pCubeMapRenderTargetsA) == 0x26C8);
 
 struct Renderer
 {
@@ -96,8 +97,6 @@ struct RendererInitReturn
 {
     HWND hwnd;
 };
-
-static_assert(offsetof(RendererData, pDevice) == 56);
 
 // former ViewportConfig
 struct RendererInitOSData

--- a/Code/client/Services/Generic/ImguiService.cpp
+++ b/Code/client/Services/Generic/ImguiService.cpp
@@ -21,19 +21,13 @@ ImguiService::~ImguiService() noexcept
 
 void ImguiService::Create(RenderSystemD3D11* apRenderSystem, HWND aHwnd)
 {
-    ID3D11Device* d3dDevice = nullptr;
-    ID3D11DeviceContext* d3dContext = nullptr;
-
     m_imDriver.Initialize(static_cast<void*>(aHwnd));
 
     // init platform
     if (!ImGui_ImplWin32_Init(aHwnd))
         spdlog::error("Failed to initialize Imgui-Win32");
 
-    apRenderSystem->GetSwapChain()->GetDevice(__uuidof(d3dDevice), reinterpret_cast<void**>(&d3dDevice));
-    d3dDevice->GetImmediateContext(&d3dContext);
-
-    ImGui_ImplDX11_Init(d3dDevice, d3dContext);
+    ImGui_ImplDX11_Init(apRenderSystem->GetDevice(), apRenderSystem->GetDeviceContext());
 }
 
 void ImguiService::Render() const

--- a/Code/client/Services/Generic/OverlayService.cpp
+++ b/Code/client/Services/Generic/OverlayService.cpp
@@ -60,6 +60,8 @@ struct D3D11RenderProvider final : OverlayApp::RenderProvider, OverlayRenderHand
     [[nodiscard]] HWND GetWindow() override { return m_pRenderSystem->GetWindow(); }
 
     [[nodiscard]] IDXGISwapChain* GetSwapChain() const noexcept override { return m_pRenderSystem->GetSwapChain(); }
+    [[nodiscard]] ID3D11Device* GetDevice() const noexcept override { return m_pRenderSystem->GetDevice(); }
+    [[nodiscard]] ID3D11DeviceContext* GetDeviceContext() const noexcept override { return m_pRenderSystem->GetDeviceContext(); }
 
 private:
     RenderSystemD3D11* m_pRenderSystem;

--- a/Code/client/Systems/RenderSystemD3D11.cpp
+++ b/Code/client/Systems/RenderSystemD3D11.cpp
@@ -6,29 +6,21 @@
 #include <Services/OverlayService.h>
 #include <Services/ImguiService.h>
 
-#include <D3D11Hook.hpp>
 #include <d3d11.h>
 
 RenderSystemD3D11::RenderSystemD3D11(OverlayService& aOverlay, ImguiService& aImguiService)
     : m_pSwapChain(nullptr)
+    , m_pDevice(nullptr)
+    , m_pDeviceContext(nullptr)
     , m_overlay(aOverlay)
     , m_imguiService(aImguiService)
 {
-    auto& d3d11 = TiltedPhoques::D3D11Hook::Get();
+    // Note: D3D11Hook is not utilized in the codebase
 
-    m_createConnection = d3d11.OnCreate.Connect(std::bind(&RenderSystemD3D11::OnDeviceCreation, this, std::placeholders::_1));
-    m_resetConnection = d3d11.OnLost.Connect(std::bind(&RenderSystemD3D11::OnReset, this, std::placeholders::_1));
-
+    // auto& d3d11 = TiltedPhoques::D3D11Hook::Get();
+    // m_createConnection = d3d11.OnCreate.Connect(std::bind(&RenderSystemD3D11::OnDeviceCreation, this, std::placeholders::_2));
+    // m_resetConnection = d3d11.OnLost.Connect(std::bind(&RenderSystemD3D11::OnReset, this, std::placeholders::_1));
     // m_renderConnection = d3d11.OnPresent.Connect(std::bind(&RenderSystemD3D11::OnRender, this, std::placeholders::_1));
-}
-
-RenderSystemD3D11::~RenderSystemD3D11()
-{
-    auto& d3d11 = TiltedPhoques::D3D11Hook::Get();
-
-    d3d11.OnCreate.Disconnect(m_createConnection);
-    // d3d11.OnPresent.Disconnect(m_renderConnection);
-    d3d11.OnLost.Disconnect(m_resetConnection);
 }
 
 HWND RenderSystemD3D11::GetWindow() const
@@ -42,14 +34,11 @@ HWND RenderSystemD3D11::GetWindow() const
     return desc.OutputWindow;
 }
 
-IDXGISwapChain* RenderSystemD3D11::GetSwapChain() const
-{
-    return m_pSwapChain;
-}
-
-void RenderSystemD3D11::OnDeviceCreation(IDXGISwapChain* apSwapChain)
+void RenderSystemD3D11::OnDeviceCreation(IDXGISwapChain* apSwapChain, ID3D11Device* apDevice, ID3D11DeviceContext* apContext)
 {
     m_pSwapChain = apSwapChain;
+    m_pDevice = apDevice;
+    m_pDeviceContext = apContext;
 
     m_imguiService.Create(this, GetWindow());
     m_overlay.Create(this);

--- a/Code/client/Systems/RenderSystemD3D11.h
+++ b/Code/client/Systems/RenderSystemD3D11.h
@@ -2,6 +2,8 @@
 
 struct ImguiService;
 struct IDXGISwapChain;
+struct ID3D11Device;
+struct ID3D11DeviceContext;
 struct OverlayService;
 
 /**
@@ -10,20 +12,25 @@ struct OverlayService;
 struct RenderSystemD3D11
 {
     RenderSystemD3D11(OverlayService& aOverlay, ImguiService& aImguiService);
-    ~RenderSystemD3D11();
+    ~RenderSystemD3D11() = default;
 
     TP_NOCOPYMOVE(RenderSystemD3D11);
 
     [[nodiscard]] HWND GetWindow() const;
-    [[nodiscard]] IDXGISwapChain* GetSwapChain() const;
+    [[nodiscard]] IDXGISwapChain* GetSwapChain() const { return m_pSwapChain; };
+    [[nodiscard]] ID3D11Device* GetDevice() const { return m_pDevice; };
+    [[nodiscard]] ID3D11DeviceContext* GetDeviceContext() const { return m_pDeviceContext; };
 
     // to make yamashi mad
-    void OnDeviceCreation(IDXGISwapChain* apSwapChain);
+    void OnDeviceCreation(IDXGISwapChain* apSwapChain, ID3D11Device* apDevice, ID3D11DeviceContext* apContext);
     void OnRender();
     void OnReset(IDXGISwapChain* apSwapChain);
 
 private:
     IDXGISwapChain* m_pSwapChain;
+    ID3D11Device* m_pDevice;
+    ID3D11DeviceContext* m_pDeviceContext;
+
     OverlayService& m_overlay;
     ImguiService& m_imguiService;
     size_t m_createConnection;


### PR DESCRIPTION
Prerequisite: https://github.com/tiltedphoques/TiltedUI/pull/17

Retrieving them from the swapchain is not the way and might cause unwanted side effects. This also fixes a crash with Community Shaders' Upscaling feature