### PR TITLE
Feature/party leader settime on private servers - still requires admin on public servers

### DIFF
--- a/Code/server/Game/Player.h
+++ b/Code/server/Game/Player.h
@@ -16,6 +16,7 @@ struct Player
     [[nodiscard]] ConnectionId_t GetConnectionId() const noexcept { return m_connectionId; }
     [[nodiscard]] std::optional<entt::entity> GetCharacter() const noexcept { return m_character; }
     [[nodiscard]] PartyComponent& GetParty() noexcept { return m_party; }
+    [[nodiscard]] const PartyComponent& GetParty() const noexcept { return m_party; }
     [[nodiscard]] const String& GetUsername() const noexcept { return m_username; }
     [[nodiscard]] const String& GetEndPoint() const noexcept { return m_endpoint; }
     [[nodiscard]] const uint64_t GetDiscordId() const noexcept { return m_discordId; }

--- a/Code/server/Scripting/Player_Bindings.cpp
+++ b/Code/server/Scripting/Player_Bindings.cpp
@@ -13,7 +13,7 @@ void BindPlayer(sol::state_view aState)
     playerType["GetId"] = &Player::GetId;
     playerType["GetConnectionId"] = &Player::GetConnectionId;
     playerType["GetCharacter"] = &Player::GetCharacter;
-    playerType["GetParty"] = &Player::GetParty;
+    playerType["GetParty"] = [](Player& aSelf) -> PartyComponent& { return aSelf.GetParty(); };
     playerType["GetUsername"] = &Player::GetUsername;
     playerType["GetEndPoint"] = &Player::GetEndPoint;
     playerType["GetDiscordId"] = &Player::GetDiscordId;

--- a/Code/server/Services/CommandService.cpp
+++ b/Code/server/Services/CommandService.cpp
@@ -9,6 +9,13 @@
 #include <Messages/TeleportCommandRequest.h>
 #include <Messages/TeleportCommandResponse.h>
 
