### PR TITLE
Several fixes for naked NPCs

### DIFF
--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -17,9 +17,11 @@ struct ActorExtension
     bool IsLocalPlayer() const noexcept;
     void SetRemote(bool aSet) noexcept;
     void SetPlayer(bool aSet) noexcept;
+    void SetNakedDeadline() noexcept { nakedDeadline = std::chrono::steady_clock::now();  }
 
     ActionEvent LatestAnimation{};
     size_t GraphDescriptorHash = 0;
+    std::chrono::steady_clock::time_point nakedDeadline{};
 
   private:
     uint32_t onlineFlags{0};

--- a/Code/client/Games/PapyrusFunctions.cpp
+++ b/Code/client/Games/PapyrusFunctions.cpp
@@ -7,8 +7,6 @@ namespace PapyrusFunctions
 
 bool IsRemotePlayer(Actor* apActor)
 {
-    spdlog::info("Calling IsRemotePlayer");
-
     auto* pExtension = apActor->GetExtension();
     if (!pExtension)
         return false;

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -520,6 +520,50 @@ bool Actor::ShouldWearBodyPiece() const noexcept
     return false;
 }
 
+void Actor::SetOutfit(BGSOutfit* apOutfit, bool aIsSleepOutfit) 
+{
+    PAPYRUS_FUNCTION(void, Actor, SetOutfit, const BGSOutfit*, bool);
+    s_pSetOutfit(this, apOutfit, aIsSleepOutfit);
+}
+
+void Actor::EquipOutfit(bool aIsSleepOutfit) noexcept
+{
+    auto* pBase = Cast<TESNPC>(baseForm);
+    if (!pBase)
+        return;
+
+    BGSOutfit* pDefaultOutfit = pBase->outfits[aIsSleepOutfit ? 1:0];
+    if (!pDefaultOutfit)
+        return;
+
+    auto* pEquipManager = EquipManager::Get();
+    for (auto* pItem : pDefaultOutfit->outfitItems)
+    {
+        TESObjectARMO* pArmor = nullptr;
+
+        if (pItem->formType == FormType::Armor)
+            pArmor = Cast<TESObjectARMO>(pItem);
+        else if (pItem->formType == FormType::LeveledItem)
+        {
+            TESLevItem* pLevItem = Cast<TESLevItem>(pItem);
+            if (!pLevItem || !pLevItem->pLeveledListA || !pLevItem->pLeveledListA->pForm)
+                continue;
+
+            pArmor = Cast<TESObjectARMO>(pLevItem->pLeveledListA->pForm);
+        }
+        else
+            continue;
+
+        if (!pArmor)
+            continue;
+
+        spdlog::debug(__FUNCTION__ ": equipping {:X} on actor {:X} {}", pArmor->formID, formID, baseForm->GetName());
+        pEquipManager->Equip(this, pArmor, nullptr, 1, nullptr, false, true, false, false);  
+    }
+
+    return;
+}
+
 // Get owner of a summon or raised corpse
 Actor* Actor::GetCommandingActor() const noexcept
 {

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -22,6 +22,7 @@ struct ActorExtension;
 struct AIProcess;
 struct CombatController;
 struct TESIdleForm;
+struct BGSOutfit;
 
 struct Actor : TESObjectREFR
 {
@@ -251,6 +252,8 @@ struct Actor : TESObjectREFR
     bool PlayIdle(TESIdleForm* apIdle) noexcept;
     void FixVampireLordModel() noexcept;
     bool RemoveSpell(MagicItem* apSpell) noexcept;
+    void SetOutfit(BGSOutfit* apOutfit, bool aIsSleepOutfit = false);
+    void EquipOutfit(bool aIsSleepOutfit = false) noexcept;
 
     enum ActorFlags
     {

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -142,6 +142,7 @@ bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acS
     }
 
     pExtension->SetRemote(false);
+    pExtension->SetNakedDeadline();
 
     // TODO(cosideci): this should be done differently.
     // Send an ownership claim request, and have the server broadcast the result.
@@ -287,7 +288,7 @@ void CharacterService::OnDisconnected(const DisconnectedEvent& acDisconnectedEve
 
 void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessage) noexcept
 {
-    spdlog::info("Received for cookie {:X}, server id {:X}", acMessage.Cookie, acMessage.ServerId);
+    spdlog::info(__FUNCTION__ ": Received for cookie {:X}, server id {:X}", acMessage.Cookie, acMessage.ServerId);
 
     auto view = m_world.view<WaitingForAssignmentComponent>();
     const auto itor = std::find_if(std::begin(view), std::end(view), [view, cookie = acMessage.Cookie](auto entity) { return view.get<WaitingForAssignmentComponent>(entity).Cookie == cookie; });
@@ -327,7 +328,7 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
 
     if (acMessage.Owner)
     {
-        spdlog::info("Received local actor, form id: {:X}", pActor->formID);
+        spdlog::info(__FUNCTION__ ": received local actor, form id: {:X}, {}", pActor->formID, pActor->baseForm->GetName());
 
         m_world.emplace_or_replace<LocalComponent>(cEntity, acMessage.ServerId);
         auto& localAnimationComponent = m_world.emplace_or_replace<LocalAnimationComponent>(cEntity);
@@ -345,7 +346,7 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
     }
     else
     {
-        spdlog::info("Received remote actor, form id: {:X}, isweapondrawn: {}", pActor->formID, acMessage.IsWeaponDrawn);
+        spdlog::info(__FUNCTION__ ": received remote actor, form id: {:X}, isweapondrawn: {}, {}", pActor->formID, acMessage.IsWeaponDrawn, pActor->baseForm->GetName());
 
         m_world.emplace_or_replace<RemoteComponent>(cEntity, acMessage.ServerId, formIdComponent->Id);
 
@@ -370,6 +371,7 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
 
         MoveActor(pActor, acMessage.WorldSpaceId, acMessage.CellId, acMessage.Position);
     }
+    pActor->GetExtension()->SetNakedDeadline();
 }
 
 void CharacterService::OnCharacterSpawn(const CharacterSpawnRequest& acMessage) const noexcept
@@ -1292,7 +1294,8 @@ void CharacterService::RequestServerAssignment(const entt::entity aEntity) const
     message.LatestAction = pExtension->LatestAnimation;
     pActor->SaveAnimationVariables(message.LatestAction.Variables);
 
-    spdlog::info("Request id: {:X}, cookie: {:X}, entity: {:X}", formIdComponent.Id, sCookieSeed, to_integral(aEntity));
+    const bool isLeader = m_world.Get().GetPartyService().IsLeader(); // Distinguish logs in 2-party      
+    spdlog::info(__FUNCTION__ ": request id: {:X}, cookie: {:X}, entity: {:X}, isLeader: {}", formIdComponent.Id, sCookieSeed, to_integral(aEntity), isLeader);
 
     if (m_transport.Send(message))
     {
@@ -1304,10 +1307,11 @@ void CharacterService::RequestServerAssignment(const entt::entity aEntity) const
 
 void CharacterService::CancelServerAssignment(const entt::entity aEntity, const uint32_t aFormId) const noexcept
 {
+    Actor* pActor = Cast<Actor>(TESForm::GetById(aFormId));
+    const char* pName = !pActor ? "" : pActor->baseForm->GetName();
+
     if (m_world.all_of<RemoteComponent>(aEntity))
     {
-        Actor* pActor = Cast<Actor>(TESForm::GetById(aFormId));
-
         if (pActor)
         {
             if (pActor->IsTemporary())
@@ -1322,8 +1326,6 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
         }
 
         DeleteRemoteEntityComponents(aEntity);
-
-        return;
     }
 
     // In the event we were waiting for assignment, drop it
@@ -1346,7 +1348,7 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
         RequestOwnershipTransfer request{};
         request.ServerId = localComponent.Id;
 
-        if (Actor* pActor = Cast<Actor>(TESForm::GetById(aFormId)))
+        if (pActor)
         {
             if (!pActor->IsTemporary())
             {
@@ -1368,15 +1370,19 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
             }
         }
 
+
         spdlog::info(
-            "Transferring ownership of local actor, server id: {:X}, worldspace: {:X}, cell: {:X}, position: "
-            "({}, {}, {})",
-            request.ServerId, request.WorldSpaceId.BaseId, request.CellId.BaseId, request.Position.x, request.Position.y, request.Position.z);
+            __FUNCTION__ ": transferring ownership of local actor, formId: {:X}, server id: {:X}, worldspace: {:X}, cell: {:X}, position: "
+                         "({}, {}, {}), name: {}",
+            aFormId, request.ServerId, request.WorldSpaceId.BaseId, request.CellId.BaseId, request.Position.x, request.Position.y, request.Position.z, pName);
 
         m_transport.Send(request);
 
         m_world.remove<LocalAnimationComponent, LocalComponent>(aEntity);
     }
+
+    if (pActor)
+        pActor->GetExtension()->SetNakedDeadline();
 }
 
 Actor* CharacterService::CreateCharacterForEntity(entt::entity aEntity) const noexcept
@@ -1572,9 +1578,12 @@ void CharacterService::RunRemoteUpdates() noexcept
         if (pActor->IsVampireLord())
             pActor->FixVampireLordModel();
 
+        // (Re)start naked NPC deadline. Actor MUST be fully constructed before check clock starts.
+        pActor->GetExtension()->SetNakedDeadline();
+
         toRemove.push_back(entity);
 
-        spdlog::info("Applied 3D for actor, form id: {:X}", pActor->formID);
+        spdlog::info(__FUNCTION__ ": applied 3D for actor, form id: {:X}, name {}", pActor->formID, pActor->baseForm->GetName());
     }
 
     for (auto entity : toRemove)

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -25,6 +25,7 @@
 #include <EquipManager.h>
 #include <Games/ActorExtension.h>
 #include <Forms/TESNPC.h>
