### PR TITLE
IsSlowTime fix caster, not target

### DIFF
--- a/Code/client/Services/Generic/MagicService.cpp
+++ b/Code/client/Services/Generic/MagicService.cpp
@@ -408,6 +408,15 @@ void MagicService::OnNotifyAddTarget(const NotifyAddTarget& acMessage) noexcept
         return;
     }
 
+    // This hack is here because slow time seems to be twice as slow when cast by an npc
+    if (pEffect->IsSlowEffect())
+    {
+        acMessage.CasterId && (pCaster = PlayerCharacter::Get());
+        spdlog::debug(
+            __FUNCTION__ ": hacking IsSlowEffect() targetId {:X}, casterId {:X}, magnitude {}, IsDualCasting {}", acMessage.TargetId, acMessage.CasterId, acMessage.Magnitude,
+            acMessage.IsDualCasting);
+    }
+
     MagicTarget::AddTargetData data{};
     data.pCaster = pCaster;
     data.pSpell = pSpell;
@@ -422,10 +431,6 @@ void MagicService::OnNotifyAddTarget(const NotifyAddTarget& acMessage) noexcept
 
     if (pEffect->IsVampireLordEffect())
         pActor->GetExtension()->GraphDescriptorHash = AnimationGraphDescriptor_VampireLordBehavior::m_key;
-
-    // This hack is here because slow time seems to be twice as slow when cast by an npc
-    if (pEffect->IsSlowEffect())
-        pActor = PlayerCharacter::Get();
 
     pActor->magicTarget.AddTarget(data, acMessage.ApplyHealPerkBonus, acMessage.ApplyStaminaPerkBonus);
     spdlog::debug("Applied remote magic effect");


### PR DESCRIPTION
A fix to a prior fix, which observed SlowEffect was doubled if cast by an NPC. 
Bug was changing TargetId instead of the CasterId. It does the latter now.