### PR TITLE
Add "Clear stuck screen effects" to the F3 helpers menu

### DIFF
--- a/Code/client/Games/Skyrim/Forms/ImageSpaceModifierInstanceForm.h
+++ b/Code/client/Games/Skyrim/Forms/ImageSpaceModifierInstanceForm.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <NetImmerse/ImageSpaceModifierInstance.h>
+
+struct TESImageSpaceModifier;
+
+struct ImageSpaceModifierInstanceForm : public ImageSpaceModifierInstance
+{
+    static void Stop(TESImageSpaceModifier* apMod)
+    {
+        using TClearImageSpaceModifier = void(TESImageSpaceModifier*);
+        POINTER_SKYRIMSE(TClearImageSpaceModifier, s_clearImageSpaceModifier, 18573);
+        return s_clearImageSpaceModifier.Get()(apMod);
+    }
+
+    TESImageSpaceModifier* pMod;
+    uint64_t unk30;
+    float unk38;
+    uint32_t unk3C;
+    uint64_t unk40;
+    uint32_t unk48;
+};

--- a/Code/client/Games/Skyrim/Forms/TESImageSpaceModifier.h
+++ b/Code/client/Games/Skyrim/Forms/TESImageSpaceModifier.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <Forms/TESForm.h>
+
+struct TESImageSpaceModifier : TESForm
+{
+    ~TESImageSpaceModifier() override;
+
+    // ...fields
+};

--- a/Code/client/Games/Skyrim/NetImmerse/ImageSpaceModifierInstance.h
+++ b/Code/client/Games/Skyrim/NetImmerse/ImageSpaceModifierInstance.h
@@ -1,0 +1,30 @@
+#pragma once
+
+struct ImageSpaceModifierInstanceForm;
+struct NiAVObject;
+
+struct ImageSpaceModifierInstance : public NiObject
+{
+    ~ImageSpaceModifierInstance() override;
+
+    virtual bool Unk25(void);
+    virtual void Apply() = 0;
+    virtual ImageSpaceModifierInstanceForm* IsForm();
+    virtual void Unk28(void*) = 0;
+
+    uint32_t unk;
+    float strength;
+    NiPointer<NiAVObject> target;
+    float age;
+    uint32_t flags;
+
+    static void Stop(ImageSpaceModifierInstance* apMod)
+    {
+        using TClearImageSpaceModifier = void(ImageSpaceModifierInstance*);
+        POINTER_SKYRIMSE(TClearImageSpaceModifier, s_clearImageSpaceModifier, 18563);
+        return s_clearImageSpaceModifier.Get()(apMod);
+    }
+};
+
+static_assert(offsetof(ImageSpaceModifierInstance, target) == 0x18);
+static_assert(sizeof(ImageSpaceModifierInstance) == 0x28);

--- a/Code/client/Games/Skyrim/NetImmerse/NiPointer.h
+++ b/Code/client/Games/Skyrim/NetImmerse/NiPointer.h
@@ -32,5 +32,10 @@ template <class T> struct NiPointer
         return *this;
     }
 
+    [[nodiscard]] explicit constexpr operator bool() const noexcept
+    {
+        return static_cast<bool>(object);
+    }
+
     T* object;
 };

--- a/Code/client/Games/TES.h
+++ b/Code/client/Games/TES.h
@@ -6,6 +6,7 @@ struct TESWorldSpace;
 struct NiPoint3;
 struct TESForm;
 struct Actor;
+struct ImageSpaceModifierInstance;
 
 struct GridCellArray
 {
@@ -41,10 +42,16 @@ struct TES
     int32_t currentGridX;
     int32_t currentGridY;
     TESObjectCELL* interiorCell;
+    TESObjectCELL** interiorBuffer;
+    TESObjectCELL** exteriorBuffer;
+    uint8_t padD8[0x108 - 0xD8];
+    GameValueList<NiPointer<ImageSpaceModifierInstance>> activeImageSpaceModifiers;
 };
 
 static_assert(offsetof(TES, cells) == 0x78);
 static_assert(offsetof(TES, interiorCell) == 0xC0);
+static_assert(offsetof(TES, exteriorBuffer) == 0xD0);
+static_assert(offsetof(TES, activeImageSpaceModifiers) == 0x108);
 
 struct ProcessLists
 {

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -39,6 +39,8 @@
 
 #include <Forms/TESObjectCELL.h>
 #include <Forms/TESWorldSpace.h>
+#include <Forms/ImageSpaceModifierInstanceForm.h>
+#include <NetImmerse/ImageSpaceModifierInstance.h>
 #include <Games/TES.h>
 
 #include <AI/AIProcess.h>
@@ -288,6 +290,14 @@ void DebugService::OnDraw() noexcept
                     if (pRefr && pRefr->GetNiNode())
                         pRefr->StopCombat();
                 }
+            }
+        }
+
+        if (ImGui::Button("Clear stuck screen effects"))
+        {
+            for (const auto& modifier : TES::Get()->activeImageSpaceModifiers)
+            {
+                ImageSpaceModifierInstance::Stop(modifier.object);
             }
         }
         ImGui::EndMenu();


### PR DESCRIPTION
"Clear Imagespace Modifiers" is the technical term. This button can be used to quickly clear annoying imagespace modifiers that occasionally get stuck on in a save

Addresses (but not fixes) #835