### PR TITLE
Update to PR #727 better better multithread logging

### DIFF
--- a/Code/client/TiltedOnlineApp.cpp
+++ b/Code/client/TiltedOnlineApp.cpp
@@ -36,8 +36,6 @@ TiltedOnlineApp::TiltedOnlineApp()
     auto rotatingLogger = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logPath / "tp_client.log", 1048576 * 5, 3);
     // rotatingLogger->set_level(spdlog::level::debug);
     auto console = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    console->set_pattern("%^[%Y-%m-%d %H:%M:%S.%e] [%l] [tid %t] %$ %v");
-
     auto logger = std::make_shared<spdlog::logger>("", spdlog::sinks_init_list{console, rotatingLogger});
     logger->set_pattern("%^[%Y-%m-%d %H:%M:%S.%e] [%l] [tid %t] %$ %v");
     spdlog::flush_every(std::chrono::seconds(1));

--- a/Code/client/TiltedOnlineApp.cpp
+++ b/Code/client/TiltedOnlineApp.cpp
@@ -36,9 +36,11 @@ TiltedOnlineApp::TiltedOnlineApp()
     auto rotatingLogger = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logPath / "tp_client.log", 1048576 * 5, 3);
     // rotatingLogger->set_level(spdlog::level::debug);
     auto console = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    console->set_pattern("%^[%H:%M:%S.%e] [%l] [tid %t] %$ %v");
+    console->set_pattern("%^[%Y-%m-%d %H:%M:%S.%e] [%l] [tid %t] %$ %v");
 
     auto logger = std::make_shared<spdlog::logger>("", spdlog::sinks_init_list{console, rotatingLogger});
+    logger->set_pattern("%^[%Y-%m-%d %H:%M:%S.%e] [%l] [tid %t] %$ %v");
+    spdlog::flush_every(std::chrono::seconds(1));
     set_default_logger(logger);
 }
 

--- a/Code/server_runner/main.cpp
+++ b/Code/server_runner/main.cpp
@@ -65,9 +65,12 @@ struct LogInstance
 
         auto fileOut = std::make_shared<sinks::rotating_file_sink_mt>(std::string("logs/") + kLogFileName, kLogFileSizeCap, 3);
         auto serverOut = std::make_shared<sinks::stdout_color_sink_mt>();
-        serverOut->set_pattern("%^[%H:%M:%S.%e] [%l] [tid %t] %$ %v");
+        serverOut->set_pattern("%^[%Y-%m-%d %H:%M:%S.%e] [%l] [tid %t] %$ %v");
         auto globalOut = std::make_shared<logger>("", sinks_init_list{serverOut, fileOut});
+        globalOut->set_pattern("%^[%Y-%m-%d %H:%M:%S.%e] [%l] [tid %t] %$ %v");
+
         globalOut->set_level(level::from_str(sLogLevel.value()));
+        spdlog::flush_every(std::chrono::seconds(2));
 
         // as the library is compiled into the client + server we have to do this twice
         spdlog::set_default_logger(globalOut);

--- a/Code/server_runner/main.cpp
+++ b/Code/server_runner/main.cpp
@@ -65,7 +65,6 @@ struct LogInstance
 
         auto fileOut = std::make_shared<sinks::rotating_file_sink_mt>(std::string("logs/") + kLogFileName, kLogFileSizeCap, 3);
         auto serverOut = std::make_shared<sinks::stdout_color_sink_mt>();
-        serverOut->set_pattern("%^[%Y-%m-%d %H:%M:%S.%e] [%l] [tid %t] %$ %v");
         auto globalOut = std::make_shared<logger>("", sinks_init_list{serverOut, fileOut});
         globalOut->set_pattern("%^[%Y-%m-%d %H:%M:%S.%e] [%l] [tid %t] %$ %v");
 


### PR DESCRIPTION
Follow-on to PR #727

In addition to console window, make sure the file logs also contain the millisecond and thread ID.

Flushes server console log every 2 seconds.

Flushes client log on every log line at [info] or greater. This is to make sure that crash logs are up-to-date (or reasonably close).