### PR TITLE
Fix/issue 871 restore password hiding parity in connect dialogue

### DIFF
--- a/Code/skyrim_ui/src/app/components/connect/connect.component.html
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.html
@@ -21,18 +21,21 @@
     [(ngModel)]="password"
     (keydown.enter)="connect()"
   />
-  <span class="hide-password">
-    <input type="checkbox" id="hide-password" [(ngModel)]="hidePassword" />
-    <label for="hide-password">
-      {{ 'COMPONENT.CONNECT.HIDE_PASSWORD' | transloco }}
-    </label>
-  </span>
-  <span class="save-password">
-    <input type="checkbox" id="save-password" [(ngModel)]="savePassword" />
-    <label for="save-password">{{
-      'COMPONENT.CONNECT.SAVE_PASSWORD' | transloco
-    }}</label>
-  </span>
+
+  <div class="checkbox-row">
+    <span class="save-password">
+      <input type="checkbox" id="save-password" [(ngModel)]="savePassword" />
+      <label for="save-password">{{
+        'COMPONENT.CONNECT.SAVE_PASSWORD' | transloco
+      }}</label>
+    </span>
+    <span class="hide-password">
+      <input type="checkbox" id="hide-password" [(ngModel)]="hidePassword" />
+      <label for="hide-password">
+        {{ 'COMPONENT.CONNECT.HIDE_PASSWORD' | transloco }}
+      </label>
+    </span>
+  </div>
 
   <app-action-buttons>
     <button

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.html
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.html
@@ -21,19 +21,18 @@
     [(ngModel)]="password"
     (keydown.enter)="connect()"
   />
-
-  <div class="checkbox-row">
-    <span class="save-password">
+  <div class="password-options">
+    <span>
       <input type="checkbox" id="save-password" [(ngModel)]="savePassword" />
       <label for="save-password">{{
         'COMPONENT.CONNECT.SAVE_PASSWORD' | transloco
       }}</label>
     </span>
-    <span class="hide-password">
+    <span>
       <input type="checkbox" id="hide-password" [(ngModel)]="hidePassword" />
-      <label for="hide-password">
-        {{ 'COMPONENT.CONNECT.HIDE_PASSWORD' | transloco }}
-      </label>
+      <label for="hide-password">{{
+        'COMPONENT.CONNECT.HIDE_PASSWORD' | transloco
+      }}</label>
     </span>
   </div>
 

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.html
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.html
@@ -15,12 +15,18 @@
     spellcheck="false"
   />
   <input
-    type="text"
+    [type]="hidePassword ? 'password' : 'text'"
     [placeholder]="'COMPONENT.CONNECT.PASSWORD' | transloco"
     spellcheck="false"
     [(ngModel)]="password"
     (keydown.enter)="connect()"
   />
