### PR TITLE
Hide location from player list; default to party menu tab to prevent trolling

### DIFF
--- a/Code/skyrim_ui/src/app/components/player-list/player-list.component.html
+++ b/Code/skyrim_ui/src/app/components/player-list/player-list.component.html
@@ -12,9 +12,6 @@
         <tr>
           <th>{{ 'COMPONENT.PARTY_LIST.TABLE_HEADERS.LEVEL' | transloco }}</th>
           <th>{{ 'COMPONENT.PARTY_LIST.TABLE_HEADERS.NAME' | transloco }}</th>
-          <th>
-            {{ 'COMPONENT.PARTY_LIST.TABLE_HEADERS.LOCATION' | transloco }}
-          </th>
           <th></th>
         </tr>
       </thead>
@@ -22,7 +19,6 @@
         <tr *ngFor="let player of playerList$ | async">
           <td>{{ player.level }}</td>
           <td>{{ player.name }}</td>
-          <td>{{ player.cellName }}</td>
           <td class="actions-col">
             <button
               [class.hidden]="player.isMember || !(isPartyLeader$ | async)"

--- a/Code/skyrim_ui/src/app/store/ui.repository.ts
+++ b/Code/skyrim_ui/src/app/store/ui.repository.ts
@@ -18,7 +18,7 @@ const uiStore = createStore(
   { name: 'auth' },
   withProps<UiProps>({
     view: null,
-    playerManagerTab: PlayerManagerTab.PLAYER_LIST,
+    playerManagerTab: PlayerManagerTab.PARTY_MENU,
     connectIp: null,
     connectPort: null,
     connectName: null,


### PR DESCRIPTION
On servers with auto-party join turned off, this will help prevent location trolling on public servers, they join and kill npcs where the existing players are located. This used to be displayed in the player list and even if denied party, trolls could go there and kill.

Also, the party menu is infinitely more useful as a default tab in the player manager. So I thought to make it the default tab too.