### PR TITLE
CI: pin `windows-2022` runner for now

### DIFF
--- a/.github/workflows/windows-playable-build.yml
+++ b/.github/workflows/windows-playable-build.yml
@@ -20,7 +20,7 @@ jobs:
       upload-build-for-next-job: true
 
   package-and-upload:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: build-windows
     steps:
       - name: Download artifact from the previous job

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-2022]
         arch: [x64]
 
     runs-on: ${{ matrix.os }}

--- a/Code/immersive_launcher/loader/MemoryLayout.cpp
+++ b/Code/immersive_launcher/loader/MemoryLayout.cpp
@@ -32,7 +32,7 @@ namespace
 {
 extern "C" const IMAGE_DOS_HEADER __ImageBase;
 
-const uint8_t* const pBasePtr = reinterpret_cast<const uint8_t*>(&__ImageBase);
+constinit const uint8_t* pBasePtr = reinterpret_cast<const uint8_t*>(&__ImageBase);
 const uint8_t* kpImageEnd{pBasePtr + ((PIMAGE_NT_HEADERS)(pBasePtr + __ImageBase.e_lfanew))->OptionalHeader.SizeOfImage};
 
 bool InRange(const uint8_t* apObj, const uint8_t* apLo, const uint8_t* apHi)


### PR DESCRIPTION
`windows-latest` and `windows-2025` are now defaulting to VS2026. VS2026 and the newer SDKs/platform toolsets currently can cause issues (like certain DLLs not loading for some reason); we'll migrate later, maybe

Also undo `MemoryLayout.cpp` change

https://github.com/actions/runner-images/issues/14017