### PR TITLE
Basic .clang-format fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@ BraceWrapping:
   IndentBraces: true
 BreakBeforeBraces: Allman
 BreakConstructorInitializers: BeforeComma
-ColumnLimit: 300
+ColumnLimit: 180
 IndentWidth: 4
 PenaltyBreakFirstLessLess: 300
 PointerAlignment: Left

--- a/Code/.clang-format
+++ b/Code/.clang-format
@@ -1,5 +1,0 @@
-﻿---
-BasedOnStyle: Microsoft
-PointerAlignment: Left
-
-...


### PR DESCRIPTION
Drop .clang-format ColumnLimit to 180 (from 300) so lines fit on less than an ultra-wide.
Delete incorrect .clang-format accidently committed years ago.