### PR TITLE
Enable servers and clients to declare compatibility with public servers.

### DIFF
--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -69,7 +69,12 @@
 #include <inttypes.h>
 extern thread_local bool g_overrideFormId;
 
-constexpr char kBuildTag[] = "Build: " BUILD_COMMIT " " BUILD_BRANCH " EVO\nBuilt: " __TIMESTAMP__;
+#define COMPAT_STRING
+#ifdef COMPATIBLE_WITH_BUILD_COMMIT
+#define COMPAT_STRING "\nCompatible with protocol version " COMPATIBLE_WITH_BUILD_COMMIT
+#endif
+constexpr char kBuildTag[] = "Build: " BUILD_COMMIT " " BUILD_BRANCH " EVO\nBuilt: " __TIMESTAMP__ COMPAT_STRING;
+
 static void DrawBuildTag()
 {
     auto* pWindow = BSGraphics::GetMainWindow();

--- a/Code/client/Services/Generic/InputService.cpp
+++ b/Code/client/Services/Generic/InputService.cpp
@@ -1,4 +1,5 @@
 #include <TiltedOnlinePCH.h>
+#include <BranchInfo.h>
 
 #include <Services/InputService.h>
 #include <Services/OverlayService.h>
@@ -103,7 +104,11 @@ void SetUIActive(OverlayService& aOverlay, auto apRenderer, bool aActive)
     aOverlay.SetActive(aActive);
 
     // Ensures the game is actually loaded, in case the initial event was sent too early
+#ifdef COMPATIBLE_WITH_BUILD_COMMIT
+    aOverlay.SetVersion(COMPATIBLE_WITH_BUILD_COMMIT);
+#else
     aOverlay.SetVersion(BUILD_COMMIT);
+#endif
     aOverlay.GetOverlayApp()->ExecuteAsync("enterGame");
 
     apRenderer->SetCursorVisible(aActive);

--- a/Code/client/Services/Generic/OverlayService.cpp
+++ b/Code/client/Services/Generic/OverlayService.cpp
@@ -1,4 +1,5 @@
 #include <TiltedOnlinePCH.h>
+#include <BranchInfo.h>
 
 #include <Services/OverlayService.h>
 
@@ -217,7 +218,11 @@ void OverlayService::SetInGame(bool aInGame) noexcept
 
     if (m_inGame)
     {
+#ifdef COMPATIBLE_WITH_BUILD_COMMIT
+        SetVersion(COMPATIBLE_WITH_BUILD_COMMIT);
+#else
         SetVersion(BUILD_COMMIT);
+#endif
         m_pOverlay->ExecuteAsync("enterGame");
     }
     else

--- a/Code/client/Services/Generic/TransportService.cpp
+++ b/Code/client/Services/Generic/TransportService.cpp
@@ -1,4 +1,5 @@
 
+#include <BranchInfo.h>
 #include <Services/TransportService.h>
 
 #include <Events/ConnectedEvent.h>
@@ -112,7 +113,11 @@ void TransportService::OnConsume(const void* apData, uint32_t aSize)
 void TransportService::OnConnected()
 {
     AuthenticationRequest request{};
+#ifdef COMPATIBLE_WITH_BUILD_COMMIT
+    request.Version = COMPATIBLE_WITH_BUILD_COMMIT;
+#else
     request.Version = BUILD_COMMIT;
+#endif
     request.SKSEActive = IsScriptExtenderLoaded();
     request.MO2Active = GetModuleHandleW(kMO2DllName);
 
@@ -211,14 +216,18 @@ void TransportService::HandleAuthenticationResponse(const AuthenticationResponse
     // error finding
 
     TiltedPhoques::String ErrorInfo;
-
     ErrorInfo = "{";
+
+    TiltedPhoques::String protocolVersion{BUILD_COMMIT};
+#ifdef COMPATIBLE_WITH_BUILD_COMMIT
+    protocolVersion = COMPATIBLE_WITH_BUILD_COMMIT;
+#endif
 
     switch (acMessage.Type)
     {
     case AR::kWrongVersion:
         ErrorInfo += "\"error\": \"wrong_version\", \"data\": {";
-        ErrorInfo += fmt::format("\"expectedVersion\": \"{}\", \"version\": \"{}\"", acMessage.Version, BUILD_COMMIT);
+        ErrorInfo += fmt::format("\"expectedVersion\": \"{}\", \"protocolVersion\": \"{}\", \"version\": \"{}\"", acMessage.Version, protocolVersion, BUILD_COMMIT);
         ErrorInfo += "}";
         break;
     case AR::kModsMismatch:

--- a/Code/server/Services/ServerListService.cpp
+++ b/Code/server/Services/ServerListService.cpp
@@ -1,3 +1,4 @@
+#include <BranchInfo.h>
 #include <Events/PlayerJoinEvent.h>
 #include <Events/PlayerLeaveEvent.h>
 #include <Events/UpdateEvent.h>
@@ -75,7 +76,11 @@ void ServerListService::PostAnnouncement(String acName, String acDesc, String ac
                                          uint16_t aPlayerCount, uint16_t aPlayerMaxCount, String acTagList,
                                          bool aPublic, bool aPassword, int32 aFlags) noexcept
 {
+#ifdef COMPATIBLE_WITH_BUILD_COMMIT
+    const std::string kVersion{COMPATIBLE_WITH_BUILD_COMMIT};
+#else
     const std::string kVersion{BUILD_COMMIT};
+#endif
     const httplib::Params params{
         {"name", std::string(acName.c_str(), acName.size())},
         {"desc", std::string(acDesc.c_str(), acDesc.size())},

--- a/Code/skyrim_ui/src/assets/i18n/en.json
+++ b/Code/skyrim_ui/src/assets/i18n/en.json
@@ -162,7 +162,7 @@
     },
     "ERROR": {
       "ERRORS": {
-        "WRONG_VERSION": "This server expects version {{expectedVersion}} but you are on version {{version}}.",
+        "WRONG_VERSION": "This server requires protocol version {{expectedVersion}}\n but you are on protocol version {{protocolVersion}}, build {{version}}.\nUpdate your version or run the private server that comes with it.",
         "MODS_MISMATCH": "This server has ModPolicy enabled.{{mods}}",
         "MODS_MISMATCH_REMOVE": "Please remove the following mods to join:\n{{mods}}",
         "MODS_MISMATCH_INSTALL": "Please install the following mods to join:\n{{mods}}",

--- a/xmake.lua
+++ b/xmake.lua
@@ -83,6 +83,9 @@ before_build(function (target)
     bool_to_number[branch == "bluedove"], 
     bool_to_number[branch == "prerel"])
 
+    -- Comment out next line if incompatible with current release, or, fix compatibility version.
+    contents = contents .. "#if !IS_MASTER\n" .. "    #define COMPATIBLE_WITH_BUILD_COMMIT \"v1.8.0\"\n" .. "    #endif"
+
     -- fix always-compiles problem by updating the file only if content has changed.
     local filepath = "build/BranchInfo.h"
     local old_content = nil


### PR DESCRIPTION
Declare which public server version your new build can support in top-level xmake.lua. MASTER builds will never declare support for a different version.

You can also comment out the COMPATIBLE_WITH_BUILD_COMMIT line in xmake.lua to turn it off in other branches.