### PR TITLE
prevent teammates from syncing QuestStop events for incomplete quests

### DIFF
--- a/Code/client/Services/Generic/QuestService.cpp
+++ b/Code/client/Services/Generic/QuestService.cpp
@@ -64,7 +64,7 @@ BSTEventResult QuestService::OnEvent(const TESQuestStartStopEvent* apEvent, cons
         if (IsNonSyncableQuest(pQuest))
             return BSTEventResult::kOk;
 
-        if(!m_world.Get().GetPartyService().IsLeader() && pQuest->IsStopped() && !pQuest->IsCompleted())
+        if(!m_world.Get().GetPartyService().IsLeader() && pQuest->IsStopped())
             return BSTEventResult::kOk;
      
         if (pQuest->type == TESQuest::Type::None || pQuest->type == TESQuest::Type::Miscellaneous)

--- a/Code/client/Services/Generic/QuestService.cpp
+++ b/Code/client/Services/Generic/QuestService.cpp
@@ -63,6 +63,9 @@ BSTEventResult QuestService::OnEvent(const TESQuestStartStopEvent* apEvent, cons
     {
         if (IsNonSyncableQuest(pQuest))
             return BSTEventResult::kOk;
+
+        if(!m_world.Get().GetPartyService().IsLeader() && pQuest->IsStopped() && !pQuest->IsCompleted())
+            return BSTEventResult::kOk;
      
         if (pQuest->type == TESQuest::Type::None || pQuest->type == TESQuest::Type::Miscellaneous)
         {


### PR DESCRIPTION
For example, in the Companions’ radiant quest “Trouble in Whiterun”—where the player is sent to break up a brawl in the streets—team members often misinterpret the fight’s outcome. Even when the Leader has successfully resolved the encounter (e.g., by making the aggressor yield), some teammates may incorrectly register the quest as failed on their end. As a result, they unintentionally synchronize a “stop quest” command back to the Leader, forcibly halting the Leader’s active quest and corrupting their progress.