### PR TITLE
Add F11 hotkey to clear stuck imagespace modifiers (#835)

### DIFF
--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -167,14 +167,16 @@ void DebugService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
 
     if (GetAsyncKeyState(VK_F3) & 0x01)
     {
-        m_showDebugStuff = !m_showDebugStuff;
-    }
-
-    if (GetAsyncKeyState(VK_F11) & 0x01)
-    {
-        for (const auto& modifier : TES::Get()->activeImageSpaceModifiers)
+        if (GetAsyncKeyState(VK_CONTROL) & 0x8000)
         {
-            ImageSpaceModifierInstance::Stop(modifier.object);
+            for (const auto& modifier : TES::Get()->activeImageSpaceModifiers)
+            {
+                ImageSpaceModifierInstance::Stop(modifier.object);
+            }
+        }
+        else
+        {
+            m_showDebugStuff = !m_showDebugStuff;
         }
     }
 

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -170,6 +170,14 @@ void DebugService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
         m_showDebugStuff = !m_showDebugStuff;
     }
 
+    if (GetAsyncKeyState(VK_F11) & 0x01)
+    {
+        for (const auto& modifier : TES::Get()->activeImageSpaceModifiers)
+        {
+            ImageSpaceModifierInstance::Stop(modifier.object);
+        }
+    }
+
 #if (!IS_MASTER)
     if (GetAsyncKeyState(VK_F6))
     {


### PR DESCRIPTION
Reuses the existing "Clear stuck screen effects" debug logic and exposes it as a dedicated hotkey available in release builds, giving users an escape hatch for stuck screen effects (e.g. Karliah's poison dart in Speaking With Silence) without needing to open the F3 debug overlay.