+#include <Setting.h>
+
+namespace
+{
+Console::Setting bAnnounceServer{"LiveServices:bAnnounceServer", "Whether to list the server on the public server list", false};
+}
+
 CommandService::CommandService(World& aWorld, entt::dispatcher& aDispatcher) noexcept
     : m_world(aWorld)
 {
@@ -21,30 +28,27 @@ void CommandService::OnSetTimeCommand(const PacketEvent<SetTimeCommandRequest>& 
     NotifySetTimeResult response{};
 
     const auto cPlayerId = static_cast<uint32_t>(acMessage.Packet.PlayerId);
-    const auto* pSender = acMessage.pPlayer;
 
-    const bool isAdmin = [&]
+    // Admin override: always allowed
+    for (const auto session : GameServer::Get()->GetAdminSessions())
     {
-        for (const auto session : GameServer::Get()->GetAdminSessions())
+        if (PlayerManager::Get()->GetByConnectionId(session)->GetId() == cPlayerId)
         {
-            if (auto* pPlayer = PlayerManager::Get()->GetByConnectionId(session))
-            {
-                if (pPlayer->GetId() == cPlayerId)
-                    return true;
-            }
+            const auto cHours = static_cast<int>(acMessage.Packet.Hours);
+            const auto cMinutes = static_cast<int>(acMessage.Packet.Minutes);
+
+            m_world.GetCalendarService().SetTime(cHours, cMinutes, m_world.GetCalendarService().GetTimeScale());
+
+            response.Result = NotifySetTimeResult::SetTimeResult::kSuccess;
+            acMessage.pPlayer->Send(response);
+
+            return;
         }
-        return false;
-    }();
+    }
 
-    const bool isLeaderAndNotAnnounced = [&]() -> bool
-    {
-        const auto* pPartyService = &m_world.GetPartyService();
-        if (pPartyService->IsPlayerLeader(pSender))
-            return !ServerListService::bAnnounceServer;
-        return false;
-    }();
-
-    if (isAdmin || isLeaderAndNotAnnounced)
+    // Party leader allowed on private servers only
+    const auto* pPartyService = &m_world.GetPartyService();
+    if (pPartyService->IsPlayerLeader(acMessage.pPlayer) && !bAnnounceServer)
     {
         const auto cHours = static_cast<int>(acMessage.Packet.Hours);
         const auto cMinutes = static_cast<int>(acMessage.Packet.Minutes);
@@ -52,13 +56,13 @@ void CommandService::OnSetTimeCommand(const PacketEvent<SetTimeCommandRequest>& 
         m_world.GetCalendarService().SetTime(cHours, cMinutes, m_world.GetCalendarService().GetTimeScale());
 
         response.Result = NotifySetTimeResult::SetTimeResult::kSuccess;
-        pSender->Send(response);
+        acMessage.pPlayer->Send(response);
 
         return;
     }
 
     response.Result = NotifySetTimeResult::SetTimeResult::kNoPermission;
-    pSender->Send(response);
+    acMessage.pPlayer->Send(response);
 }
 
 void CommandService::OnTeleportCommandRequest(const PacketEvent<TeleportCommandRequest>& acMessage) const noexcept

--- a/Code/server/Services/CommandService.cpp
+++ b/Code/server/Services/CommandService.cpp
@@ -21,26 +21,44 @@ void CommandService::OnSetTimeCommand(const PacketEvent<SetTimeCommandRequest>& 
     NotifySetTimeResult response{};
 
     const auto cPlayerId = static_cast<uint32_t>(acMessage.Packet.PlayerId);
+    const auto* pSender = acMessage.pPlayer;
 
-    // Only set time if player is an admin
-    for (const auto session : GameServer::Get()->GetAdminSessions())
+    const bool isAdmin = [&]
     {
-        if (PlayerManager::Get()->GetByConnectionId(session)->GetId() == cPlayerId)
+        for (const auto session : GameServer::Get()->GetAdminSessions())
         {
-            const auto cHours = static_cast<int>(acMessage.Packet.Hours);
-            const auto cMinutes = static_cast<int>(acMessage.Packet.Minutes);
-
-            m_world.GetCalendarService().SetTime(cHours, cMinutes, m_world.GetCalendarService().GetTimeScale());
-
-            response.Result = NotifySetTimeResult::SetTimeResult::kSuccess;
-            acMessage.pPlayer->Send(response);
-
-            return;
+            if (auto* pPlayer = PlayerManager::Get()->GetByConnectionId(session))
+            {
+                if (pPlayer->GetId() == cPlayerId)
+                    return true;
+            }
         }
+        return false;
+    }();
+
+    const bool isLeaderAndNotAnnounced = [&]() -> bool
+    {
+        const auto* pPartyService = &m_world.GetPartyService();
+        if (pPartyService->IsPlayerLeader(pSender))
+            return !ServerListService::bAnnounceServer;
+        return false;
+    }();
+
+    if (isAdmin || isLeaderAndNotAnnounced)
+    {
+        const auto cHours = static_cast<int>(acMessage.Packet.Hours);
+        const auto cMinutes = static_cast<int>(acMessage.Packet.Minutes);
+
+        m_world.GetCalendarService().SetTime(cHours, cMinutes, m_world.GetCalendarService().GetTimeScale());
+
+        response.Result = NotifySetTimeResult::SetTimeResult::kSuccess;
+        pSender->Send(response);
+
+        return;
     }
 
     response.Result = NotifySetTimeResult::SetTimeResult::kNoPermission;
-    acMessage.pPlayer->Send(response);
+    pSender->Send(response);
 }
 
 void CommandService::OnTeleportCommandRequest(const PacketEvent<TeleportCommandRequest>& acMessage) const noexcept

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -62,8 +62,8 @@ bool PartyService::IsPlayerLeader(const Player* const apPlayer) const noexcept
 >>>>>>> fcdb4c4d (fix: add const Player::GetParty() overload and use it in IsPlayerLeader)
     if (inviterPartyComponent.JoinedPartyId)
     {
-        Party& party = m_parties[*inviterPartyComponent.JoinedPartyId];
-        return party.LeaderPlayerId == apPlayer->GetId();
+        if (const auto* const pParty = GetById(*inviterPartyComponent.JoinedPartyId))
+            return pParty->LeaderPlayerId == apPlayer->GetId();
     }
 
     return false;

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -55,7 +55,11 @@ bool PartyService::IsPlayerInParty(Player* const apPlayer) const noexcept
 
 bool PartyService::IsPlayerLeader(const Player* const apPlayer) const noexcept
 {
+<<<<<<< HEAD
     auto& inviterPartyComponent = apPlayer->GetParty();
+=======
+    const auto& inviterPartyComponent = apPlayer->GetParty();
+>>>>>>> fcdb4c4d (fix: add const Player::GetParty() overload and use it in IsPlayerLeader)
     if (inviterPartyComponent.JoinedPartyId)
     {
         Party& party = m_parties[*inviterPartyComponent.JoinedPartyId];

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -55,11 +55,7 @@ bool PartyService::IsPlayerInParty(Player* const apPlayer) const noexcept
 
 bool PartyService::IsPlayerLeader(const Player* const apPlayer) const noexcept
 {
-<<<<<<< HEAD
-    auto& inviterPartyComponent = apPlayer->GetParty();
-=======
     const auto& inviterPartyComponent = apPlayer->GetParty();
->>>>>>> fcdb4c4d (fix: add const Player::GetParty() overload and use it in IsPlayerLeader)
     if (inviterPartyComponent.JoinedPartyId)
     {
         if (const auto* const pParty = GetById(*inviterPartyComponent.JoinedPartyId))

--- a/Code/server/Services/PartyService.cpp
+++ b/Code/server/Services/PartyService.cpp
@@ -53,7 +53,7 @@ bool PartyService::IsPlayerInParty(Player* const apPlayer) const noexcept
     return apPlayer->GetParty().JoinedPartyId.has_value();
 }
 
-bool PartyService::IsPlayerLeader(Player* const apPlayer) noexcept
+bool PartyService::IsPlayerLeader(const Player* const apPlayer) const noexcept
 {
     auto& inviterPartyComponent = apPlayer->GetParty();
     if (inviterPartyComponent.JoinedPartyId)

--- a/Code/server/Services/PartyService.h
+++ b/Code/server/Services/PartyService.h
@@ -33,7 +33,7 @@ struct PartyService
 
     const Party* GetById(uint32_t aId) const noexcept;
     bool IsPlayerInParty(Player* const apPlayer) const noexcept;
-    bool IsPlayerLeader(Player* const apPlayer) noexcept;
+    bool IsPlayerLeader(const Player* const apPlayer) const noexcept;
     Party* GetPlayerParty(Player* const apPlayer) noexcept;
 
 protected:


### PR DESCRIPTION
This change allows players who play using private servers to control /settime to wait out nighttime or certain events quicker.

Examples: Before, playtogether.gg users could not access console to /settime , and that service also has no admin password.

Before and after: On public servers, any player can join using an admin password to be able to /settime at their convenience.

After: Party leaders can use /settime from the ingame chat on private servers. Playguide recommends only 1 party per server.

Edge case: If a player makes their own party apart from others in a private server, several can mess with time (out of scope).

Prerequisites, set an admin password in server config like "test" and bAnnounceServer = false
Tested steps: boot server and 2 clients https://github.com/absol89/TiltedEvolutionScriptFixes/actions/runs/27875669545
1. join 1 player with admin password, without creating a party.
2. join second player , which in turn will also NOT be in a party.
3. Have player 1 use /settime XX XX in chat to set a specific time, verify with pressing T to wait and read the time. (PASSES)
4. Have player 2 use /settime YY YY in chat, verify that they are denied permission to do so (same result as previous design)
5. Have player 2 create a party and join player 1 to it
6. Have player 2 use /settime YY YY in chat, verify that they are granted permission to do so, verify with T wait to read time.
7. Repeat test with bAnnounceServer=true and see that only player 1 is allowed to change time due to admin connection.

Note: Unlocking /settime still does not seem to grant any rested bonuses if used during sleeping, survival still out of scope.