### PR TITLE
Prevent non-leader party members from using zone transition doors (#845)

### DIFF
--- a/Code/client/Games/Skyrim/TESObjectREFR.cpp
+++ b/Code/client/Games/Skyrim/TESObjectREFR.cpp
@@ -983,7 +983,7 @@ bool TP_MAKE_THISCALL(HookActivate, TESObjectREFR, TESObjectREFR* apActivator, u
     Actor* pActivator = Cast<Actor>(apActivator);
 
     // Exclude books from activation since only reading them removes them from the cell
-    // Note: Books are now unsynced 
+    // Note: Books are now unsynced
     if (pActivator && apThis->baseForm->formType != FormType::Book)
     {
         auto openState = TESObjectREFR::kNone;
@@ -993,6 +993,21 @@ bool TP_MAKE_THISCALL(HookActivate, TESObjectREFR, TESObjectREFR* apActivator, u
         World::Get().GetRunner().Trigger(
             ActivateEvent(apThis, pActivator, apObjectToGet, aCount, aDefaultProcessing, aUnk1, openState)
         );
+    }
+
+    // #845: prevent non-leader party members from triggering zone transitions.
+    // A load door is a Door reference that carries an ExtraTeleport entry.
+    if (pActivator == PlayerCharacter::Get() &&
+        apThis->baseForm->formType == FormType::Door &&
+        apThis->extraData.Contains(ExtraDataType::Teleport))
+    {
+        auto& partyService = World::Get().GetPartyService();
+        if (partyService.IsInParty() && !partyService.IsLeader())
+        {
+            World::Get().GetOverlayService().SendSystemMessage(
+                "Only the party leader can use zone transition doors. Use the party menu to teleport to them.");
+            return false;
+        }
     }
 
     return TiltedPhoques::ThisCall(RealActivate, apThis, apActivator, aUnk1, apObjectToGet, aCount, aDefaultProcessing);


### PR DESCRIPTION
When the local player is in a party but is not the leader, block load door activations (Door + ExtraTeleport) and show a system message pointing the user at the party menu teleport. Leader activations, solo play, non-party contexts, NPC/script activations, and in-cell doors (which lack ExtraTeleport) are untouched.
Scope note: this is the minimal "always block" interpretation. The issue's richer "door unlocks for followers once the leader passes through" mechanic is deferred, since it needs per-door state synced across the party and is worth its own PR.
Known trade-off: a quest script that calls `player.Activate(loadDoor)` directly will also be blocked for non-leaders. This path is rare in practice; if it surfaces, a per-quest exclusion list (mirroring QuestService's kNonSyncableQuestIds) is the natural follow-up.