+#include <Forms/BGSOutfit.h>
 #include <DefaultObjectManager.h>
 
 InventoryService::InventoryService(World& aWorld, entt::dispatcher& aDispatcher, TransportService& aTransport) noexcept
@@ -57,10 +58,21 @@ void InventoryService::OnInventoryChangeEvent(const InventoryChangeEvent& acEven
     if (iter == std::end(view))
         return;
 
+    const bool isLeader = m_world.GetPartyService().IsLeader(); // Helps distinguish in 2-party logs
     std::optional<uint32_t> serverIdRes = Utils::GetServerId(*iter);
     if (!serverIdRes.has_value())
     {
-        spdlog::error(__FUNCTION__ ": failed to find server id, target form id: {:X}, item id: {:X}, count: {}", acEvent.FormId, acEvent.Item.BaseId.BaseId, acEvent.Item.Count);
+        spdlog::error(
+            __FUNCTION__ ": failed to find server id, target form id: {:X}, isLeader: {}, item id: {:X}, count: {}", acEvent.FormId,
+            isLeader, acEvent.Item.BaseId.LogFormat(), acEvent.Item.Count);
+        return;
+    }
+
+    if (m_world.try_get<WaitingForAssignmentComponent>(*iter))
+    {
+        spdlog::debug(
+            __FUNCTION__ ": WaitingForAssignment, don't send inventory changes actorId: {:X}, serverId {:X}, isLeader: {}, item id: {:X}",
+            acEvent.FormId, serverIdRes.value(), isLeader, acEvent.Item.BaseId.LogFormat());
         return;
     }
 
@@ -72,7 +84,7 @@ void InventoryService::OnInventoryChangeEvent(const InventoryChangeEvent& acEven
 
     m_transport.Send(request);
 
-    spdlog::info("Sending item request, item: {:X}, count: {}, target object: {:X}", acEvent.Item.BaseId.BaseId, acEvent.Item.Count, acEvent.FormId);
+    spdlog::info(__FUNCTION__ ": sending item request, item: {:X}, count: {}, target object: {:X}", acEvent.Item.BaseId.LogFormat(), acEvent.Item.Count, acEvent.FormId);
 }
 
 void InventoryService::OnEquipmentChangeEvent(const EquipmentChangeEvent& acEvent) noexcept
@@ -87,16 +99,29 @@ void InventoryService::OnEquipmentChangeEvent(const EquipmentChangeEvent& acEven
     if (iter == std::end(view))
         return;
 
-    std::optional<uint32_t> serverIdRes = Utils::GetServerId(*iter);
-    if (!serverIdRes.has_value())
-    {
-        spdlog::error(__FUNCTION__ ": failed to find server id, actor id: {:X}, item id: {:X}, isAmmo: {}, unequip: {}, slot: {:X}", acEvent.ActorId, acEvent.ItemId, acEvent.IsAmmo, acEvent.Unequip, acEvent.EquipSlotId);
-        return;
-    }
-
+    const bool isLeader = m_world.GetPartyService().IsLeader(); // Helps distinguish in 2-party logs
     Actor* pActor = Cast<Actor>(TESForm::GetById(acEvent.ActorId));
     if (!pActor)
         return;
+
+    std::optional<uint32_t> serverIdRes = Utils::GetServerId(*iter);
+    if (!serverIdRes.has_value())
+    {
+        spdlog::error(
+            __FUNCTION__ ": failed to find server id, actorId: {:X}, isLeader: {}, item id: {:X}, isAmmo: {}, unequip: {}, slot: {:X}, name: {}",
+            acEvent.ActorId, isLeader, acEvent.ItemId, acEvent.IsAmmo, acEvent.Unequip, acEvent.EquipSlotId, pActor->baseForm->GetName());
+        return;
+    }
+
+    if (m_world.try_get<WaitingForAssignmentComponent>(*iter))
+    {
+        spdlog::debug(
+            __FUNCTION__ ": WaitingForAssignment, don't send equipment changes actorId: {:X}, serverId {:X}, isLeader: {}, "
+                         "item id: {:X}, isAmmo: {}, unequip: {}, slot: {:X}, name: {}",
+            acEvent.ActorId, serverIdRes.value(), isLeader, acEvent.ItemId, acEvent.IsAmmo, acEvent.Unequip, acEvent.EquipSlotId,
+            pActor->baseForm->GetName());
+        return;
+    }
 
     auto& modSystem = World::Get().GetModSystem();
 
@@ -117,7 +142,9 @@ void InventoryService::OnEquipmentChangeEvent(const EquipmentChangeEvent& acEven
 
     m_transport.Send(request);
 
-    spdlog::info("Sending equipment request, item: {:X}, count: {}, target object: {:X}", acEvent.ItemId, acEvent.Count, acEvent.ActorId);
+    spdlog::info(
+        __FUNCTION__ ": sending equipment change, actorId: {:X}, serverId {:X}, isLeader: {}, item: {:X}, count: {}, name: {}",
+        acEvent.ActorId, request.ServerId, isLeader, acEvent.ItemId, acEvent.Count, pActor->baseForm->GetName());
 }
 
 void InventoryService::OnNotifyInventoryChanges(const NotifyInventoryChanges& acMessage) noexcept
@@ -273,6 +300,8 @@ void InventoryService::RunNakedNPCBugChecks() noexcept
 
     static std::chrono::steady_clock::time_point lastSendTimePoint;
     constexpr auto cDelayBetweenUpdates = 1000ms;
+    constexpr auto cDelayAfterAssignment = 3s;
+    constexpr auto cNoDeadline = std::chrono::steady_clock::time_point{};
 
     const auto now = std::chrono::steady_clock::now();
     if (now - lastSendTimePoint < cDelayBetweenUpdates)
@@ -292,20 +321,48 @@ void InventoryService::RunNakedNPCBugChecks() noexcept
         if (pActor->GetExtension()->IsPlayer())
             continue;
 
-        if (pActor->IsDead())
+        if (pActor->GetExtension()->nakedDeadline == cNoDeadline)
             continue;
 
-        if (pActor->IsWearingBodyPiece())
+        if (pActor->IsDead() || !pActor->ShouldWearBodyPiece())
+        {
+            pActor->GetExtension()->nakedDeadline = cNoDeadline;
+            spdlog::debug(__FUNCTION__ ": actorId {:X} naked check is irrelevant {}", pActor->formID, pActor->baseForm->GetName());
+            continue; 
+        }
+
+        if (now < pActor->GetExtension()->nakedDeadline + cDelayAfterAssignment)
+        {
+            spdlog::debug(__FUNCTION__ ": actorId {:X} with naked check deadline {}", pActor->formID, pActor->baseForm->GetName());
+            continue; 
+        }
+
+        else
+        {
+            spdlog::debug(__FUNCTION__ ": actorId {:X} naked check deadline expires {}", pActor->formID, pActor->baseForm->GetName());
+            if (m_world.try_get<WaitingForAssignmentComponent>(entity))
+            {
+                spdlog::debug(__FUNCTION__ ": but still WaitingForAssignment", pActor->formID, pActor->baseForm->GetName());
+                pActor->GetExtension()->SetNakedDeadline();
+                continue;
+            }
+
+            pActor->GetExtension()->nakedDeadline = cNoDeadline;   
+        }
+
+        if (pActor->GetExtension()->IsRemote())
+        {
+            spdlog::debug(__FUNCTION__ ": actorId {:X} naked check canceled, IsRemote(), {}", pActor->formID, pActor->baseForm->GetName());
             continue;
+        }
 
-        if (!pActor->ShouldWearBodyPiece())
-            continue;
-
-        // Don't broadcast changes, it'll just make things messier.
-        // If all clients have this problem, they'll all fix it individually.
-        ScopedEquipOverride seo;
-        ScopedInventoryOverride sio;
-
-        pActor->ResetInventory(false);
+        // If somehow inventory was damaged despite fixes, dress actor. Belt and suspenders.
+        // Note if the outfit items have been removed from inventory, they aren't regenerated.
+        TESNPC* pBase = Cast<TESNPC>(pActor->baseForm);
+        if (!pActor->IsWearingBodyPiece() && pBase)
+        {
+            spdlog::warn(__FUNCTION__ ": actorId {:X} naked check fires {}", pActor->formID, pActor->baseForm->GetName());
+            pActor->EquipOutfit();
+        }
     }
 }


