### PR TITLE
Remove `WasResized` hack in `OverlayService::Render`

### DIFF
--- a/Code/client/Services/Generic/OverlayService.cpp
+++ b/Code/client/Services/Generic/OverlayService.cpp
@@ -152,15 +152,6 @@ void OverlayService::Create(RenderSystemD3D11* apRenderSystem) noexcept
 
 void OverlayService::Render() noexcept
 {
-    // TODO: delete this hack?
-    static bool s_bi = false;
-    if (!s_bi)
-    {
-        m_pOverlay->GetClient()->GetBrowser()->GetHost()->WasResized();
-
-        s_bi = true;
-    }
-
     auto pPlayer = PlayerCharacter::Get();
     bool inGame = pPlayer && pPlayer->GetNiNode();
     if (inGame && !m_inGame)


### PR DESCRIPTION
Supposedly caused CEF crashes