### PR TITLE
fix: null deref in OnRequestRespawn

### DIFF
--- a/Code/server/Services/CharacterService.cpp
+++ b/Code/server/Services/CharacterService.cpp
@@ -499,7 +499,8 @@ void CharacterService::OnRequestRespawn(const PacketEvent<RequestRespawn>& acMes
     auto& ownerComponent = view.get<OwnerComponent>(*it);
 
     // Replay cache needs to be cleared when a character respawns
-    m_world.try_get<AnimationComponent>(*it)->ActionsReplayCache.Clear();
+    if (auto* pAnimationComponent = m_world.try_get<AnimationComponent>(*it))
+        pAnimationComponent->ActionsReplayCache.Clear();
 
     if (ownerComponent.GetOwner() == acMessage.pPlayer)
     {


### PR DESCRIPTION
try_get<AnimationComponent>() on line 502 of CharacterService.cpp was being dereferenced without a null check. The view only includes OwnerComponent and CharacterComponent, so AnimationComponent isn't guaranteed to exist on the entity. Added a null check to match every other try_get usage in the file.