### PR TITLE
Flush all spdlog loggers before processing crash exit

### DIFF
--- a/Code/client/CrashHandler.cpp
+++ b/Code/client/CrashHandler.cpp
@@ -101,7 +101,7 @@ LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
             }
         }
 
-        spdlog::default_logger()->flush();
+        spdlog::shutdown();
 
         // Something in STR breaks top-level unhandled exception filters.
         // The Win API for them is pretty clunky (non-atomic, not chainable), 


### PR DESCRIPTION
According to spdlog:: docs, invoking spdlog::shutdown() before continuing to the crash exit will flush all logs synchronously before returning.