### PR DESCRIPTION
Original naked NPC fix worked around the "fighting over NPC ownership" issues in STR by checking periodically to see if NPCs were naked and redressing them if they were. It didn't really address root cause, and introduced some new bugs.

The changes here:
- Are constrained by the lack of solid reproducers. Simulations only get you so far.
- Address all the root-cause issues that could be found / inferred in reasonable time. Difficult to say if it gets all (or enough) of  them without solid reproducers.
- Fixes the new bugs introduced by the first version.
- Keeps a last-resort timeout to redress NPCs in case this still doesn't fix all the root causes. If it ever happens, it will log at warning level and we will know there's more to hunt for.

Root cause:
- Common wisdom was the Ownership code was fighting over NPCs. Leader and Member jump into a cell together and each try to set up the NPCs, broadcasting conflicting changes to  the other.
- This turned out to be directionally correct. First, when an Actor is constructed, shortly after creation the engine fires a bunch of EquipmentChangeEvents as the engine dresses the actor. Some to all of these these could be dropped because ServerIds for the actors or equipment aren't available yet. But, it is a real problem if some of them ARE broadcast once server IDs are allocated. Equipping an item the sender has but the receiver doesn't can end up unequipping. Even worse if inventory changes are sent.
- The new code blocks sending updates until WaitingFor3D ends (according to CK, accessing the default outfit before the Actor is fully constructed is undefined). And, it blocks sending updates while WaitingForAssignment. This is the KEY fix, since at the end of WaitingForAssignment, we know who should win, and the winner has sent a full Inventory and a full Equipment list. Applying that (by the non-owners) should fully dress the NPC. At least as long as the Owner has dressed the NPC.
- As a last resort/backstop, a "naked deadline" trips on the Actor. If this happens where the actor IsLocal(), and the actor is not dressed, then they will equip the default outfit (if there is one). These changes are synced.
- That last is sort of what the original fix did, but improved. This redressing is non-destructive.

Bugs fixed in Vanilla:
- Blocks the sending of potentially destructive equipment and  possibly inventory changes while debating Ownership. This may or may not be a complete fix.

Bugs fixed in orignal Naked fix:
- The original code just tried to dress NPCs once every second. Note, that was not "after a second", but between 0 and 1 seconds after creation. I can't prove it, but this firing too soon, and in particular before WaitingFor3D leads to undefined behavior and is probably one of the reasons for lingering nakedness, and syncing broken equip states (and inventory?). This was replaced with a per-Actor timeout that works out to between 3 and 4 seconds. It is reset at the end of WaitingFor3D and again at the end of Ownership change.
- Replaces the forced-redress by fully resetting inventory with simply equipping the default outfit; no changes to inventory. This is critical for followers that may have accumulated a lot of loot, but applies to any NPC that has loot. The previous fix deleted all that loot.
- Does not try to recreate the default outfit inventory if you have removed it from inventory. This is probably what you wanted anyway.
- Only checks for redressing once per ownership change of the Actor, rather than rechecking every second. So you can change what the actor is wearing and it will stay that way as long as you stay in the cell (and the Leader doesn't enter and take over)