### PR TITLE
Server: prevent Party auto-join when bAnnounceServer is true to prevent public server trolling

### DIFF
--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -32,6 +32,7 @@ Console::Setting bPremiumTickrate{"GameServer:bPremiumMode", "Use premium tick r
 Console::StringSetting sServerName{"GameServer:sServerName", "Name that shows up in the server list", "Dedicated Together Server"};
 Console::StringSetting sAdminPassword{"GameServer:sAdminPassword", "Admin authentication password", ""};
 Console::StringSetting sPassword{"GameServer:sPassword", "Server password", ""};
+Console::Setting bAnnounceServer{"LiveServices:bAnnounceServer", "Whether to list the server on the public server list", false};
 
 // Gameplay
 // TODO: to make this easier for users, use game names for difficulty instead of int
@@ -201,6 +202,16 @@ GameServer::~GameServer()
 GameServer* GameServer::Get() noexcept
 {
     return s_pInstance;
+}
+
+bool GameServer::IsPublicServer() const noexcept
+{
+    return bAnnounceServer;
+}
+
+bool GameServer::AllowsAutoPartyJoin() const noexcept
+{
+    return bAutoPartyJoin && !IsPublicServer();
 }
 
 void GameServer::Initialize()

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -66,6 +66,8 @@ struct GameServer final : Server
 
     bool IsRunning() const noexcept { return !m_requestStop; }
     bool IsPasswordProtected() const noexcept { return m_isPasswordProtected; }
+    [[nodiscard]] bool IsPublicServer() const noexcept;
+    [[nodiscard]] bool AllowsAutoPartyJoin() const noexcept;
 
     template <class T> void ForEachAdmin(const T& aFunctor)
     {

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -24,11 +24,8 @@
 namespace
 {
 Console::Setting bAutoPartyJoin{"Gameplay:bAutoPartyJoin", "Join parties automatically, as long as there is only one party in the server", true};
+Console::Setting bAnnounceServer{"LiveServices:bAnnounceServer", "If the server is on the public server list autojoin is guarded against", false};
 }
-
-// Reuse the canonical server-list announce setting so runtime toggles apply here too.
-// The real variable is defined in ServerListService.cpp. If true, it guards autojoin.
-extern const Console::Setting<bool>& bAnnounceServer;
 
 PartyService::PartyService(World& aWorld, entt::dispatcher& aDispatcher) noexcept
     : m_world(aWorld)

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -28,7 +28,7 @@ Console::Setting bAutoPartyJoin{"Gameplay:bAutoPartyJoin", "Join parties automat
 
 // Reuse the canonical server-list announce setting so runtime toggles apply here too.
 // The real variable is defined in ServerListService.cpp. If true, it guards autojoin.
-extern const Console::Setting& bAnnounceServer;
+extern const Console::Setting<bool>& bAnnounceServer;
 
 PartyService::PartyService(World& aWorld, entt::dispatcher& aDispatcher) noexcept
     : m_world(aWorld)

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -20,10 +20,15 @@
 #include <Messages/NotifyPlayerJoined.h>
 
 #include <Setting.h>
+
 namespace
 {
 Console::Setting bAutoPartyJoin{"Gameplay:bAutoPartyJoin", "Join parties automatically, as long as there is only one party in the server", true};
 }
+
+// Reuse the canonical server-list announce setting so runtime toggles apply here too.
+// The real variable is defined in ServerListService.cpp. If true, it guards autojoin.
+extern const Console::Setting& bAnnounceServer;
 
 PartyService::PartyService(World& aWorld, entt::dispatcher& aDispatcher) noexcept
     : m_world(aWorld)
@@ -122,7 +127,7 @@ void PartyService::OnPartyCreate(const PacketEvent<PartyCreateRequest>& acPacket
         spdlog::debug("[PartyService]: Created party for {}", player->GetId());
         SendPartyJoinedEvent(party, player);
 
-        if (m_parties.size() == 1 && bAutoPartyJoin)
+        if (m_parties.size() == 1 && bAutoPartyJoin && !bAnnounceServer)
         {
             for (Player* otherPlayer : m_world.GetPlayerManager())
             {

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -220,7 +220,7 @@ void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept
 
     GameServer::Get()->SendToPlayers(notify, acEvent.pPlayer);
 
-    if (m_parties.size() == 1 && bAutoPartyJoin)
+    if (m_parties.size() == 1 && bAutoPartyJoin && !bAnnounceServer)
     {
         for (Player* player : m_world.GetPlayerManager())
         {

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -19,14 +19,6 @@
 #include <Messages/PartyKickRequest.h>
 #include <Messages/NotifyPlayerJoined.h>
 
-#include <Setting.h>
-
-namespace
-{
-Console::Setting bAutoPartyJoin{"Gameplay:bAutoPartyJoin", "Join parties automatically, as long as there is only one party in the server", true};
-Console::Setting bAnnounceServer{"LiveServices:bAnnounceServer", "If the server is on the public server list autojoin is guarded against", false};
-}
-
 PartyService::PartyService(World& aWorld, entt::dispatcher& aDispatcher) noexcept
     : m_world(aWorld)
     , m_updateEvent(aDispatcher.sink<UpdateEvent>().connect<&PartyService::OnUpdate>(this))
@@ -124,7 +116,7 @@ void PartyService::OnPartyCreate(const PacketEvent<PartyCreateRequest>& acPacket
         spdlog::debug("[PartyService]: Created party for {}", player->GetId());
         SendPartyJoinedEvent(party, player);
 
-        if (m_parties.size() == 1 && bAutoPartyJoin && !bAnnounceServer)
+        if (m_parties.size() == 1 && GameServer::Get()->AllowsAutoPartyJoin())
         {
             for (Player* otherPlayer : m_world.GetPlayerManager())
             {
@@ -220,7 +212,7 @@ void PartyService::OnPlayerJoin(const PlayerJoinEvent& acEvent) noexcept
 
     GameServer::Get()->SendToPlayers(notify, acEvent.pPlayer);
 
-    if (m_parties.size() == 1 && bAutoPartyJoin && !bAnnounceServer)
+    if (m_parties.size() == 1 && GameServer::Get()->AllowsAutoPartyJoin())
     {
         for (Player* player : m_world.GetPlayerManager())
         {


### PR DESCRIPTION
This PR adresses players who public server hop to teleport to other players and grief them and pollute their quest progress.

The changes in this PR have been tested with OnPartyCreate, and I added OnPlayerJoin safeguard as the last commit june 16.

This does not affect players playing privately, or using playtogether.gg, as those use the connect UI with private IP and port.

Before: Player joined and instantly got autojoined to the party (default setting), and proceeded to share progress + location.

After: Player joined a public server and has to type to request a party invite from the previous players, to affect their savefile.

Note: The compile fix commit is not really relevant, it was just an attempt to read the variable from elsewhere, but i learned that it was static there and that the variable cannot be changed at runtime, so just having a copy of the setting in partyservice seems to be enough. The variable is used in ServerListService.cpp as well