+  <span class="hide-password">
+    <input type="checkbox" id="hide-password" [(ngModel)]="hidePassword" />
+    <label for="hide-password">
+      {{ 'COMPONENT.CONNECT.HIDE_PASSWORD' | transloco }}
+    </label>
+  </span>
   <span class="save-password">
     <input type="checkbox" id="save-password" [(ngModel)]="savePassword" />
     <label for="save-password">{{

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -19,12 +19,17 @@
 
     .hide-password,
     .save-password {
-      flex: 0 0 auto;
+      flex: 1 1 auto;
       display: flex;
       justify-content: flex-start;
       align-items: center;
       gap: 0.5em;
 	  white-space: nowrap;
+	  
+	  input[type="checkbox"] {
+        flex: 0 0 auto;     /* CRITICAL: Force the checkbox to keep its original size */
+        width: auto;        /* Override the global input { width: 100% } rule below */
+      }
     }
   }
 

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -20,7 +20,15 @@
 .save-password {
   width: 100%;
   display: flex;
-  justify-items: start;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.hide-password {
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
   align-items: center;
   gap: 0.5em;
 }

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -19,11 +19,12 @@
 
     .hide-password,
     .save-password {
-      flex: 0 1 auto;
+      flex: 0 0 auto;
       display: flex;
       justify-content: flex-start;
       align-items: center;
       gap: 0.5em;
+	  white-space: nowrap;
     }
   }
 

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -1,71 +1,65 @@
-@import 'env';
+@import 'env'; 
 
-@import 'functions/mod';
-@import 'mixins/gapped-vertical';
+@import 'functions/mod'; 
+@import 'mixins/gapped-vertical'; 
 
-.container {
-  @include gapped-vertical($-size-gap);
+.container { 
+  @include gapped-vertical($-size-gap); 
 
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: flex; 
+  flex-direction: column; 
+  align-items: center; 
 
-  .checkbox-row {
-    display: flex;
-    width: 100%;
-    justify-content: space-between; /* This pushes them to the far left and far right */
-    align-items: center;
-    gap: 1em;
+  .checkbox-row { 
+    display: flex; 
+    width: 100%; 
+    justify-content: space-between; 
+    align-items: center; 
+    gap: 1em; 
 
-    .hide-password,
-    .save-password {
-      /* Do not grow, do not shrink. Stay exactly text-sized */
-      display: flex;
-      align-items: center;
-      gap: 0.5em;
-      white-space: nowrap;  /* Force text onto one line */
+    .hide-password, 
+    .save-password { 
+      flex: 0 1 auto; 
+      display: flex; 
+      justify-content: flex-start; 
+      align-items: center; 
+      gap: 0.5em; 
+      white-space: nowrap; /* 1. Prevent the text from wrapping */
 
-      /* Targets the checkbox input and forces visibility */
-      input[type="checkbox"] {
-        display: inline-block !important; /* Ensure it isn't set to display: none */
-        visibility: visible !important;   /* Ensure it isn't hidden */
-        appearance: checkbox !important;  /* Force native checkbox rendering */
-        -webkit-appearance: checkbox !important;
-        
-        width: 1em !important;            /* Force a visible size */
-        height: 1em !important;
-        margin: 0;
-        flex: 0 0 auto;                   /* Prevent flex engine from crushing it */
+      /* 2. Keep original diamond checkbox look */
+      input[type="checkbox"] { 
+        width: auto;       /* Overrides the global width: 100% */
+        flex: 0 0 auto;    /* Prevents flexbox from flattening UI */
       }
-    }
-  }
+    } 
+  } 
 
-  ::ng-deep {
-    strong {
-      color: mod($-color-background, 1);
-    }
-  }
-}
+  ::ng-deep { 
+    strong { 
+      color: mod($-color-background, 1); 
+    } 
+  } 
+} 
 
-.instructions > * {
-  text-align: center;
-  margin: 0.3em;
-  line-height: $-size-line;
-}
+.instructions > * { 
+  text-align: center; 
+  margin: 0.3em; 
+  line-height: $-size-line; 
+} 
 
-input {
-  width: 100%;
-}
+input { 
+  width: 100%; 
+} 
 
-.warning {
-  color: rgb(247, 54, 54);
-}
+.warning { 
+  color: rgb(247, 54, 54); 
+} 
 
-hr {
-  border: 0;
-  clear: both;
-  display: block;
-  width: 80%;
-  background-color: grey;
-  height: 1px;
+hr { 
+  border: 0; 
+  clear: both; 
+  display: block; 
+  width: 80%; 
+  background-color: grey; 
+  height: 1px; 
 }

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -24,12 +24,10 @@
       justify-content: flex-start; 
       align-items: center; 
       gap: 0.5em; 
-      white-space: nowrap; /* 1. Prevent the text from wrapping */
 
-      /* 2. Keep original diamond checkbox look */
-      input[type="checkbox"] { 
-        width: auto;       /* Overrides the global width: 100% */
-        flex: 0 0 auto;    /* Prevents flexbox from flattening UI */
+      /* Target the text container explicitly to prevent wrapping */
+      label {
+        white-space: nowrap;
       }
     } 
   } 

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -10,27 +10,27 @@
   flex-direction: column;
   align-items: center;
 
+  .checkbox-row {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    gap: 1em;
+
+    .hide-password,
+    .save-password {
+      flex: 1 1 auto;
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      gap: 0.5em;
+    }
+  }
+
   ::ng-deep {
     strong {
       color: mod($-color-background, 1);
     }
   }
-}
-
-.save-password {
-  width: 100%;
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 0.5em;
-}
-
-.hide-password {
-  width: 100%;
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 0.5em;
 }
 
 .instructions > * {

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -1,72 +1,71 @@
-@import 'env'; 
+@import 'env';
 
-@import 'functions/mod'; 
-@import 'mixins/gapped-vertical'; 
+@import 'functions/mod';
+@import 'mixins/gapped-vertical';
 
-.container { 
-  @include gapped-vertical($-size-gap); 
+.container {
+  @include gapped-vertical($-size-gap);
 
-  display: flex; 
-  flex-direction: column; 
-  align-items: center; 
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
-  .checkbox-row { 
-    display: flex; 
-    width: 100%; 
-    justify-content: space-between; 
-    align-items: center; 
-    gap: 1em; 
-
-    .hide-password, 
-    .save-password { 
-      /* 1. Force both halves to split the available space equally */
-      flex: 1 1 0%; 
-      display: flex; 
-      align-items: center; 
-      gap: 0.5em; 
-
-      label {
-        white-space: nowrap; /* 2. Prevent text from wrapping */
-      }
-    } 
-
-    /* 3. Keep the left side glued to the far left edge */
-    .save-password {
-      justify-content: flex-start;
+  ::ng-deep {
+    strong {
+      color: mod($-color-background, 1);
     }
+  }
+}
 
-    /* 4. Keep the right side glued to the far right edge */
-    .hide-password {
-      justify-content: flex-end;
-    }
-  } 
+.password-options {
+  width: 100%;
+  display: flex;
+  align-items: center;
 
-  ::ng-deep { 
-    strong { 
-      color: mod($-color-background, 1); 
-    } 
-  } 
-} 
+  span {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+  }
 
-.instructions > * { 
-  text-align: center; 
-  margin: 0.3em; 
-  line-height: $-size-line; 
-} 
+  span + span {
+    margin-left: 1.5em;
+  }
 
-input { 
-  width: 100%; 
-} 
+  input[type='checkbox'] {
+    flex: 0 0 $scrollbar;
+    min-width: $scrollbar;
+    min-height: $scrollbar;
+  }
 
-.warning { 
-  color: rgb(247, 54, 54); 
-} 
+  label {
+    white-space: nowrap;
+  }
+}
 
-hr { 
-  border: 0; 
-  clear: both; 
-  display: block; 
-  width: 80%; 
-  background-color: grey; 
-  height: 1px; 
+.instructions > * {
+  text-align: center;
+  margin: 0.3em;
+  line-height: $-size-line;
+}
+
+input {
+  width: 100%;
+
+  &[type='password'] {
+    border: 3px solid #808081;
+  }
+}
+
+.warning {
+  color: rgb(247, 54, 54);
+}
+
+hr {
+  border: 0;
+  clear: both;
+  display: block;
+  width: 80%;
+  background-color: grey;
+  height: 1px;
 }

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -13,22 +13,29 @@
   .checkbox-row {
     display: flex;
     width: 100%;
-    justify-content: space-between;
+    justify-content: space-between; /* This pushes them to the far left and far right */
     align-items: center;
     gap: 1em;
 
     .hide-password,
     .save-password {
-      flex: 1 1 auto;
+      /* Do not grow, do not shrink. Stay exactly text-sized */
       display: flex;
-      justify-content: flex-start;
       align-items: center;
       gap: 0.5em;
-	  white-space: nowrap;
-	  
-	  input[type="checkbox"] {
-        flex: 0 0 auto;     /* CRITICAL: Force the checkbox to keep its original size */
-        width: auto;        /* Override the global input { width: 100% } rule below */
+      white-space: nowrap;  /* Force text onto one line */
+
+      /* Targets the checkbox input and forces visibility */
+      input[type="checkbox"] {
+        display: inline-block !important; /* Ensure it isn't set to display: none */
+        visibility: visible !important;   /* Ensure it isn't hidden */
+        appearance: checkbox !important;  /* Force native checkbox rendering */
+        -webkit-appearance: checkbox !important;
+        
+        width: 1em !important;            /* Force a visible size */
+        height: 1em !important;
+        margin: 0;
+        flex: 0 0 auto;                   /* Prevent flex engine from crushing it */
       }
     }
   }

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -19,17 +19,26 @@
 
     .hide-password, 
     .save-password { 
-      flex: 0 1 auto; 
+      /* 1. Force both halves to split the available space equally */
+      flex: 1 1 0%; 
       display: flex; 
-      justify-content: flex-start; 
       align-items: center; 
       gap: 0.5em; 
 
-      /* Target the text container explicitly to prevent wrapping */
       label {
-        white-space: nowrap;
+        white-space: nowrap; /* 2. Prevent text from wrapping */
       }
     } 
+
+    /* 3. Keep the left side glued to the far left edge */
+    .save-password {
+      justify-content: flex-start;
+    }
+
+    /* 4. Keep the right side glued to the far right edge */
+    .hide-password {
+      justify-content: flex-end;
+    }
   } 
 
   ::ng-deep { 

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -32,6 +32,9 @@
   }
 }
 
+<<<<<<< HEAD
+=======
+>>>>>>> c7e6e811 (fix: align save-password left and hide-password right in connect)
 .instructions > * {
   text-align: center;
   margin: 0.3em;

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -12,6 +12,8 @@
 
   .checkbox-row {
     display: flex;
+    width: 100%;
+    justify-content: space-between;
     align-items: center;
     gap: 1em;
 
@@ -32,9 +34,6 @@
   }
 }
 
-<<<<<<< HEAD
-=======
->>>>>>> c7e6e811 (fix: align save-password left and hide-password right in connect)
 .instructions > * {
   text-align: center;
   margin: 0.3em;

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.scss
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.scss
@@ -12,13 +12,12 @@
 
   .checkbox-row {
     display: flex;
-    width: 100%;
     align-items: center;
     gap: 1em;
 
     .hide-password,
     .save-password {
-      flex: 1 1 auto;
+      flex: 0 1 auto;
       display: flex;
       justify-content: flex-start;
       align-items: center;

--- a/Code/skyrim_ui/src/app/components/connect/connect.component.ts
+++ b/Code/skyrim_ui/src/app/components/connect/connect.component.ts
@@ -26,6 +26,7 @@ export class ConnectComponent implements OnDestroy, AfterViewInit {
   public address = '';
   public password = '';
   public savePassword = false;
+  public hidePassword = true;
 
   public connecting = false;
 


### PR DESCRIPTION
Fixes tiltedphoques/TiltedEvolution#871 by copying logic from the server browser's connect-password.component to the connect.component which is more used. New behavior is that the password is censored by default, and it can be toggled.

<img width="684" height="425" alt="image" src="https://github.com/user-attachments/assets/19292fbe-6ec6-41af-add3-d70b3cfb7591" />

verified 16 june in https://github.com/absol89/TiltedEvolutionScriptFixes/actions/runs/27628058512