### PR TITLE
Several dialog & subtitle improvements in the way Scenes / Cutscenes …

### DIFF
--- a/Code/client/Games/Misc/SubtitleManager.cpp
+++ b/Code/client/Games/Misc/SubtitleManager.cpp
@@ -4,6 +4,7 @@
 
 #include <TESObjectREFR.h>
 #include <Games/ActorExtension.h>
+#include <Forms/TESQuest.h>
 
 #include <Forms/TESTopicInfo.h>
 #include <Misc/BSFixedString.h>
@@ -31,10 +32,8 @@ void* SubtitleManager::HideSubtitle(TESObjectREFR* apSpeaker) noexcept
 
 void TP_MAKE_THISCALL(HookShowSubtitle, SubtitleManager, TESObjectREFR* apSpeaker, const char* apSubtitleText, bool aIsInDialogue)
 {
-    // spdlog::debug("Subtitle for actor {:X} (bool {}):\n\t{}", apSpeaker ? apSpeaker->formID : 0, aIsInDialogue, apSubtitleText);
-
     Actor* pActor = Cast<Actor>(apSpeaker);
-    if (apSubtitleText && pActor && pActor->GetExtension()->IsLocal() && !pActor->GetExtension()->IsPlayer())
+    if (apSubtitleText && std::strlen(apSubtitleText) && pActor && !pActor->GetExtension()->IsPlayer())
         World::Get().GetRunner().Trigger(SubtitleEvent(apSpeaker->formID, apSubtitleText));
 
     TiltedPhoques::ThisCall(RealShowSubtitle, apThis, apSpeaker, apSubtitleText, aIsInDialogue);

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -6,6 +6,7 @@
 #include <DefaultObjectManager.h>
 #include <Forms/TESNPC.h>
 #include <Forms/TESFaction.h>
+#include <Forms/TESQuest.h>
 #include <Components/TESActorBaseData.h>
 #include <ExtraData/ExtraFactionChanges.h>
 #include <Games/Memory.h>
@@ -54,6 +55,8 @@
 #include <Forms/TESObjectARMO.h>
 
 #include <ModCompat/BehaviorVar.h>
+
+#include <World.h>
 
 #ifdef SAVE_STUFF
 
@@ -1189,7 +1192,7 @@ uint64_t TP_MAKE_THISCALL(HookProcessResponse, void, DialogueItem* apVoice, Acto
     if (apTalkingActor)
     {
         if (apTalkingActor->GetExtension()->IsRemotePlayer())
-            return 0;
+            return 0;  
     }
     return TiltedPhoques::ThisCall(RealProcessResponse, apThis, apVoice, apTalkingActor, apTalkedToActor);
 }
@@ -1210,32 +1213,82 @@ void TP_MAKE_THISCALL(HookUnequipObject, Actor, void* apUnk1, TESBoundObject* ap
     TiltedPhoques::ThisCall(RealUnequipObject, apThis, apUnk1, apObject, aUnk2, apUnk3);
 }
 
-TP_THIS_FUNCTION(TSpeakSoundFunction, bool, Actor, const char* apName, uint32_t* a3, uint32_t a4, uint32_t a5, uint32_t a6, uint64_t a7, uint64_t a8, uint64_t a9, bool a10, uint64_t a11, bool a12, bool a13, bool a14);
+TP_THIS_FUNCTION(TSpeakSoundFunction, float, Actor, const char* apName, uint32_t* a3, uint32_t a4, uint32_t a5, uint32_t a6, uint64_t a7, uint64_t a8, uint64_t a9, bool a10, uint64_t a11, bool a12, bool a13, bool a14);
 static TSpeakSoundFunction* RealSpeakSoundFunction = nullptr;
 
-bool TP_MAKE_THISCALL(HookSpeakSoundFunction, Actor, const char* apName, uint32_t* a3, uint32_t a4, uint32_t a5, uint32_t a6, uint64_t a7, uint64_t a8, uint64_t a9, bool a10, uint64_t a11, bool a12, bool a13, bool a14)
+float TP_MAKE_THISCALL(HookSpeakSoundFunction, Actor, const char* apName, uint32_t* a3, uint32_t a4, uint32_t a5, uint32_t a6, uint64_t a7, uint64_t a8, uint64_t a9, bool a10, uint64_t a11, bool a12, bool a13, bool a14)
 {
+    // Note most dialogues invoke SpeakSoundFunction twice, an initial call that queues it to an update thread, then a reinvocation.
+
     spdlog::debug("a3: {:X}, a4: {}, a5: {}, a6: {}, a7: {}, a8: {:X}, a9: {:X}, a10: {}, a11: {:X}, a12: {}, a13: {}, a14: {}", (uint64_t)a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
 
-    if (apThis->GetExtension()->IsLocal())
-        World::Get().GetRunner().Trigger(DialogueEvent(apThis->formID, apName));
-
+    World::Get().GetRunner().Trigger(DialogueEvent(apThis->formID, apName));
+    
     return TiltedPhoques::ThisCall(RealSpeakSoundFunction, apThis, apName, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
 }
 
-void Actor::SpeakSound(const char* pFile)
+float Actor::SpeakSound(const char* pFile)
 {
     uint32_t handle[3]{};
     handle[0] = -1;
-    TiltedPhoques::ThisCall(RealSpeakSoundFunction, this, pFile, handle, 0, 0x32, 0, 0, 0, 0, 0, 0, 0, 1, 1);
+
+    return TiltedPhoques::ThisCall(RealSpeakSoundFunction, this, pFile, handle, 0, 0x32, 0, 0, 0, 0, 0, 0, 0, 1, 1);
+}
+
+bool Actor::IsTalking() noexcept
+{
+    TP_THIS_FUNCTION(TIsTalking, bool, Actor);
+    POINTER_SKYRIMSE(TIsTalking, s_IsTalking, 37266);
+    return TiltedPhoques::ThisCall(s_IsTalking, this);
+}
+
+bool Actor::IsInScene() noexcept
+{
+    // We don't have a solution for Condition Functions
+    //PAPYRUS_FUNCTION(bool, Actor, IsInScene);
+    //bool papyrusValue = s_pIsInScene(this);
+    bool flagsValue= (flags1 & ActorBoolBits::kHasSceneExtra) != 0;
+
+    return flagsValue;
+}
+
+bool Actor::IsInDialogueWithPlayer() noexcept
+{
+    using ObjectReference = TESObjectREFR;
+    PAPYRUS_FUNCTION(bool, ObjectReference, IsInDialogueWithPlayer);
+    return s_pIsInDialogueWithPlayer(this);
+}
+
+float Actor::GetVoiceRecoveryTime() noexcept
+{
+    // Doesn't work. And Wiki only describes w.r.t shouts
+    // PAPYRUS_FUNCTION(float, Actor, GetVoiceRecoveryTime);
+    // float fVRT = s_pGetVoiceRecoveryTime(this);
+    // if (fVRT != fVoiceTimer)
+    //    spdlog::warn(__FUNCTION__ ": fVRT {}, fVoiceTimer {}", fVRT, fVoiceTimer);
+
+    return fVoiceTimer;
+}
+
+bool Actor::IsSpeakingInScene() 
+{
+    auto pScene = GetCurrentScene();
+    bool isSpeakingInScene = IsInScene(); 
+    isSpeakingInScene = isSpeakingInScene && GetVoiceRecoveryTime() > 0.0f;
+    const bool isTalking = IsTalking(); 
+    const bool isLeader = World::Get().GetPartyService().IsLeader(); // Helps distinguish logs in 2-party
+
+    spdlog::debug(__FUNCTION__ ": isSpeakingInScene {}, isTalking {}, voiceRecoveryTime {}, isLeader {}, formId {:X}, name {}", isSpeakingInScene, isTalking, GetVoiceRecoveryTime(), isLeader, formID, baseForm->GetName());
+
+    return isSpeakingInScene;
 }
 
 char TP_MAKE_THISCALL(HookActorProcess, Actor, float a2)
 {
-    // Don't process AI if we own the actor
+    // Only process AI if we own the actor
 
     if (apThis->GetExtension()->IsRemote())
-        return 0;
+            return 0;
 
     return TiltedPhoques::ThisCall(RealActorProcess, apThis, a2);
 }

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -210,6 +210,12 @@ struct Actor : TESObjectREFR
     [[nodiscard]] bool IsWearingBodyPiece() const noexcept;
     [[nodiscard]] bool ShouldWearBodyPiece() const noexcept;
     [[nodiscard]] bool IsVampireLord() const noexcept;
+    [[nodiscard]] bool IsTalking() noexcept;
+    [[nodiscard]] bool IsInScene() noexcept;
+    [[nodiscard]] bool IsInDialogueWithPlayer() noexcept;
+    [[nodiscard]] float GetVoiceRecoveryTime() noexcept;
+    [[nodiscard]] bool IsSpeakingInScene();
+
 
     // Setters
     void SetSpeed(float aSpeed) noexcept;
@@ -243,7 +249,7 @@ struct Actor : TESObjectREFR
     void PickUpObject(TESObjectREFR* apObject, int32_t aCount, bool aUnk1, float aUnk2) noexcept;
     void DropObject(TESBoundObject* apObject, ExtraDataList* apExtraData, int32_t aCount, NiPoint3* apLocation, NiPoint3* apRotation) noexcept;
     void DropOrPickUpObject(const Inventory::Entry& arEntry, NiPoint3* apPoint, NiPoint3* apRotate) noexcept;
-    void SpeakSound(const char* pFile);
+    float SpeakSound(const char* pFile);
     void StartCombatEx(Actor* apTarget) noexcept;
     void SetCombatTargetEx(Actor* apTarget) noexcept;
     void StartCombat(Actor* apTarget) noexcept;
@@ -251,6 +257,12 @@ struct Actor : TESObjectREFR
     bool PlayIdle(TESIdleForm* apIdle) noexcept;
     void FixVampireLordModel() noexcept;
     bool RemoveSpell(MagicItem* apSpell) noexcept;
+
+    enum ActorBoolBits
+    {
+        kNone = 0,
+        kHasSceneExtra = 1 << 3,
+    };
 
     enum ActorFlags
     {

--- a/Code/client/Games/Skyrim/Forms/TESQuest.h
+++ b/Code/client/Games/Skyrim/Forms/TESQuest.h
@@ -9,7 +9,20 @@ struct BGSScene : TESForm
 {
     GameArray<void*> phases;
     GameArray<uint32_t> actorIds;
+    GameArray<uint32_t> actorFlags;
+    GameArray<uint32_t> actorProgressionFlags;
+    GameArray<BGSSceneAction*> actions;
+    TESQuest* owningQuest;
+    uint32_t flags;
+    uint32_t padA4;
+    TESCondition conditions;
+    bool isPlaying;
+
+    void ScriptForceStart();
+    void ScriptStop();
 };
+static_assert(offsetof(BGSScene, owningQuest) == 0x98);
+static_assert(offsetof(BGSScene, isPlaying) == 0xB0);
 
 struct TESQuest : BGSStoryManagerTreeForm
 {

--- a/Code/client/Games/Skyrim/TESObjectREFR.h
+++ b/Code/client/Games/Skyrim/TESObjectREFR.h
@@ -17,6 +17,7 @@ struct AnimationVariables;
 struct TESWorldSpace;
 struct TESBoundObject;
 struct TESContainer;
+struct BGSScene;
 
 enum class ITEM_REMOVE_REASON
 {
@@ -78,7 +79,7 @@ struct TESObjectREFR : TESForm
     virtual void sub_47();
     virtual void sub_48();
     virtual void sub_49();
-    virtual void sub_4A();
+    virtual BGSScene* GetCurrentScene();
     virtual void sub_4B();
     virtual void sub_4C();
     virtual void sub_4D();

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -515,7 +515,7 @@ void CharacterService::OnRemoteSpawnDataReceived(const NotifySpawnData& acMessag
         {
             if (auto serverId = Utils::GetServerId(entity))
             {
-                if (*serverId == id)
+                if (serverId.has_value() && serverId.value() == id)
                     return true;
             }
             return false;
@@ -920,43 +920,100 @@ void CharacterService::OnDialogueEvent(const DialogueEvent& acEvent) noexcept
     if (!m_transport.IsConnected())
         return;
 
+    const bool isLeader = World::Get().GetPartyService().IsLeader(); // Helps distinguish in 2-party logs
     auto view = m_world.view<FormIdComponent>(entt::exclude<ObjectComponent>);
-    auto entityIt = std::find_if(view.begin(), view.end(), [view, formId = acEvent.ActorID](auto entity) { return view.get<FormIdComponent>(entity).Id == formId; });
+    auto entityIt = std::find_if(view.begin(), view.end(), [view, formId = acEvent.ActorID](auto entity) {
+        return view.get<FormIdComponent>(entity).Id == formId;
+    });
 
     if (entityIt == view.end())
+    {
+        spdlog::debug(__FUNCTION__ ": failed to find speaking Actor's FormIdComponent, formId {:X}, isLeader {}", acEvent.ActorID, isLeader);
         return;
+    }
 
     auto serverIdRes = Utils::GetServerId(*entityIt);
     if (!serverIdRes)
     {
-        spdlog::error("{}: server id not found for form id {:X}", __FUNCTION__, acEvent.ActorID);
+        spdlog::debug(__FUNCTION__ ": server id not found for formId {:X}, isLeader {}", acEvent.ActorID, isLeader);
         return;
     }
+    
+    Actor* pActor = Cast<Actor>(TESForm::GetById(acEvent.ActorID));
+    if (!pActor)
+        return;
 
-    DialogueRequest request{};
-    request.ServerId = serverIdRes.value();
-    request.SoundFilename = acEvent.VoiceFile;
+    bool isLocal = pActor->GetExtension()->IsLocal();
+    bool isInScene = pActor->IsInScene();
+    auto sceneId = isInScene ? pActor->GetCurrentScene()->formID : 0;
+    bool isTaskDialogue = pActor->IsTalking() && pActor->IsInDialogueWithPlayer();
+    bool isSpeakingInScene = pActor->IsSpeakingInScene();
 
-    m_transport.Send(request);
+    // There's no good way to distinguish the goodbye line 
+    // from the  first line of the scene, so disable this.
+    bool repairEdgeCase = false;
+#if 0
+    // Fix the edge case, "goodbye line" of TaskDialogue
+    static Actor* plastDialogueActor = nullptr;
+    static bool lastIsInDialogueWithPlayer = false;
+    bool repairEdgeCase = (pActor == plastDialogueActor) && lastIsInDialogueWithPlayer;
+
+    if (repairEdgeCase)
+    {
+        plastDialogueActor = nullptr;
+        lastIsInDialogueWithPlayer = false;
+    }
+
+    else if (isTaskDialogue)
+    {
+        plastDialogueActor = pActor;
+        lastIsInDialogueWithPlayer = true;
+    }
+#endif
+
+    const bool willSync = isTaskDialogue || repairEdgeCase || isLocal && !isInScene;
+
+    spdlog::debug(
+        __FUNCTION__ ": isLocal {}, isInScene {}, isSpeakingInScene {}, isTaskDialogue {} repaireEdgeCase {}, willSync {}, scene {:X}, Actor "
+                     "{:X}, serverId {:X}, isLeader {}, name {}, soundFile {}",
+        isLocal, isInScene, isSpeakingInScene, isTaskDialogue, repairEdgeCase, willSync, sceneId, pActor->formID, serverIdRes.value(), isLeader, pActor->baseForm->GetName(),
+        acEvent.VoiceFile);
+
+    if (willSync)
+    {
+        DialogueRequest request{};
+        request.ServerId = serverIdRes.value();
+        request.SoundFilename = acEvent.VoiceFile;
+
+        m_transport.Send(request);
+    }
 }
 
 void CharacterService::OnNotifyDialogue(const NotifyDialogue& acMessage) noexcept
 {
-    auto remoteView = m_world.view<RemoteComponent, FormIdComponent>();
-    const auto remoteIt = std::find_if(std::begin(remoteView), std::end(remoteView), [remoteView, Id = acMessage.ServerId](auto entity) { return remoteView.get<RemoteComponent>(entity).Id == Id; });
+    const bool isLeader = World::Get().GetPartyService().IsLeader(); // Helps distinguish in 2-party logs
+    auto view = m_world.view<FormIdComponent>(entt::exclude<ObjectComponent>);
+    auto viewIt = std::find_if(
+        view.begin(), view.end(),
+        [view, id = acMessage.ServerId](auto entity)
+        {
+            auto serverId = Utils::GetServerId(entity);
+            return serverId.has_value() && serverId.value() == id;
+        });
 
-    if (remoteIt == std::end(remoteView))
+    if (viewIt == view.end())
     {
-        spdlog::warn("Actor for dialogue with remote id {:X} not found.", acMessage.ServerId);
+        spdlog::debug(__FUNCTION__ ": failed to find speaking Actor's FormIdComponent, serverId {:X}, isLeader {}", acMessage.ServerId, isLeader);
         return;
     }
 
-    auto formIdComponent = remoteView.get<FormIdComponent>(*remoteIt);
-    const TESForm* pForm = TESForm::GetById(formIdComponent.Id);
-    Actor* pActor = Cast<Actor>(pForm);
-
+    Actor* pActor = Cast<Actor>(TESForm::GetById(view.get<FormIdComponent>(*viewIt).Id));
     if (!pActor)
         return;
+
+    spdlog::debug(
+        __FUNCTION__ ": playing dialogue Actor {:X}, serverId {:X}, isLeader {}, name {}, soundFile {}", pActor->formID, acMessage.ServerId, isLeader, pActor->baseForm->GetName(),
+        acMessage.SoundFilename);
 
     pActor->StopCurrentDialogue(true);
     pActor->SpeakSound(acMessage.SoundFilename.c_str());
@@ -967,42 +1024,92 @@ void CharacterService::OnSubtitleEvent(const SubtitleEvent& acEvent) noexcept
     if (!m_transport.IsConnected())
         return;
 
+    const bool isLeader = World::Get().GetPartyService().IsLeader(); // Helps distinguish in 2-party logs
     auto view = m_world.view<FormIdComponent>(entt::exclude<ObjectComponent>);
     auto entityIt = std::find_if(view.begin(), view.end(), [view, formId = acEvent.SpeakerID](auto entity) { return view.get<FormIdComponent>(entity).Id == formId; });
 
     if (entityIt == view.end())
+    {
+        spdlog::debug(__FUNCTION__ ": failed to find subtitle Actor's FormIdComponent, formId {:X}, isLeader {}", acEvent.SpeakerID, isLeader);
         return;
+    }
 
     auto serverIdRes = Utils::GetServerId(*entityIt);
     if (!serverIdRes)
     {
-        spdlog::error("{}: server id not found for form id {:X}", __FUNCTION__, acEvent.SpeakerID);
+        spdlog::debug(__FUNCTION__ ": server id not found for formId {:X}, isLeader {}", acEvent.SpeakerID, isLeader);
         return;
     }
 
-    SubtitleRequest request{};
-    request.ServerId = serverIdRes.value();
-    request.Text = acEvent.Text;
-    request.TopicFormId = acEvent.TopicFormID;
+    Actor* pActor = Cast<Actor>(TESForm::GetById(acEvent.SpeakerID));
+    if (!pActor)
+        return;
 
-    m_transport.Send(request);
+    bool isLocal = pActor->GetExtension()->IsLocal();
+    bool isInScene = pActor->IsInScene();
+    auto isSpeakingInScene = pActor->IsSpeakingInScene();
+    auto sceneId = isInScene ? pActor->GetCurrentScene()->formID : 0;
+    bool isTaskDialogue = pActor->IsTalking() && pActor->IsInDialogueWithPlayer();
+
+    // There's no good way to distinguish the goodbye line
+    // from the  first line of the scene, so disable this.
+    bool repairEdgeCase = false;
+#if 0
+    // Fix the edge case, "goodbye line" of TaskDialogue
+    static Actor* plastDialogueActor = nullptr;
+    static bool lastIsInDialogueWithPlayer = false;
+    bool repairEdgeCase = (pActor == plastDialogueActor) && lastIsInDialogueWithPlayer;
+
+    if (repairEdgeCase)
+    {
+        plastDialogueActor = nullptr;
+        lastIsInDialogueWithPlayer = false;
+    }
+
+    else if (isTaskDialogue)
+    {
+        plastDialogueActor = pActor;
+        lastIsInDialogueWithPlayer = true;
+    }
+#endif
+
+    const bool willSync = isTaskDialogue || repairEdgeCase || isLocal && !isInScene;
+
+    spdlog::debug(
+        __FUNCTION__ ": isLocal {}, isInScene {}, isSpeakingInScene {}, isTaskDialogue {} repaireEdgeCase {}, willSync {}, scene {:X}, Actor "
+                     "{:X}, serverId {:X}, isLeader {}, name {}, subtitle {}",
+        isLocal, isInScene, isSpeakingInScene, isTaskDialogue, repairEdgeCase, willSync, sceneId, pActor->formID, serverIdRes.value(), isLeader, pActor->baseForm->GetName(),
+        acEvent.Text);
+
+    if (willSync)
+    {
+        SubtitleRequest request{};
+        request.ServerId = serverIdRes.value();
+        request.Text = acEvent.Text;
+        request.TopicFormId = acEvent.TopicFormID;
+        m_transport.Send(request);
+    }
 }
 
 void CharacterService::OnNotifySubtitle(const NotifySubtitle& acMessage) noexcept
 {
-    auto remoteView = m_world.view<RemoteComponent, FormIdComponent>();
-    const auto remoteIt = std::find_if(std::begin(remoteView), std::end(remoteView), [remoteView, Id = acMessage.ServerId](auto entity) { return remoteView.get<RemoteComponent>(entity).Id == Id; });
+    const bool isLeader = m_world.Get().GetPartyService().IsLeader();
+    auto view = m_world.view<FormIdComponent>(entt::exclude<ObjectComponent>);
+    auto viewIt = std::find_if(
+        view.begin(), view.end(),
+        [view, id = acMessage.ServerId](auto entity)
+        {
+            auto serverId = Utils::GetServerId(entity);
+            return serverId.has_value() && serverId.value() == id;
+        });
 
-    if (remoteIt == std::end(remoteView))
+    if (viewIt == view.end())
     {
-        spdlog::warn("Actor for dialogue with remote id {:X} not found.", acMessage.ServerId);
+        spdlog::debug(__FUNCTION__ ": failed to find subtitle Actor's FormIdComponent, serverId {:X}, isLeader {}", acMessage.ServerId, isLeader);
         return;
     }
 
-    auto formIdComponent = remoteView.get<FormIdComponent>(*remoteIt);
-    const TESForm* pForm = TESForm::GetById(formIdComponent.Id);
-    Actor* pActor = Cast<Actor>(pForm);
-
+    Actor* pActor = Cast<Actor>(TESForm::GetById(view.get<FormIdComponent>(*viewIt).Id));
     if (!pActor)
         return;
 
@@ -1010,6 +1117,10 @@ void CharacterService::OnNotifySubtitle(const NotifySubtitle& acMessage) noexcep
     TESTopicInfo* pInfo = nullptr;
     pInfo = Cast<TESTopicInfo>(TESForm::GetById(acMessage.TopicFormId));
 
+    spdlog::debug(__FUNCTION__ ": showing subtitle Actor {:X}, serverId {:X}, isLeader {}, name {}, message: {}",
+                     pActor->formID, acMessage.ServerId, isLeader, pActor->baseForm->GetName(), acMessage.Text);
+
+    SubtitleManager::Get()->HideSubtitle(pActor);   // Subtitle conflicts can hang, this makes it beter at least.
     SubtitleManager::Get()->ShowSubtitle(pActor, acMessage.Text.c_str(), pInfo);
 }
 

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -949,34 +949,12 @@ void CharacterService::OnDialogueEvent(const DialogueEvent& acEvent) noexcept
     bool isTaskDialogue = pActor->IsTalking() && pActor->IsInDialogueWithPlayer();
     bool isSpeakingInScene = pActor->IsSpeakingInScene();
 
-    // There's no good way to distinguish the goodbye line 
-    // from the  first line of the scene, so disable this.
-    bool repairEdgeCase = false;
-#if 0
-    // Fix the edge case, "goodbye line" of TaskDialogue
-    static Actor* plastDialogueActor = nullptr;
-    static bool lastIsInDialogueWithPlayer = false;
-    bool repairEdgeCase = (pActor == plastDialogueActor) && lastIsInDialogueWithPlayer;
-
-    if (repairEdgeCase)
-    {
-        plastDialogueActor = nullptr;
-        lastIsInDialogueWithPlayer = false;
-    }
-
-    else if (isTaskDialogue)
-    {
-        plastDialogueActor = pActor;
-        lastIsInDialogueWithPlayer = true;
-    }
-#endif
-
-    const bool willSync = isTaskDialogue || repairEdgeCase || isLocal && !isInScene;
+    const bool willSync = isTaskDialogue || isLocal && !isInScene;
 
     spdlog::debug(
-        __FUNCTION__ ": isLocal {}, isInScene {}, isSpeakingInScene {}, isTaskDialogue {} repaireEdgeCase {}, willSync {}, scene {:X}, Actor "
+        __FUNCTION__ ": isLocal {}, isInScene {}, isSpeakingInScene {}, isTaskDialogue {}, willSync {}, scene {:X}, Actor "
                      "{:X}, serverId {:X}, isLeader {}, name {}, soundFile {}",
-        isLocal, isInScene, isSpeakingInScene, isTaskDialogue, repairEdgeCase, willSync, sceneId, pActor->formID, serverIdRes.value(), isLeader, pActor->baseForm->GetName(),
+        isLocal, isInScene, isSpeakingInScene, isTaskDialogue, willSync, sceneId, pActor->formID, serverIdRes.value(), isLeader, pActor->baseForm->GetName(),
         acEvent.VoiceFile);
 
     if (willSync)
@@ -1051,34 +1029,12 @@ void CharacterService::OnSubtitleEvent(const SubtitleEvent& acEvent) noexcept
     auto sceneId = isInScene ? pActor->GetCurrentScene()->formID : 0;
     bool isTaskDialogue = pActor->IsTalking() && pActor->IsInDialogueWithPlayer();
 
-    // There's no good way to distinguish the goodbye line
-    // from the  first line of the scene, so disable this.
-    bool repairEdgeCase = false;
-#if 0
-    // Fix the edge case, "goodbye line" of TaskDialogue
-    static Actor* plastDialogueActor = nullptr;
-    static bool lastIsInDialogueWithPlayer = false;
-    bool repairEdgeCase = (pActor == plastDialogueActor) && lastIsInDialogueWithPlayer;
-
-    if (repairEdgeCase)
-    {
-        plastDialogueActor = nullptr;
-        lastIsInDialogueWithPlayer = false;
-    }
-
-    else if (isTaskDialogue)
-    {
-        plastDialogueActor = pActor;
-        lastIsInDialogueWithPlayer = true;
-    }
-#endif
-
-    const bool willSync = isTaskDialogue || repairEdgeCase || isLocal && !isInScene;
+    const bool willSync = isTaskDialogue || isLocal && !isInScene;
 
     spdlog::debug(
-        __FUNCTION__ ": isLocal {}, isInScene {}, isSpeakingInScene {}, isTaskDialogue {} repaireEdgeCase {}, willSync {}, scene {:X}, Actor "
+        __FUNCTION__ ": isLocal {}, isInScene {}, isSpeakingInScene {}, isTaskDialogue {}, willSync {}, scene {:X}, Actor "
                      "{:X}, serverId {:X}, isLeader {}, name {}, subtitle {}",
-        isLocal, isInScene, isSpeakingInScene, isTaskDialogue, repairEdgeCase, willSync, sceneId, pActor->formID, serverIdRes.value(), isLeader, pActor->baseForm->GetName(),
+        isLocal, isInScene, isSpeakingInScene, isTaskDialogue, willSync, sceneId, pActor->formID, serverIdRes.value(), isLeader, pActor->baseForm->GetName(),
         acEvent.Text);
 
     if (willSync)


### PR DESCRIPTION
…work in a party.

Updated PR with a new approach that syncs better. Turned down all the logging for release.

If the cutscene design is that all party members (or all inrange) play the scene, the Leader's dialog sync would step on and cancel the copies running in the party members. This would mess up the scene phase timing, causing the members to race ahead and abort actions of the Leader, potentially hanging the scene. Found with the Finn/Carbos scene in Enderal.

If the cutscene design is only the person(s) who trigger the scene play the scene, and the scene is triggered by a non-Leader, no one except the scene-initiator got any dialog. This is an uncommon case; usually the start of a scene triggers a quest stage change that brings everyone into the scene, or the scene is just random encounter / idle chatter that is just fine to sync to just the triggering player.

Because scenes that don't trigger quest stage changes but also would be desirable to sync are rare, and because there is no good way to distinguish them from scenes where syncing the audio will cause dialog cancels and timing problems, this case is left as unsolved, have to live with it.

There is some logic in the quest sync PR #848 to trigger scenes in the rest of the party when one starts the scene. This solves some cases. In others, there are scene start conditions that just stop the scene again. Best known example is the Companions Brotherhood quest stage C02. Unless the entire party stands on the tiny hotspot where the initiator triggers the scene, it just stops again.

It's not perfect, but the selected (surviving experiment) solution is:
1) Try to trigger the scene for  the entire party, which often works.
2) Each party member plays the scene to themselves, generally with decent audio sync. The party Leader is still controlling the NPCs and motion / animation sync handles most cases.
3) If the scene triggers TaskDialogues (those NPC dialogues where you answer with a menu pick), that dialog is individual to the SceneMaster (they who triggered), so that is synced to party (PlayersInRange).
4) Only flaw known is AI packages.

Subtitle sync follows the same rules as Dialogue sync.

AI package handling is left for a future iteration, since it also is tricky. Current state: AI packages only run on Leader, so if Member triggers a scene, the AI packages doesn't run. If it is anything of consequence (more than "look at player", say, having to do something and then interact with player), the scene will get stuck and Leader will have to take over. If Leader is close, NPC will just switch to Leader. If farther away or not in scene, Leader will have to get closer, possibly having to unlock the Leader with the EPC (EnablePlayerControls) console command.

For the next round, the two big options I see for fixing AI is for
1. SceneMaster to take ownership of NPCs in-scene. They can be released at end of scene, or just wait for a cell change. This will solve the scene getting stuck problem, but not the dialog sync problem.
2. Find a way to reactivate AI on "remote" NPCs for the duration of the scene, This sounds more fragile, but since everyone is playing the scene again, dialogue will sync.
3. Switch model to "everyone listens to SceneMaster." This combines the first option with changing the dialog sync so the scene ONLY plays on the SceneMaster, and diaglog / motion / animation is synced as usual from the NPC owner. This one is fragile because the way Skyrim works the scene is often started on all players, and trying to stop / interrupt it is sure to cause new issues.

Thanks to @miredirex and @powerof3  CommonLibSSE for help with some of the RE:: trickery.

This was extracted from a bigger PR #848 in the works, so draft until we get a bit more mileage using this version.