### PR TITLE
Slow effect is player-specific, should not sync.

### DIFF
--- a/Code/client/Games/Skyrim/Magic/MagicTarget.cpp
+++ b/Code/client/Games/Skyrim/Magic/MagicTarget.cpp
@@ -68,7 +68,7 @@ bool MagicTarget::AddTargetData::IsForbiddenEffect(Actor* apTarget)
     if (apTarget != PlayerCharacter::Get())
         return false;
 
-    return pEffectItem->IsNightVisionEffect();
+    return pEffectItem->IsNightVisionEffect() || pEffectItem->IsSlowEffect();
 }
 
 Actor* MagicTarget::GetTargetAsActor()


### PR DESCRIPTION
From @miredirex. A one-line fix to not sync SlowEffect.