### PR TITLE
Fix/improved naked npc fixes for NPC and Players

### DIFF
--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -17,9 +17,11 @@ struct ActorExtension
     bool IsLocalPlayer() const noexcept;
     void SetRemote(bool aSet) noexcept;
     void SetPlayer(bool aSet) noexcept;
+    void SetNakedDeadline() noexcept { nakedDeadline = std::chrono::steady_clock::now();  }
 
     ActionEvent LatestAnimation{};
     size_t GraphDescriptorHash = 0;
+    std::chrono::steady_clock::time_point nakedDeadline{};
 
   private:
     uint32_t onlineFlags{0};

--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -17,11 +17,9 @@ struct ActorExtension
     bool IsLocalPlayer() const noexcept;
     void SetRemote(bool aSet) noexcept;
     void SetPlayer(bool aSet) noexcept;
-    void SetNakedDeadline() noexcept { nakedDeadline = std::chrono::steady_clock::now();  }
 
     ActionEvent LatestAnimation{};
     size_t GraphDescriptorHash = 0;
-    std::chrono::steady_clock::time_point nakedDeadline{};
 
   private:
     uint32_t onlineFlags{0};

--- a/Code/client/Games/PapyrusFunctions.cpp
+++ b/Code/client/Games/PapyrusFunctions.cpp
@@ -7,8 +7,6 @@ namespace PapyrusFunctions
 
 bool IsRemotePlayer(Actor* apActor)
 {
-    spdlog::info("Calling IsRemotePlayer");
-
     auto* pExtension = apActor->GetExtension();
     if (!pExtension)
         return false;

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -681,10 +681,20 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
             // Collect the armor(s) this outfit item resolves to. A leveled list entry
             // must resolve to EXACTLY ONE pick, not every candidate: pushing all list
             // members gave an NPC one cuirass per possible roll (issue #5's stacked
-            // outfit items). Taking the first valid member is deterministic -- leveled
-            // list order is identical in every client's load order, so both clients
-            // derive the same item and snapshots stay consistent across ownership flips.
+            // outfit items). Prefer the first MAPPED BODY-PIECE member (fall back to
+            // first mapped member): leveled-list order is identical across clients, so
+            // the pick stays deterministic while guaranteeing outfits resolve to a
+            // torso -- a boot-only pick left city NPCs permanently half-naked because
+            // every downstream check tests the body slot.
             Vector<TESObjectARMO*> armors;
+
+            auto& modSystem = World::Get().GetModSystem();
+            auto isMapped = [&modSystem](TESObjectARMO* apArmor)
+            {
+                GameId id{};
+                modSystem.GetServerModId(apArmor->formID, id);
+                return id != GameId{};
+            };
 
             if (pItem->formType == FormType::Armor)
             {
@@ -706,27 +716,36 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
                             if (pList[i].pForm)
                             {
                                 if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(pList[i].pForm))
-                                {
                                     armors.push_back(pArmor);
-                                    break; // single deterministic roll per list
-                                }
                             }
                         }
                     }
                 }
             }
 
-            for (TESObjectARMO* pArmor : armors)
+            TESObjectARMO* pPick = nullptr;
+            for (TESObjectARMO* pCandidate : armors)
+            {
+                // Unmapped armor (mod not registered with the server) resolves to a
+                // {0,0} BaseId which collides with every other unmapped entry under
+                // dedup -- committing one erases distinct pieces. Skip them.
+                if (!isMapped(pCandidate))
+                    continue;
+                pPick = pCandidate;
+                if (pPick->IsBodyPiece())
+                    break;
+            }
+
+            if (pPick)
             {
                 Inventory::Entry entry{};
-                World::Get().GetModSystem().GetServerModId(pArmor->formID, entry.BaseId);
+                World::Get().GetModSystem().GetServerModId(pPick->formID, entry.BaseId);
                 entry.Count = 1;
                 entry.ExtraWorn = true;
                 fallback.Entries.push_back(std::move(entry));
 
                 ++wearable;
-                if (entry.BaseId != GameId{})
-                    ++mapped;
+                ++mapped;
             }
         }
 
@@ -734,8 +753,24 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
                      pOutfit->formID, pOutfit->outfitItems.length, wearable, mapped,
                      fallback.HasWornItems());
 
-        // Use the first outfit slot that yields worn items; otherwise keep trying.
-        if (fallback.HasWornItems())
+        // Accept this outfit slot only if it yields a wearable set INCLUDING a body
+        // piece; otherwise try the next slot/template. A non-body-only derive (boot,
+        // satchel) is what stranded the city NPCs in the unrecoverable state.
+        bool hasBody = false;
+        for (const auto& entry : fallback.Entries)
+        {
+            const uint32_t gameId = World::Get().GetModSystem().GetGameId(entry.BaseId);
+            if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(TESForm::GetById(gameId)))
+            {
+                if (pArmor->IsBodyPiece())
+                {
+                    hasBody = true;
+                    break;
+                }
+            }
+        }
+
+        if (fallback.HasWornItems() && hasBody)
             break;
     }
 

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -678,8 +678,12 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
             if (!pItem)
                 continue;
 
-            // Collect every armor this outfit item can resolve to: a direct ARMO, or
-            // any entry in a leveled item list (Skyrim only uses list A).
+            // Collect the armor(s) this outfit item resolves to. A leveled list entry
+            // must resolve to EXACTLY ONE pick, not every candidate: pushing all list
+            // members gave an NPC one cuirass per possible roll (issue #5's stacked
+            // outfit items). Taking the first valid member is deterministic -- leveled
+            // list order is identical in every client's load order, so both clients
+            // derive the same item and snapshots stay consistent across ownership flips.
             Vector<TESObjectARMO*> armors;
 
             if (pItem->formType == FormType::Armor)
@@ -702,7 +706,10 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
                             if (pList[i].pForm)
                             {
                                 if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(pList[i].pForm))
+                                {
                                     armors.push_back(pArmor);
+                                    break; // single deterministic roll per list
+                                }
                             }
                         }
                     }

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -625,7 +625,7 @@ Inventory Actor::GetActorInventory() const noexcept
     // unaffected.
     if (!GetExtension()->IsPlayer() && !IsDead() && !inventory.HasWornItems())
     {
-        spdlog::info("[NakedFix] fallback path for actor {:X} (base {:X})", formID,
+        spdlog::debug("[NakedFix] fallback path for actor {:X} (base {:X})", formID,
                      baseForm ? baseForm->formID : 0);
 
         Inventory fallback = DeriveOutfitInventory();
@@ -635,7 +635,7 @@ Inventory Actor::GetActorInventory() const noexcept
         }
         else
         {
-            spdlog::info("[NakedFix]   no wearable outfit derived (base {:X})",
+            spdlog::debug("[NakedFix]   no wearable outfit derived (base {:X})",
                          baseForm ? baseForm->formID : 0);
         }
     }
@@ -711,7 +711,7 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
             }
         }
 
-        spdlog::info("[NakedFix]   outfit {:X} outfitItems={} wearable={} mapped={} fallbackHasWorn={}",
+        spdlog::debug("[NakedFix]   outfit {:X} outfitItems={} wearable={} mapped={} fallbackHasWorn={}",
                      pOutfit->formID, pOutfit->outfitItems.length, wearable, mapped,
                      fallback.HasWornItems());
 

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -651,9 +651,21 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
     if (!pBase)
         return fallback;
 
+    // Templated NPCs (FF-prefixed leveled-character spawns) carry no outfit on the
+    // leaf base -- the default outfit lives on the template base. Try the leaf first,
+    // then walk to the template base if the leaf defines no outfit at all. Without this
+    // the owner self-heal derives an empty inventory and leaves the NPC naked on the
+    // owner's own screen (remote clients are unaffected: they dress from the snapshot).
+    const TESNPC* pOutfitSource = pBase;
+    if (!pBase->outfits[0] && !pBase->outfits[1])
+    {
+        if (const TESNPC* pTemplate = pBase->GetTemplateBase())
+            pOutfitSource = pTemplate;
+    }
+
     // NPCs may carry their default outfit in either outfits[0] or outfits[1]; some
     // (e.g. guards) only define outfits[1]. Try both slots before giving up.
-    for (BGSOutfit* pOutfit : {pBase->outfits[0], pBase->outfits[1]})
+    for (BGSOutfit* pOutfit : {pOutfitSource->outfits[0], pOutfitSource->outfits[1]})
     {
         if (!pOutfit)
             continue;

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -790,10 +790,30 @@ void Actor::SetActorInventory(const Inventory& acInventory) noexcept
             // Supplement: keep any non-worn inventory the server did send (e.g. gold, quest
             // items, food) and add the derived worn items on top. Preserves legit contents
             // while guaranteeing the NPC ends up dressed.
+            //
+            // Idempotent by BaseId: if the server snapshot already carries this exact item
+            // (from a previous self-heal apply), REPLACE it rather than pushing a second copy.
+            // The owner self-heal re-runs SetActorInventory on every ownership flip; without
+            // this de-dup, each flip appends another full derived outfit and the NPC ends up
+            // with N copies of every piece (observed: horses/owned NPCs stacking 5x near the
+            // spawn area). Replacing on BaseId makes a re-apply a no-op for already-present items.
             Inventory toApply = acInventory;
             for (auto& entry : derived.Entries)
             {
-                if (entry.IsWorn())
+                if (!entry.IsWorn())
+                    continue;
+
+                bool replaced = false;
+                for (auto& existing : toApply.Entries)
+                {
+                    if (existing.BaseId == entry.BaseId)
+                    {
+                        existing = entry; // refresh worn flags/extra data, keep single copy
+                        replaced = true;
+                        break;
+                    }
+                }
+                if (!replaced)
                     toApply.Entries.push_back(entry);
             }
             toApply.CurrentMagicEquipment = acInventory.CurrentMagicEquipment;

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -625,45 +625,90 @@ Inventory Actor::GetActorInventory() const noexcept
     // unaffected.
     if (!GetExtension()->IsPlayer() && !IsDead() && !inventory.HasWornItems())
     {
+        spdlog::info("[NakedFix] fallback path for actor {:X} (base {:X})", formID,
+                     baseForm ? baseForm->formID : 0);
+
         if (const TESNPC* pBase = Cast<TESNPC>(baseForm))
         {
-            if (BGSOutfit* pDefaultOutfit = pBase->outfits[0])
+            // NPCs may carry their default outfit in either outfits[0] or outfits[1]; some
+            // (e.g. guards) only define outfits[1]. Try both slots before giving up.
+            for (BGSOutfit* pOutfit : {pBase->outfits[0], pBase->outfits[1]})
             {
+                if (!pOutfit)
+                    continue;
+
                 Inventory fallback{};
                 fallback.CurrentMagicEquipment = inventory.CurrentMagicEquipment;
 
-                for (TESForm* pItem : pDefaultOutfit->outfitItems)
+                size_t wearable = 0;
+                size_t mapped = 0;
+
+                for (TESForm* pItem : pOutfit->outfitItems)
                 {
                     if (!pItem)
                         continue;
 
-                    TESObjectARMO* pArmor = nullptr;
+                    // Collect every armor this outfit item can resolve to: a direct ARMO, or
+                    // any entry in a leveled item list (Skyrim only uses list A).
+                    Vector<TESObjectARMO*> armors;
+
                     if (pItem->formType == FormType::Armor)
-                        pArmor = Cast<TESObjectARMO>(pItem);
+                    {
+                        if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(pItem))
+                            armors.push_back(pArmor);
+                    }
                     else if (pItem->formType == FormType::LeveledItem)
                     {
                         if (const TESLevItem* pLevItem = Cast<TESLevItem>(pItem))
                         {
-                            if (pLevItem->pLeveledListA && pLevItem->pLeveledListA->pForm)
-                                pArmor = Cast<TESObjectARMO>(pLevItem->pLeveledListA->pForm);
+                            auto* pList = pLevItem->pLeveledListA;
+                            if (pList)
+                            {
+                                // count is stored 8 bytes before the array base.
+                                const auto count = *reinterpret_cast<const int32_t*>(
+                                    reinterpret_cast<const uint8_t*>(pList) - 8);
+                                for (int32_t i = 0; i < count; ++i)
+                                {
+                                    if (pList[i].pForm)
+                                    {
+                                        if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(pList[i].pForm))
+                                            armors.push_back(pArmor);
+                                    }
+                                }
+                            }
                         }
                     }
 
-                    if (!pArmor)
-                        continue;
+                    for (TESObjectARMO* pArmor : armors)
+                    {
+                        Inventory::Entry entry{};
+                        World::Get().GetModSystem().GetServerModId(pArmor->formID, entry.BaseId);
+                        entry.Count = 1;
+                        entry.ExtraWorn = true;
+                        fallback.Entries.push_back(std::move(entry));
 
-                    Inventory::Entry entry{};
-                    World::Get().GetModSystem().GetServerModId(pArmor->formID, entry.BaseId);
-                    entry.Count = 1;
-                    entry.ExtraWorn = true;
-                    fallback.Entries.push_back(std::move(entry));
+                        ++wearable;
+                        if (entry.BaseId != GameId{})
+                            ++mapped;
+                    }
                 }
+
+                spdlog::info("[NakedFix]   outfit {:X} outfitItems={} wearable={} mapped={} fallbackHasWorn={}",
+                             pOutfit->formID, pOutfit->outfitItems.size(), wearable, mapped,
+                             fallback.HasWornItems());
 
                 // Only use the fallback when it actually yields worn items; otherwise keep the
                 // (possibly legitimately empty) live snapshot so we never invent gear.
                 if (fallback.HasWornItems())
+                {
                     inventory = std::move(fallback);
+                    break;
+                }
             }
+        }
+        else
+        {
+            spdlog::info("[NakedFix]   pBase is null or not a TESNPC");
         }
     }
 
@@ -705,6 +750,20 @@ int32_t Actor::GetGoldAmount() const noexcept
 
 void Actor::SetActorInventory(const Inventory& acInventory) noexcept
 {
+    // If the incoming snapshot has no worn items but this actor is actually dressed, the
+    // snapshot is garbage (e.g. the server propagated a transient/broken naked state). Forcing
+    // it through SetInventory() would call RemoveAllItems() and strip a correctly-dressed NPC
+    // for no reason - there is nothing to unequip, so there is nothing to do. Skip the strip
+    // and the (now-pointless) magic-equip entirely. Dead NPCs and legitimately empty inventory
+    // (pickpocket/stripped alive NPC) snapshots are unaffected because they aren't "dressed".
+    if (!GetExtension()->IsPlayer() && !IsDead() && !acInventory.HasWornItems() &&
+        GetActorInventory().HasWornItems())
+    {
+        spdlog::info("Skipping inventory set for actor {:X}: incoming has no worn items but actor is dressed",
+                     formID);
+        return;
+    }
+
     spdlog::info("Setting inventory for actor {:X}", formID);
 
     // The UnEquipAll() that used to be here is redundant,

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -735,6 +735,33 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
     return fallback;
 }
 
+void Actor::ForceEquipWornArmor() noexcept
+{
+    // Read the RAW container worn state (GetArmor, not GetActorInventory -- the latter would
+    // substitute a derived outfit when empty and mask the true state). For every armor piece
+    // the container has flagged worn, re-issue the engine Equip with abForceEquip=true so the
+    // item is actually applied to the biped. This repairs the "container says dressed, render
+    // is naked" desync without inventing gear: only items already owned+flagged are equipped.
+    auto& modSystem = World::Get().GetModSystem();
+    auto* pEquipManager = EquipManager::Get();
+    auto& defaultObjects = DefaultObjectManager::Get();
+
+    Inventory armor = GetArmor();
+    for (const Inventory::Entry& entry : armor.Entries)
+    {
+        if (!entry.IsWorn())
+            continue;
+
+        const uint32_t objectId = modSystem.GetGameId(entry.BaseId);
+        TESBoundObject* pObject = Cast<TESBoundObject>(TESForm::GetById(objectId));
+        if (!pObject)
+            continue;
+
+        TESForm* pSlot = entry.ExtraWornLeft ? defaultObjects.leftEquipSlot : defaultObjects.rightEquipSlot;
+        pEquipManager->Equip(this, pObject, nullptr, 1, pSlot, false, true, false, false);
+    }
+}
+
 MagicEquipment Actor::GetMagicEquipment() const noexcept
 {
     MagicEquipment equipment;

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -694,7 +694,7 @@ Inventory Actor::GetActorInventory() const noexcept
                 }
 
                 spdlog::info("[NakedFix]   outfit {:X} outfitItems={} wearable={} mapped={} fallbackHasWorn={}",
-                             pOutfit->formID, pOutfit->outfitItems.size(), wearable, mapped,
+                             pOutfit->formID, pOutfit->outfitItems.length, wearable, mapped,
                              fallback.HasWornItems());
 
                 // Only use the fallback when it actually yields worn items; otherwise keep the

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -520,6 +520,50 @@ bool Actor::ShouldWearBodyPiece() const noexcept
     return false;
 }
 
+void Actor::SetOutfit(BGSOutfit* apOutfit, bool aIsSleepOutfit) 
+{
+    PAPYRUS_FUNCTION(void, Actor, SetOutfit, const BGSOutfit*, bool);
+    s_pSetOutfit(this, apOutfit, aIsSleepOutfit);
+}
+
+void Actor::EquipOutfit(bool aIsSleepOutfit) noexcept
+{
+    auto* pBase = Cast<TESNPC>(baseForm);
+    if (!pBase)
+        return;
+
+    BGSOutfit* pDefaultOutfit = pBase->outfits[aIsSleepOutfit ? 1:0];
+    if (!pDefaultOutfit)
+        return;
+
+    auto* pEquipManager = EquipManager::Get();
+    for (auto* pItem : pDefaultOutfit->outfitItems)
+    {
+        TESObjectARMO* pArmor = nullptr;
+
+        if (pItem->formType == FormType::Armor)
+            pArmor = Cast<TESObjectARMO>(pItem);
+        else if (pItem->formType == FormType::LeveledItem)
+        {
+            TESLevItem* pLevItem = Cast<TESLevItem>(pItem);
+            if (!pLevItem || !pLevItem->pLeveledListA || !pLevItem->pLeveledListA->pForm)
+                continue;
+
+            pArmor = Cast<TESObjectARMO>(pLevItem->pLeveledListA->pForm);
+        }
+        else
+            continue;
+
+        if (!pArmor)
+            continue;
+
+        spdlog::debug(__FUNCTION__ ": equipping {:X} on actor {:X} {}", pArmor->formID, formID, baseForm->GetName());
+        pEquipManager->Equip(this, pArmor, nullptr, 1, nullptr, false, true, false, false);  
+    }
+
+    return;
+}
+
 // Get owner of a summon or raised corpse
 Actor* Actor::GetCommandingActor() const noexcept
 {

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -5,6 +5,9 @@
 #include <Misc/GameVM.h>
 #include <DefaultObjectManager.h>
 #include <Forms/TESNPC.h>
+#include <Forms/TESObjectARMO.h>
+#include <Forms/TESLevItem.h>
+#include <Forms/BGSOutfit.h>
 #include <Forms/TESFaction.h>
 #include <Components/TESActorBaseData.h>
 #include <ExtraData/ExtraFactionChanges.h>
@@ -233,6 +236,17 @@ ActorExtension* Actor::GetExtension() noexcept
     {
         return static_cast<ActorExtension*>(AsExPlayerCharacter());
     }
+
+    return nullptr;
+}
+
+const ActorExtension* Actor::GetExtension() const noexcept
+{
+    if (formType == Type && this != PlayerCharacter::Get())
+        return static_cast<const ExActor*>(this);
+
+    if (this == PlayerCharacter::Get())
+        return static_cast<const ExPlayerCharacter*>(this);
 
     return nullptr;
 }
@@ -599,6 +613,59 @@ Inventory Actor::GetActorInventory() const noexcept
     Inventory inventory = GetInventory();
 
     inventory.CurrentMagicEquipment = GetMagicEquipment();
+
+    // Root-cause fix for the "naked NPC on reload" race: when a client sends its inventory
+    // snapshot during the transient window right after a cell reload (before the engine has
+    // re-dressed the NPC), GetInventory() reports the actor as wearing nothing. If we forward
+    // that naked snapshot to the server it becomes the authoritative Content and propagates
+    // nakedness to every client. The server can't derive a dressed inventory, so the owner
+    // client - which has engine access - must send correct data instead: fall back to the
+    // NPC's default outfit. This only triggers on the broken fully-naked state, so legitimate
+    // pickpocket removals (incremental path) and dead-NPC loot (the alive check below) are
+    // unaffected.
+    if (!GetExtension()->IsPlayer() && !IsDead() && !inventory.HasWornItems())
+    {
+        if (const TESNPC* pBase = Cast<TESNPC>(baseForm))
+        {
+            if (BGSOutfit* pDefaultOutfit = pBase->outfits[0])
+            {
+                Inventory fallback{};
+                fallback.CurrentMagicEquipment = inventory.CurrentMagicEquipment;
+
+                for (TESForm* pItem : pDefaultOutfit->outfitItems)
+                {
+                    if (!pItem)
+                        continue;
+
+                    TESObjectARMO* pArmor = nullptr;
+                    if (pItem->formType == FormType::Armor)
+                        pArmor = Cast<TESObjectARMO>(pItem);
+                    else if (pItem->formType == FormType::LeveledItem)
+                    {
+                        if (const TESLevItem* pLevItem = Cast<TESLevItem>(pItem))
+                        {
+                            if (pLevItem->pLeveledListA && pLevItem->pLeveledListA->pForm)
+                                pArmor = Cast<TESObjectARMO>(pLevItem->pLeveledListA->pForm);
+                        }
+                    }
+
+                    if (!pArmor)
+                        continue;
+
+                    Inventory::Entry entry{};
+                    World::Get().GetModSystem().GetServerModId(pArmor->formID, entry.BaseId);
+                    entry.Count = 1;
+                    entry.ExtraWorn = true;
+                    fallback.Entries.push_back(std::move(entry));
+                }
+
+                // Only use the fallback when it actually yields worn items; otherwise keep the
+                // (possibly legitimately empty) live snapshot so we never invent gear.
+                if (fallback.HasWornItems())
+                    inventory = std::move(fallback);
+            }
+        }
+    }
 
     return inventory;
 }

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -788,7 +788,10 @@ void Actor::SetActorInventory(const Inventory& acInventory) noexcept
 
             spdlog::info("Setting inventory for actor {:X}", formID);
             if (!this->GetExtension()->IsPlayer() && toApply.ContainsQuestItems())
-                SetInventoryRetainingQuestItems(GetActorInventory(), toApply);
+            {
+                Inventory currentInventory = GetActorInventory();
+                SetInventoryRetainingQuestItems(currentInventory, toApply);
+            }
             else
                 SetInventory(toApply);
 

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -737,6 +737,17 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
 
 void Actor::ForceEquipWornArmor() noexcept
 {
+    // Only touch actors whose 3D + AI process are actually present; forcing an engine equip on
+    // an actor that isn't fully loaded (e.g. a just-spawned dynamic FE summon during the
+    // deferred re-check) dereferences uninitialised biped/process state and crashes.
+    if (!GetNiNode() || !currentProcess)
+        return;
+
+    // Suppress the equip hook's network sync + re-entrancy: every internal engine-side equip in
+    // this codebase runs under ScopedEquipOverride. Without it each forced equip fires
+    // OnEquipmentChangeEvent (spamming the server) and re-enters the equip path, which crashed.
+    ScopedEquipOverride equipOverride;
+
     // Read the RAW container worn state (GetArmor, not GetActorInventory -- the latter would
     // substitute a derived outfit when empty and mask the true state). For every armor piece
     // the container has flagged worn, re-issue the engine Equip with abForceEquip=true so the

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -50,7 +50,6 @@
 #include <Games/Skyrim/BSAnimationGraphManager.h>
 #include <Havok/hkbStateMachine.h>
 #include <Havok/hkbBehaviorGraph.h>
-#include <Forms/BGSOutfit.h>
 #include <Forms/TESObjectARMO.h>
 
 #include <ModCompat/BehaviorVar.h>
@@ -477,93 +476,6 @@ TESForm* Actor::GetEquippedAmmo() const noexcept
 
     return nullptr;
 }
-
-bool Actor::IsWearingBodyPiece() const noexcept
-{
-    return GetContainerChanges()->GetArmor(32) != nullptr;
-}
-
-bool Actor::ShouldWearBodyPiece() const noexcept
-{
-    TESNPC* pBase = Cast<TESNPC>(baseForm);
-    if (!pBase)
-        return false;
-
-    BGSOutfit* pDefaultOutfit = pBase->outfits[0];
-    if (!pDefaultOutfit)
-        return false;
-
-    for (auto* pItem : pDefaultOutfit->outfitItems)
-    {
-        TESObjectARMO* pArmor = nullptr;
-
-        if (pItem->formType == FormType::Armor)
-            pArmor = Cast<TESObjectARMO>(pItem);
-        else if (pItem->formType == FormType::LeveledItem)
-        {
-            TESLevItem* pLevItem = Cast<TESLevItem>(pItem);
-            if (!pLevItem || !pLevItem->pLeveledListA || !pLevItem->pLeveledListA->pForm)
-                continue;
-
-            pArmor = Cast<TESObjectARMO>(pLevItem->pLeveledListA->pForm);
-        }
-        else
-            continue;
-
-        if (!pArmor)
-            continue;
-
-        if (pArmor->IsBodyPiece()) 
-            return true;
-    }
-
-    return false;
-}
-
-void Actor::SetOutfit(BGSOutfit* apOutfit, bool aIsSleepOutfit) 
-{
-    PAPYRUS_FUNCTION(void, Actor, SetOutfit, const BGSOutfit*, bool);
-    s_pSetOutfit(this, apOutfit, aIsSleepOutfit);
-}
-
-void Actor::EquipOutfit(bool aIsSleepOutfit) noexcept
-{
-    auto* pBase = Cast<TESNPC>(baseForm);
-    if (!pBase)
-        return;
-
-    BGSOutfit* pDefaultOutfit = pBase->outfits[aIsSleepOutfit ? 1:0];
-    if (!pDefaultOutfit)
-        return;
-
-    auto* pEquipManager = EquipManager::Get();
-    for (auto* pItem : pDefaultOutfit->outfitItems)
-    {
-        TESObjectARMO* pArmor = nullptr;
-
-        if (pItem->formType == FormType::Armor)
-            pArmor = Cast<TESObjectARMO>(pItem);
-        else if (pItem->formType == FormType::LeveledItem)
-        {
-            TESLevItem* pLevItem = Cast<TESLevItem>(pItem);
-            if (!pLevItem || !pLevItem->pLeveledListA || !pLevItem->pLeveledListA->pForm)
-                continue;
-
-            pArmor = Cast<TESObjectARMO>(pLevItem->pLeveledListA->pForm);
-        }
-        else
-            continue;
-
-        if (!pArmor)
-            continue;
-
-        spdlog::debug(__FUNCTION__ ": equipping {:X} on actor {:X} {}", pArmor->formID, formID, baseForm->GetName());
-        pEquipManager->Equip(this, pArmor, nullptr, 1, nullptr, false, true, false, false);  
-    }
-
-    return;
-}
-
 // Get owner of a summon or raised corpse
 Actor* Actor::GetCommandingActor() const noexcept
 {

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -735,44 +735,6 @@ Inventory Actor::DeriveOutfitInventory() const noexcept
     return fallback;
 }
 
-void Actor::ForceEquipWornArmor() noexcept
-{
-    // Only touch actors whose 3D + AI process are actually present; forcing an engine equip on
-    // an actor that isn't fully loaded (e.g. a just-spawned dynamic FE summon during the
-    // deferred re-check) dereferences uninitialised biped/process state and crashes.
-    if (!GetNiNode() || !currentProcess)
-        return;
-
-    // Suppress the equip hook's network sync + re-entrancy: every internal engine-side equip in
-    // this codebase runs under ScopedEquipOverride. Without it each forced equip fires
-    // OnEquipmentChangeEvent (spamming the server) and re-enters the equip path, which crashed.
-    ScopedEquipOverride equipOverride;
-
-    // Read the RAW container worn state (GetArmor, not GetActorInventory -- the latter would
-    // substitute a derived outfit when empty and mask the true state). For every armor piece
-    // the container has flagged worn, re-issue the engine Equip with abForceEquip=true so the
-    // item is actually applied to the biped. This repairs the "container says dressed, render
-    // is naked" desync without inventing gear: only items already owned+flagged are equipped.
-    auto& modSystem = World::Get().GetModSystem();
-    auto* pEquipManager = EquipManager::Get();
-    auto& defaultObjects = DefaultObjectManager::Get();
-
-    Inventory armor = GetArmor();
-    for (const Inventory::Entry& entry : armor.Entries)
-    {
-        if (!entry.IsWorn())
-            continue;
-
-        const uint32_t objectId = modSystem.GetGameId(entry.BaseId);
-        TESBoundObject* pObject = Cast<TESBoundObject>(TESForm::GetById(objectId));
-        if (!pObject)
-            continue;
-
-        TESForm* pSlot = entry.ExtraWornLeft ? defaultObjects.leftEquipSlot : defaultObjects.rightEquipSlot;
-        pEquipManager->Equip(this, pObject, nullptr, 1, pSlot, false, true, false, false);
-    }
-}
-
 MagicEquipment Actor::GetMagicEquipment() const noexcept
 {
     MagicEquipment equipment;

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -628,91 +628,99 @@ Inventory Actor::GetActorInventory() const noexcept
         spdlog::info("[NakedFix] fallback path for actor {:X} (base {:X})", formID,
                      baseForm ? baseForm->formID : 0);
 
-        if (const TESNPC* pBase = Cast<TESNPC>(baseForm))
+        Inventory fallback = DeriveOutfitInventory();
+        if (fallback.HasWornItems())
         {
-            // NPCs may carry their default outfit in either outfits[0] or outfits[1]; some
-            // (e.g. guards) only define outfits[1]. Try both slots before giving up.
-            for (BGSOutfit* pOutfit : {pBase->outfits[0], pBase->outfits[1]})
-            {
-                if (!pOutfit)
-                    continue;
-
-                Inventory fallback{};
-                fallback.CurrentMagicEquipment = inventory.CurrentMagicEquipment;
-
-                size_t wearable = 0;
-                size_t mapped = 0;
-
-                for (TESForm* pItem : pOutfit->outfitItems)
-                {
-                    if (!pItem)
-                        continue;
-
-                    // Collect every armor this outfit item can resolve to: a direct ARMO, or
-                    // any entry in a leveled item list (Skyrim only uses list A).
-                    Vector<TESObjectARMO*> armors;
-
-                    if (pItem->formType == FormType::Armor)
-                    {
-                        if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(pItem))
-                            armors.push_back(pArmor);
-                    }
-                    else if (pItem->formType == FormType::LeveledItem)
-                    {
-                        if (const TESLevItem* pLevItem = Cast<TESLevItem>(pItem))
-                        {
-                            auto* pList = pLevItem->pLeveledListA;
-                            if (pList)
-                            {
-                                // count is stored 8 bytes before the array base.
-                                const auto count = *reinterpret_cast<const int32_t*>(
-                                    reinterpret_cast<const uint8_t*>(pList) - 8);
-                                for (int32_t i = 0; i < count; ++i)
-                                {
-                                    if (pList[i].pForm)
-                                    {
-                                        if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(pList[i].pForm))
-                                            armors.push_back(pArmor);
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    for (TESObjectARMO* pArmor : armors)
-                    {
-                        Inventory::Entry entry{};
-                        World::Get().GetModSystem().GetServerModId(pArmor->formID, entry.BaseId);
-                        entry.Count = 1;
-                        entry.ExtraWorn = true;
-                        fallback.Entries.push_back(std::move(entry));
-
-                        ++wearable;
-                        if (entry.BaseId != GameId{})
-                            ++mapped;
-                    }
-                }
-
-                spdlog::info("[NakedFix]   outfit {:X} outfitItems={} wearable={} mapped={} fallbackHasWorn={}",
-                             pOutfit->formID, pOutfit->outfitItems.length, wearable, mapped,
-                             fallback.HasWornItems());
-
-                // Only use the fallback when it actually yields worn items; otherwise keep the
-                // (possibly legitimately empty) live snapshot so we never invent gear.
-                if (fallback.HasWornItems())
-                {
-                    inventory = std::move(fallback);
-                    break;
-                }
-            }
+            inventory = std::move(fallback);
         }
         else
         {
-            spdlog::info("[NakedFix]   pBase is null or not a TESNPC");
+            spdlog::info("[NakedFix]   no wearable outfit derived (base {:X})",
+                         baseForm ? baseForm->formID : 0);
         }
     }
 
     return inventory;
+}
+
+Inventory Actor::DeriveOutfitInventory() const noexcept
+{
+    Inventory fallback{};
+
+    const TESNPC* pBase = Cast<TESNPC>(baseForm);
+    if (!pBase)
+        return fallback;
+
+    // NPCs may carry their default outfit in either outfits[0] or outfits[1]; some
+    // (e.g. guards) only define outfits[1]. Try both slots before giving up.
+    for (BGSOutfit* pOutfit : {pBase->outfits[0], pBase->outfits[1]})
+    {
+        if (!pOutfit)
+            continue;
+
+        size_t wearable = 0;
+        size_t mapped = 0;
+
+        for (TESForm* pItem : pOutfit->outfitItems)
+        {
+            if (!pItem)
+                continue;
+
+            // Collect every armor this outfit item can resolve to: a direct ARMO, or
+            // any entry in a leveled item list (Skyrim only uses list A).
+            Vector<TESObjectARMO*> armors;
+
+            if (pItem->formType == FormType::Armor)
+            {
+                if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(pItem))
+                    armors.push_back(pArmor);
+            }
+            else if (pItem->formType == FormType::LeveledItem)
+            {
+                if (const TESLevItem* pLevItem = Cast<TESLevItem>(pItem))
+                {
+                    auto* pList = pLevItem->pLeveledListA;
+                    if (pList)
+                    {
+                        // count is stored 8 bytes before the array base.
+                        const auto count = *reinterpret_cast<const int32_t*>(
+                            reinterpret_cast<const uint8_t*>(pList) - 8);
+                        for (int32_t i = 0; i < count; ++i)
+                        {
+                            if (pList[i].pForm)
+                            {
+                                if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(pList[i].pForm))
+                                    armors.push_back(pArmor);
+                            }
+                        }
+                    }
+                }
+            }
+
+            for (TESObjectARMO* pArmor : armors)
+            {
+                Inventory::Entry entry{};
+                World::Get().GetModSystem().GetServerModId(pArmor->formID, entry.BaseId);
+                entry.Count = 1;
+                entry.ExtraWorn = true;
+                fallback.Entries.push_back(std::move(entry));
+
+                ++wearable;
+                if (entry.BaseId != GameId{})
+                    ++mapped;
+            }
+        }
+
+        spdlog::info("[NakedFix]   outfit {:X} outfitItems={} wearable={} mapped={} fallbackHasWorn={}",
+                     pOutfit->formID, pOutfit->outfitItems.length, wearable, mapped,
+                     fallback.HasWornItems());
+
+        // Use the first outfit slot that yields worn items; otherwise keep trying.
+        if (fallback.HasWornItems())
+            break;
+    }
+
+    return fallback;
 }
 
 MagicEquipment Actor::GetMagicEquipment() const noexcept
@@ -750,25 +758,52 @@ int32_t Actor::GetGoldAmount() const noexcept
 
 void Actor::SetActorInventory(const Inventory& acInventory) noexcept
 {
-    // If the incoming snapshot has no worn items but this actor is actually dressed, the
-    // snapshot is garbage (e.g. the server propagated a transient/broken naked state). Forcing
-    // it through SetInventory() would call RemoveAllItems() and strip a correctly-dressed NPC
-    // for no reason - there is nothing to unequip, so there is nothing to do. Skip the strip
-    // and the (now-pointless) magic-equip entirely. Dead NPCs and legitimately empty inventory
-    // (pickpocket/stripped alive NPC) snapshots are unaffected because they aren't "dressed".
-    if (!GetExtension()->IsPlayer() && !IsDead() && !acInventory.HasWornItems() &&
-        GetActorInventory().HasWornItems())
+    // Garbage-naked server snapshot (no worn items at all). This is the high-frequency naked-
+    // NPC race: an NPC receives an empty-worn snapshot during an ownership flip / spawn, and
+    // would otherwise be stripped (or left undressed if it was a leveled/temp-base spawn that
+    // was never dressed yet). Per the project's naked-NPC domain rule, a fully-empty inventory
+    // is only legitimate for a DEAD NPC (loot all) or an alive NPC being incrementally
+    // pickpocketed/looted (which sends non-empty WORN entries, so it never reaches here).
+    // So a naked snapshot on a living, non-player NPC is always broken and we substitute the
+    // local engine-derived outfit instead of applying the empty one.
+    if (!GetExtension()->IsPlayer() && !IsDead() && !acInventory.HasWornItems())
     {
-        spdlog::info("Skipping inventory set for actor {:X}: incoming has no worn items but actor is dressed",
+        Inventory derived = DeriveOutfitInventory();
+        if (derived.HasWornItems())
+        {
+            spdlog::info("[NakedFix] substituting derived outfit for actor {:X} (base {:X}) "
+                         "instead of applying naked snapshot",
+                         formID, baseForm ? baseForm->formID : 0);
+
+            // Supplement: keep any non-worn inventory the server did send (e.g. gold, quest
+            // items, food) and add the derived worn items on top. Preserves legit contents
+            // while guaranteeing the NPC ends up dressed.
+            Inventory toApply = acInventory;
+            for (auto& entry : derived.Entries)
+            {
+                if (entry.IsWorn())
+                    toApply.Entries.push_back(entry);
+            }
+            toApply.CurrentMagicEquipment = acInventory.CurrentMagicEquipment;
+
+            spdlog::info("Setting inventory for actor {:X}", formID);
+            if (!this->GetExtension()->IsPlayer() && toApply.ContainsQuestItems())
+                SetInventoryRetainingQuestItems(GetActorInventory(), toApply);
+            else
+                SetInventory(toApply);
+
+            SetMagicEquipment(toApply.CurrentMagicEquipment);
+            return;
+        }
+
+        // No wearable outfit could be derived (genuinely empty base outfit, animal, missing
+        // base form, etc.). Nothing we can do locally; let the normal path run so we don't
+        // invent gear.
+        spdlog::info("[NakedFix] actor {:X} has no derivable outfit; applying snapshot as-is",
                      formID);
-        return;
     }
 
     spdlog::info("Setting inventory for actor {:X}", formID);
-
-    // The UnEquipAll() that used to be here is redundant,
-    // as RemoveAllItems() unequips every item if needed.
-    // Placing this UnEquipAll() here seems to trigger a Skyrim bug/race.
 
     Inventory currentInventory = GetActorInventory();
 

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -195,6 +195,11 @@ struct Actor : TESObjectREFR
     float GetActorValue(uint32_t aId) const noexcept;
     float GetActorPermanentValue(uint32_t aId) const noexcept;
     Inventory GetActorInventory() const noexcept;
+    // Derives a dressed inventory from this NPC's default outfit (outfits[0]/[1], leveled
+    // list A). Returns an inventory with worn entries, or empty if the base has no wearable
+    // outfit (e.g. genuinely empty outfit, animals, or missing base form). Used to substitute
+    // a garbage-naked server snapshot with the author's local engine-derived outfit.
+    Inventory DeriveOutfitInventory() const noexcept;
     MagicEquipment GetMagicEquipment() const noexcept;
     Inventory GetEquipment() const noexcept;
     int32_t GetGoldAmount() const noexcept;

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -181,6 +181,7 @@ struct Actor : TESObjectREFR
 
     // Casting
     ActorExtension* GetExtension() noexcept;
+    const ActorExtension* GetExtension() const noexcept;
     ExActor* AsExActor() noexcept;
     ExPlayerCharacter* AsExPlayerCharacter() noexcept;
 

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -200,6 +200,12 @@ struct Actor : TESObjectREFR
     // outfit (e.g. genuinely empty outfit, animals, or missing base form). Used to substitute
     // a garbage-naked server snapshot with the author's local engine-derived outfit.
     Inventory DeriveOutfitInventory() const noexcept;
+    // Force the engine to re-equip every container item flagged worn onto the actor's biped.
+    // Fixes the case where the logical inventory reports worn armor but the actor's actual
+    // equip/render state is empty (naked render despite a "dressed" container) -- e.g. a
+    // locally-owned templated NPC after spawn or an ownership change. Idempotent on the render:
+    // re-equipping an already-worn piece is a visual no-op.
+    void ForceEquipWornArmor() noexcept;
     MagicEquipment GetMagicEquipment() const noexcept;
     Inventory GetEquipment() const noexcept;
     int32_t GetGoldAmount() const noexcept;

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -22,7 +22,6 @@ struct ActorExtension;
 struct AIProcess;
 struct CombatController;
 struct TESIdleForm;
-struct BGSOutfit;
 
 struct Actor : TESObjectREFR
 {
@@ -208,8 +207,6 @@ struct Actor : TESObjectREFR
     [[nodiscard]] Actor* GetCombatTarget() const noexcept;
     [[nodiscard]] bool HasPerk(uint32_t aPerkFormId) const noexcept;
     [[nodiscard]] uint8_t GetPerkRank(uint32_t aPerkFormId) const noexcept;
-    [[nodiscard]] bool IsWearingBodyPiece() const noexcept;
-    [[nodiscard]] bool ShouldWearBodyPiece() const noexcept;
     [[nodiscard]] bool IsVampireLord() const noexcept;
 
     // Setters
@@ -252,8 +249,6 @@ struct Actor : TESObjectREFR
     bool PlayIdle(TESIdleForm* apIdle) noexcept;
     void FixVampireLordModel() noexcept;
     bool RemoveSpell(MagicItem* apSpell) noexcept;
-    void SetOutfit(BGSOutfit* apOutfit, bool aIsSleepOutfit = false);
-    void EquipOutfit(bool aIsSleepOutfit = false) noexcept;
 
     enum ActorFlags
     {

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -200,12 +200,6 @@ struct Actor : TESObjectREFR
     // outfit (e.g. genuinely empty outfit, animals, or missing base form). Used to substitute
     // a garbage-naked server snapshot with the author's local engine-derived outfit.
     Inventory DeriveOutfitInventory() const noexcept;
-    // Force the engine to re-equip every container item flagged worn onto the actor's biped.
-    // Fixes the case where the logical inventory reports worn armor but the actor's actual
-    // equip/render state is empty (naked render despite a "dressed" container) -- e.g. a
-    // locally-owned templated NPC after spawn or an ownership change. Idempotent on the render:
-    // re-equipping an already-worn piece is a visual no-op.
-    void ForceEquipWornArmor() noexcept;
     MagicEquipment GetMagicEquipment() const noexcept;
     Inventory GetEquipment() const noexcept;
     int32_t GetGoldAmount() const noexcept;

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -22,6 +22,7 @@ struct ActorExtension;
 struct AIProcess;
 struct CombatController;
 struct TESIdleForm;
+struct BGSOutfit;
 
 struct Actor : TESObjectREFR
 {
@@ -251,6 +252,8 @@ struct Actor : TESObjectREFR
     bool PlayIdle(TESIdleForm* apIdle) noexcept;
     void FixVampireLordModel() noexcept;
     bool RemoveSpell(MagicItem* apSpell) noexcept;
+    void SetOutfit(BGSOutfit* apOutfit, bool aIsSleepOutfit = false);
+    void EquipOutfit(bool aIsSleepOutfit = false) noexcept;
 
     enum ActorFlags
     {

--- a/Code/client/Games/Skyrim/EquipManager.cpp
+++ b/Code/client/Games/Skyrim/EquipManager.cpp
@@ -173,7 +173,12 @@ void* TP_MAKE_THISCALL(EquipHook, EquipManager, Actor* apActor, TESForm* apItem,
     // Consumables are "equipped" as well. We don't want this to sync, for several reasons.
     // The right hand item on the server would be overridden by the consumable.
     // Furthermore, the equip action on the other clients would doubly subtract the consumables.
-    if (pExtension->IsLocal() && !apItem->IsConsumable() && !apData->bQueueEquip)
+    // Also suppress the sync when an internal equip is in progress (ScopedEquipOverride):
+    // SetInventory/SetActorInventory re-dress a locally-owned NPC by calling Equip per item,
+    // and that would otherwise broadcast one EquipmentChangeEvent per worn piece to the server
+    // (a self-heal storm on the owner client). Player-driven equips are not under the override,
+    // so genuine user/AI equip stays synced.
+    if (pExtension->IsLocal() && !apItem->IsConsumable() && !apData->bQueueEquip && !ScopedEquipOverride::IsOverriden())
     {
         EquipmentChangeEvent evt{};
         evt.ActorId = apActor->formID;

--- a/Code/client/Games/Skyrim/EquipManager.cpp
+++ b/Code/client/Games/Skyrim/EquipManager.cpp
@@ -136,6 +136,22 @@ void EquipManager::UnequipAll(Actor* apActor)
     TP_THIS_FUNCTION(TUnEquipAll, void, EquipManager, Actor*);
     POINTER_SKYRIMSE(TUnEquipAll, s_unequipAll, 38899);
 
+    // Root-cause guard for the naked-NPC race: when a locally-owned NPC's 3D finishes loading,
+    // the engine runs an equip pass that calls UnequipAll (strips everything) and then re-equips
+    // from the NPC's engine-side equipment -- which is empty/incomplete for a remotely-spawned
+    // NPC, leaving it naked/partial. A full unequip of a LIVING non-player NPC that currently
+    // has worn items is never legitimate (dead-NPC loot clears and single-item unequips use
+    // other paths; the player is excluded). Skip the engine unequip so the NPC cannot be
+    // undressed this way. This is the actual stripper for the guard-naked cases (the
+    // SetInventory guard did not catch them).
+    if (apActor && !apActor->GetExtension()->IsPlayer() && !apActor->IsDead() &&
+        apActor->GetActorInventory().HasWornItems())
+    {
+        spdlog::info("[NakedFix] UnequipAll: skipping full unequip of living actor {:X} (base {:X})",
+                     apActor->formID, apActor->baseForm ? apActor->baseForm->formID : 0);
+        return;
+    }
+
     ScopedEquipOverride equipOverride;
 
     TiltedPhoques::ThisCall(s_unequipAll, this, apActor);

--- a/Code/client/Games/Skyrim/TESObjectREFR.cpp
+++ b/Code/client/Games/Skyrim/TESObjectREFR.cpp
@@ -2,6 +2,7 @@
 
 #include <Games/References.h>
 #include <Games/Overrides.h>
+#include <Forms/TESObjectARMO.h>
 
 #include <World.h>
 #include <Services/PapyrusService.h>
@@ -786,11 +787,53 @@ void TESObjectREFR::SetInventory(const Inventory& aInventory) noexcept
         }
     }
 
+    // Remote body-slot fallback: Skyrim's nude body skin is never synced (SaveSkinFar is
+    // disabled), so a remote actor only gets a torso/legs/feet mesh if its inventory carries
+    // a body-slot (cuirass) ARMO. A player wearing e.g. helmet+boots but no body armor - or a
+    // fully nude player - renders with no body on other clients (and no feet, since feet are
+    // part of the body-slot model). Inject a worn body ARMO so the remote client has a body
+    // model to render. Server inventory is untouched (we only mutate the local working copy).
+    Inventory applied = aInventory;
+    if (auto* pActor = Cast<Actor>(this))
+    {
+        bool hasBody = false;
+        if (pActor->GetExtension()->IsRemote())
+        {
+            for (const auto& entry : applied.Entries)
+            {
+                if (!entry.IsWorn())
+                    continue;
+                const uint32_t id = World::Get().GetModSystem().GetGameId(entry.BaseId);
+                if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(TESForm::GetById(id)))
+                {
+                    if (pArmor->IsBodyPiece())
+                    {
+                        hasBody = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!hasBody)
+        {
+            Inventory::Entry bodyEntry{};
+            // Vampire Lord armor (Dawnguard, mod index 0x02) - an ARMO whose body model
+            // renders the actor's nude body. Stand-in until a load-order-independent nude
+            // body is found.
+            bodyEntry.BaseId = GameId{0x02, 0x11A85};
+            bodyEntry.Count = 1;
+            bodyEntry.ExtraWorn = true;
+            applied.Entries.push_back(bodyEntry);
+            spdlog::info("[NakedFix] SetInventory: injected body ARMO for remote actor {:X} (no body-slot armor worn)", formID);
+        }
+    }
+
     ScopedInventoryOverride _;
 
     RemoveAllItems();
 
-    for (const Inventory::Entry& entry : aInventory.Entries)
+    for (const Inventory::Entry& entry : applied.Entries)
     {
         if (entry.Count != 0)
             AddOrRemoveItem(entry, true);

--- a/Code/client/Games/Skyrim/TESObjectREFR.cpp
+++ b/Code/client/Games/Skyrim/TESObjectREFR.cpp
@@ -787,17 +787,19 @@ void TESObjectREFR::SetInventory(const Inventory& aInventory) noexcept
         }
     }
 
-    // Remote body-slot fallback: Skyrim's nude body skin is never synced (SaveSkinFar is
-    // disabled), so a remote actor only gets a torso/legs/feet mesh if its inventory carries
-    // a body-slot (cuirass) ARMO. A player wearing e.g. helmet+boots but no body armor - or a
-    // fully nude player - renders with no body on other clients (and no feet, since feet are
-    // part of the body-slot model). Inject a worn body ARMO so the remote client has a body
-    // model to render. Server inventory is untouched (we only mutate the local working copy).
+    // Remote body-slot fallback (players only): Skyrim's nude body skin is never synced
+    // (SaveSkinFar is disabled), so a remote player only gets a torso/legs/feet mesh if its
+    // inventory carries a body-slot (cuirass) ARMO. A player wearing e.g. helmet+boots but no
+    // body armor - or a fully nude player - renders with no body on other clients (and no feet,
+    // since feet are part of the body-slot model). Inject a worn body ARMO so the remote client
+    // has a body model to render. Server inventory is untouched (we only mutate the local working
+    // copy). NPCs are deliberately excluded: the stand-in body ARMO does not fit NPC bodies and
+    // would leave them naked, and NPCs normally carry a body via their base outfit/worn armor.
     Inventory applied = aInventory;
     if (auto* pActor = Cast<Actor>(this))
     {
         bool hasBody = false;
-        if (pActor->GetExtension()->IsRemote())
+        if (pActor->GetExtension()->IsRemotePlayer())
         {
             for (const auto& entry : applied.Entries)
             {
@@ -825,7 +827,7 @@ void TESObjectREFR::SetInventory(const Inventory& aInventory) noexcept
             bodyEntry.Count = 1;
             bodyEntry.ExtraWorn = true;
             applied.Entries.push_back(bodyEntry);
-            spdlog::info("[NakedFix] SetInventory: injected body ARMO for remote actor {:X} (no body-slot armor worn)", formID);
+            spdlog::info("[NakedFix] SetInventory: injected body ARMO for remote player {:X} (no body-slot armor worn)", formID);
         }
     }
 

--- a/Code/client/Games/Skyrim/TESObjectREFR.cpp
+++ b/Code/client/Games/Skyrim/TESObjectREFR.cpp
@@ -796,23 +796,20 @@ void TESObjectREFR::SetInventory(const Inventory& aInventory) noexcept
     // copy). NPCs are deliberately excluded: the stand-in body ARMO does not fit NPC bodies and
     // would leave them naked, and NPCs normally carry a body via their base outfit/worn armor.
     Inventory applied = aInventory;
-    if (auto* pActor = Cast<Actor>(this))
+    if (auto* pActor = Cast<Actor>(this); pActor && pActor->GetExtension()->IsRemotePlayer())
     {
         bool hasBody = false;
-        if (pActor->GetExtension()->IsRemotePlayer())
+        for (const auto& entry : applied.Entries)
         {
-            for (const auto& entry : applied.Entries)
+            if (!entry.IsWorn())
+                continue;
+            const uint32_t id = World::Get().GetModSystem().GetGameId(entry.BaseId);
+            if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(TESForm::GetById(id)))
             {
-                if (!entry.IsWorn())
-                    continue;
-                const uint32_t id = World::Get().GetModSystem().GetGameId(entry.BaseId);
-                if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(TESForm::GetById(id)))
+                if (pArmor->IsBodyPiece())
                 {
-                    if (pArmor->IsBodyPiece())
-                    {
-                        hasBody = true;
-                        break;
-                    }
+                    hasBody = true;
+                    break;
                 }
             }
         }

--- a/Code/client/Games/Skyrim/TESObjectREFR.cpp
+++ b/Code/client/Games/Skyrim/TESObjectREFR.cpp
@@ -770,6 +770,22 @@ void TESObjectREFR::SetInventory(const Inventory& aInventory) noexcept
 {
     spdlog::debug("Setting inventory for {:X}", formID);
 
+    // Root-cause guard for the naked-NPC race: when a locally-owned NPC's 3D finishes loading,
+    // the engine runs its own equip pass that calls SetInventory with an EMPTY/incomplete
+    // inventory, and this function does RemoveAllItems() first -- stripping the NPC. A fully
+    // naked overwrite of a LIVING non-player actor is never legitimate (dead-NPC loot clears
+    // and incremental pickpocket both send non-empty worn entries, and the player is excluded).
+    // Skip the strip+reapply so the engine cannot undress a living NPC this way.
+    if (auto* pActor = Cast<Actor>(this))
+    {
+        if (!pActor->GetExtension()->IsPlayer() && !pActor->IsDead() && !aInventory.HasWornItems())
+        {
+            spdlog::info("[NakedFix] SetInventory: skipping fully-naked strip of living actor {:X} (base {:X})",
+                         formID, baseForm ? baseForm->formID : 0);
+            return;
+        }
+    }
+
     ScopedInventoryOverride _;
 
     RemoveAllItems();

--- a/Code/client/Services/CharacterService.h
+++ b/Code/client/Services/CharacterService.h
@@ -131,14 +131,20 @@ private:
 
     Map<uint32_t, WeaponDrawData> m_weaponDrawUpdates{};
 
-    // Owner self-heal deferred retry: at ownership-claim time a locally-owned NPC's 3D/biped
-    // may not be ready, so the immediate re-dress can no-op and leave it naked on the owner's
-    // screen. Retry the dress a moment later on the update tick (2 passes, like weapon draws,
-    // because Skyrim biped state is finnicky). mutable: enqueued from const TakeOwnership.
+    // Owner self-heal deferred retry: at ownership-claim/transfer time a locally-owned NPC can
+    // end up naked on the owner's screen. Two causes: (1) the biped 3D isn't ready yet at claim
+    // time, or (2) an ownership TRANSFER strips the biped but leaves the container's worn flags
+    // set, so a plain re-dress is a diff no-op (SetInventory sees "already worn" and equips
+    // nothing). Retry on the update tick: first re-dress gently (covers case 1), and if the biped
+    // is still naked while its container claims worn items, escalate to a DisableImpl()/EnableImpl()
+    // 3D rebuild (covers case 2 - the same "rebuild the render" primitive the leveled-conform path
+    // uses; EnableImpl(false) keeps the inventory intact and just re-attaches worn armor).
+    // mutable: enqueued from const TakeOwnership.
     struct SelfHealData
     {
         double m_timer = 0.0;
-        bool m_isFirstPass = true;
+        int m_pass = 0;             // 0/1 = gentle re-dress passes, 2 = post-disable re-enable
+        bool m_rebuildPending = false; // DisableImpl() issued, EnableImpl() due next pass
     };
 
     mutable Map<uint32_t, SelfHealData> m_selfHealRetries{};

--- a/Code/client/Services/CharacterService.h
+++ b/Code/client/Services/CharacterService.h
@@ -107,6 +107,7 @@ private:
     void RunSpawnUpdates() const noexcept;
     void RunExperienceUpdates() noexcept;
     void ApplyCachedWeaponDraws(const UpdateEvent& acUpdateEvent) noexcept;
+    void ApplyCachedSelfHeals(const UpdateEvent& acUpdateEvent) const noexcept;
 
     World& m_world;
     entt::dispatcher& m_dispatcher;
@@ -129,6 +130,18 @@ private:
     };
 
     Map<uint32_t, WeaponDrawData> m_weaponDrawUpdates{};
+
+    // Owner self-heal deferred retry: at ownership-claim time a locally-owned NPC's 3D/biped
+    // may not be ready, so the immediate re-dress can no-op and leave it naked on the owner's
+    // screen. Retry the dress a moment later on the update tick (2 passes, like weapon draws,
+    // because Skyrim biped state is finnicky). mutable: enqueued from const TakeOwnership.
+    struct SelfHealData
+    {
+        double m_timer = 0.0;
+        bool m_isFirstPass = true;
+    };
+
+    mutable Map<uint32_t, SelfHealData> m_selfHealRetries{};
 
     entt::scoped_connection m_referenceAddedConnection;
     entt::scoped_connection m_referenceRemovedConnection;

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -121,41 +121,30 @@ void CharacterService::DeleteRemoteEntityComponents(entt::entity aEntity) const 
 
 namespace
 {
-    // Owner self-heal: a locally-owned NPC can end up rendered naked even though its logical
-    // inventory reports worn armor -- the engine assigned/reloaded the actor without actually
-    // equipping the container's worn items onto the biped (templated NPCs on spawn, and after
-    // ownership changes). HasWornItems() is the wrong signal here: it reads the container flags,
-    // which say "dressed" while the render is naked. So:
-    //   1. If the container HAS worn armor, force the engine to re-equip it onto the biped
-    //      (idempotent -- re-equipping an already-worn piece is a visual no-op).
-    //   2. Only if the container has NO worn armor at all do we derive+apply a base outfit
-    //      (covers genuinely-undressed templated/leveled spawns).
-    // Runs at assignment and ownership change, so no per-frame polling is needed.
-    void OwnerSelfHealDress(Actor* apActor, uint32_t aBaseFormId, bool aDeferred, bool aVerbose = true) noexcept
+    // Owner self-heal: the owner never receives a network inventory snapshot for its own NPCs,
+    // so unlike remotes (which get SetActorInventory from the assign/spawn payload) a locally-
+    // owned NPC can be left rendering naked when the engine didn't equip its worn items onto
+    // the biped. Reconcile by running the SAME proven path the remote branch uses: reapply the
+    // actor's own current inventory via SetActorInventory. GetActorInventory() already derives a
+    // base outfit when the container is genuinely empty (templated/leveled spawns), and
+    // SetActorInventory re-equips worn items onto the biped. This must run on the same thread
+    // the remote SetActorInventory runs on (the assign/ownership handlers) -- never off-thread.
+    void OwnerSelfHealDress(Actor* apActor, uint32_t aBaseFormId) noexcept
     {
         if (apActor == nullptr || apActor->GetExtension()->IsPlayer() || apActor->IsDead())
             return;
 
-        // Honest raw signal: does the container actually have worn armor flagged?
-        if (apActor->GetWornArmor().HasWornItems())
+        Inventory current = apActor->GetActorInventory();
+        if (current.HasWornItems())
         {
-            spdlog::info("[NakedFix] owner self-heal{}: force re-equipping worn armor for local actor {:X} (base {:X})",
-                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
-            apActor->ForceEquipWornArmor();
-            return;
+            spdlog::info("[NakedFix] owner self-heal: reapplying inventory for local actor {:X} (base {:X})",
+                         apActor->formID, aBaseFormId);
+            apActor->SetActorInventory(current);
         }
-
-        Inventory derived = apActor->DeriveOutfitInventory();
-        if (derived.HasWornItems())
+        else
         {
-            spdlog::info("[NakedFix] owner self-heal{}: dressing local actor {:X} (base {:X}) from derived outfit",
-                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
-            apActor->SetActorInventory(derived);
-        }
-        else if (aVerbose)
-        {
-            spdlog::info("[NakedFix] owner self-heal{}: no derivable outfit for local actor {:X} (base {:X})",
-                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
+            spdlog::info("[NakedFix] owner self-heal: local actor {:X} (base {:X}) is naked with no derivable outfit",
+                         apActor->formID, aBaseFormId);
         }
     }
 }
@@ -197,19 +186,13 @@ bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acS
 
     m_transport.Send(request);
 
-    // Ownership change: we just became the owner of this NPC. The engine may have it rendered
-    // naked (worn in the container, empty on the biped) after the transfer. Reconcile now, and
-    // again next tick in case the equip state settles a frame late. Same signal as the spawn
-    // path -- force re-equip worn armor, else derive+apply a base outfit.
+    // Ownership change: we just became the owner of this NPC. Reapply its inventory so the
+    // local render is dressed (the owner won't get a network snapshot for it). Runs on this
+    // handler's thread, matching the remote SetActorInventory path.
     if (!pExtension->IsPlayer() && !pActor->IsDead())
     {
         const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
-        OwnerSelfHealDress(pActor, baseFormId, false);
-        const uint32_t actorFormId = pActor->formID;
-        m_world.GetRunner().Queue([actorFormId, baseFormId]() {
-            if (auto* pLocal = Cast<Actor>(TESForm::GetById(actorFormId)))
-                OwnerSelfHealDress(pLocal, baseFormId, true);
-        });
+        OwnerSelfHealDress(pActor, baseFormId);
     }
 
     return true;
@@ -399,25 +382,14 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         }
         m_world.remove<EarlyAnimationBufferComponent>(cEntity);
 
-        // Owner self-heal: a locally-owned NPC can render naked even though its logical
-        // inventory reports worn armor -- the engine assigned the actor without actually
-        // equipping the container's worn items onto the biped (templated NPC spawns, and
-        // ownership changes). PART 3 only fixes REMOTE clients that receive a snapshot; the
-        // owner never receives its own snapshot, so its own 3D render stays naked while the
-        // network (and thus party members) is correct. OwnerSelfHealDress reconciles this:
-        // force re-equip worn armor if the container has any, else derive+apply a base outfit.
-        // Do NOT pre-gate on HasWornItems() here: the container reporting "worn" is precisely
-        // the desync case (worn in inventory, empty on the biped) we must repair. Apply this
-        // frame, then re-check next tick in case the engine overwrote the apply mid-settle.
+        // Owner self-heal: the owner never receives its own network inventory snapshot, so
+        // while remotes get dressed via SetActorInventory from the payload, a locally-owned
+        // NPC's own 3D render can stay naked. Reconcile here on the assign thread (same thread
+        // the remote SetActorInventory runs on) by reapplying the actor's own inventory.
         if (!pActor->GetExtension()->IsPlayer() && !pActor->IsDead())
         {
             const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
-            OwnerSelfHealDress(pActor, baseFormId, false);
-            const uint32_t actorFormId = pActor->formID;
-            m_world.GetRunner().Queue([actorFormId, baseFormId]() {
-                if (auto* pLocal = Cast<Actor>(TESForm::GetById(actorFormId)))
-                    OwnerSelfHealDress(pLocal, baseFormId, true);
-            });
+            OwnerSelfHealDress(pActor, baseFormId);
         }
     }
     else

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -142,6 +142,7 @@ bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acS
     }
 
     pExtension->SetRemote(false);
+    pExtension->SetNakedDeadline();
 
     // TODO(cosideci): this should be done differently.
     // Send an ownership claim request, and have the server broadcast the result.
@@ -287,7 +288,7 @@ void CharacterService::OnDisconnected(const DisconnectedEvent& acDisconnectedEve
 
 void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessage) noexcept
 {
-    spdlog::info("Received for cookie {:X}, server id {:X}", acMessage.Cookie, acMessage.ServerId);
+    spdlog::info(__FUNCTION__ ": Received for cookie {:X}, server id {:X}", acMessage.Cookie, acMessage.ServerId);
 
     auto view = m_world.view<WaitingForAssignmentComponent>();
     const auto itor = std::find_if(std::begin(view), std::end(view), [view, cookie = acMessage.Cookie](auto entity) { return view.get<WaitingForAssignmentComponent>(entity).Cookie == cookie; });
@@ -327,7 +328,7 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
 
     if (acMessage.Owner)
     {
-        spdlog::info("Received local actor, form id: {:X}", pActor->formID);
+        spdlog::info(__FUNCTION__ ": received local actor, form id: {:X}, {}", pActor->formID, pActor->baseForm->GetName());
 
         m_world.emplace_or_replace<LocalComponent>(cEntity, acMessage.ServerId);
         auto& localAnimationComponent = m_world.emplace_or_replace<LocalAnimationComponent>(cEntity);
@@ -345,7 +346,7 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
     }
     else
     {
-        spdlog::info("Received remote actor, form id: {:X}, isweapondrawn: {}", pActor->formID, acMessage.IsWeaponDrawn);
+        spdlog::info(__FUNCTION__ ": received remote actor, form id: {:X}, isweapondrawn: {}, {}", pActor->formID, acMessage.IsWeaponDrawn, pActor->baseForm->GetName());
 
         m_world.emplace_or_replace<RemoteComponent>(cEntity, acMessage.ServerId, formIdComponent->Id);
 
@@ -370,6 +371,7 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
 
         MoveActor(pActor, acMessage.WorldSpaceId, acMessage.CellId, acMessage.Position);
     }
+    pActor->GetExtension()->SetNakedDeadline();
 }
 
 void CharacterService::OnCharacterSpawn(const CharacterSpawnRequest& acMessage) const noexcept
@@ -1292,7 +1294,8 @@ void CharacterService::RequestServerAssignment(const entt::entity aEntity) const
     message.LatestAction = pExtension->LatestAnimation;
     pActor->SaveAnimationVariables(message.LatestAction.Variables);
 
-    spdlog::info("Request id: {:X}, cookie: {:X}, entity: {:X}", formIdComponent.Id, sCookieSeed, to_integral(aEntity));
+    const bool isLeader = m_world.Get().GetPartyService().IsLeader(); // Distinguish logs in 2-party      
+    spdlog::info(__FUNCTION__ ": request id: {:X}, cookie: {:X}, entity: {:X}, isLeader: {}", formIdComponent.Id, sCookieSeed, to_integral(aEntity), isLeader);
 
     if (m_transport.Send(message))
     {
@@ -1304,10 +1307,11 @@ void CharacterService::RequestServerAssignment(const entt::entity aEntity) const
 
 void CharacterService::CancelServerAssignment(const entt::entity aEntity, const uint32_t aFormId) const noexcept
 {
+    Actor* pActor = Cast<Actor>(TESForm::GetById(aFormId));
+    const char* pName = !pActor ? "" : pActor->baseForm->GetName();
+
     if (m_world.all_of<RemoteComponent>(aEntity))
     {
-        Actor* pActor = Cast<Actor>(TESForm::GetById(aFormId));
-
         if (pActor)
         {
             if (pActor->IsTemporary())
@@ -1322,8 +1326,6 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
         }
 
         DeleteRemoteEntityComponents(aEntity);
-
-        return;
     }
 
     // In the event we were waiting for assignment, drop it
@@ -1346,7 +1348,7 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
         RequestOwnershipTransfer request{};
         request.ServerId = localComponent.Id;
 
-        if (Actor* pActor = Cast<Actor>(TESForm::GetById(aFormId)))
+        if (pActor)
         {
             if (!pActor->IsTemporary())
             {
@@ -1368,15 +1370,19 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
             }
         }
 
+
         spdlog::info(
-            "Transferring ownership of local actor, server id: {:X}, worldspace: {:X}, cell: {:X}, position: "
-            "({}, {}, {})",
-            request.ServerId, request.WorldSpaceId.BaseId, request.CellId.BaseId, request.Position.x, request.Position.y, request.Position.z);
+            __FUNCTION__ ": transferring ownership of local actor, formId: {:X}, server id: {:X}, worldspace: {:X}, cell: {:X}, position: "
+                         "({}, {}, {}), name: {}",
+            aFormId, request.ServerId, request.WorldSpaceId.BaseId, request.CellId.BaseId, request.Position.x, request.Position.y, request.Position.z, pName);
 
         m_transport.Send(request);
 
         m_world.remove<LocalAnimationComponent, LocalComponent>(aEntity);
     }
+
+    if (pActor)
+        pActor->GetExtension()->SetNakedDeadline();
 }
 
 Actor* CharacterService::CreateCharacterForEntity(entt::entity aEntity) const noexcept
@@ -1572,9 +1578,12 @@ void CharacterService::RunRemoteUpdates() noexcept
         if (pActor->IsVampireLord())
             pActor->FixVampireLordModel();
 
+        // (Re)start naked NPC deadline. Actor MUST be fully constructed before check clock starts.
+        pActor->GetExtension()->SetNakedDeadline();
+
         toRemove.push_back(entity);
 
-        spdlog::info("Applied 3D for actor, form id: {:X}", pActor->formID);
+        spdlog::info(__FUNCTION__ ": applied 3D for actor, form id: {:X}, name {}", pActor->formID, pActor->baseForm->GetName());
     }
 
     for (auto entity : toRemove)

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -342,6 +342,28 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
             }
         }
         m_world.remove<EarlyAnimationBufferComponent>(cEntity);
+
+        // Owner self-heal: a locally-owned NPC can spawn with no worn items (the vanilla ST
+        // naked-spawn race). PART 3 only fixes REMOTE clients that receive a snapshot; the
+        // owner never receives its own snapshot, so its own 3D render stays naked while the
+        // network (and thus party members) is correct. Dress it from the base outfit here.
+        // PART 1+2 already ensured what we UPLOAD is dressed; this corrects what we SEE.
+        if (!pActor->GetExtension()->IsPlayer() && !pActor->IsDead() &&
+            !pActor->GetActorInventory().HasWornItems())
+        {
+            Inventory derived = pActor->DeriveOutfitInventory();
+            if (derived.HasWornItems())
+            {
+                spdlog::info("[NakedFix] owner self-heal: dressing local actor {:X} (base {:X}) from derived outfit",
+                             pActor->formID, pActor->baseForm ? pActor->baseForm->formID : 0);
+                pActor->SetActorInventory(derived);
+            }
+            else
+            {
+                spdlog::info("[NakedFix] owner self-heal: no derivable outfit for local actor {:X} (base {:X})",
+                             pActor->formID, pActor->baseForm ? pActor->baseForm->formID : 0);
+            }
+        }
     }
     else
     {

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -1846,6 +1846,14 @@ void CharacterService::ApplyCachedSelfHeals(const UpdateEvent& acUpdateEvent) co
             if (pActor->IsDisabled())
                 pActor->EnableImpl();
 
+            // Re-enabling rebuilds the 3D/anim graph. The old GraphDescriptorHash can index the
+            // rebuilt graph's variable set out of bounds (the same OOB variable-index crash the
+            // leveled-conform re-enable guards against, and what werewolf/VL transforms reset).
+            // Zero it so the next sync tick recomputes it from the fresh graph. Without this, the
+            // actor can hang/crash when its graph is next driven -- notably during a save near
+            // dense static-NPC clusters (e.g. Riverwood's Gerdur/Frodnar).
+            pActor->GetExtension()->GraphDescriptorHash = 0;
+
             const bool wornAfter = HasWornBodyPiece(pActor->GetEquipment());
             spdlog::info("[NakedFix] self-heal 3D-rebuild re-enable for actor {:X}: wornAfter={}",
                          pActor->formID, wornAfter);

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -162,6 +162,17 @@ namespace
         if (apActor == nullptr || apActor->GetExtension()->IsPlayer() || apActor->IsDead())
             return;
 
+        // Locality guard (issue #5): ownership can flip to another client between the
+        // self-heal being scheduled and a retry pass firing. Re-running SetActorInventory
+        // on a now-REMOTE actor equips each worn entry through the remote equip path and
+        // races the incoming snapshot apply -- the window where inventories duplicated.
+        // Only the owner may self-heal.
+        if (apActor->GetExtension()->IsRemote())
+        {
+            spdlog::debug("[NakedFix] owner self-heal: actor {:X} is now remote, skipping", apActor->formID);
+            return;
+        }
+
         // Honest signal: is the biped already wearing a BODY piece? (GetEquipment reads worn
         // items, not the logical container, so it reflects the actual render state.) We test the
         // body slot specifically, not "any worn item" -- an NPC wearing only a satchel/boots but
@@ -176,6 +187,36 @@ namespace
         Inventory current = apActor->GetActorInventory();
         if (current.HasWornItems())
         {
+            // Issue #5 cleanup: containers stacked by earlier builds keep every duplicate
+            // outfit copy, and a plain re-apply would faithfully re-add them all. Collapse
+            // duplicate BaseId entries here (same policy as the server-side normalize) so
+            // each self-heal actively shrinks a polluted container instead of preserving it.
+            {
+                auto& entries = current.Entries;
+                for (size_t i = 0; i < entries.size(); ++i)
+                {
+                    if (entries[i].Count == 0)
+                        continue;
+
+                    for (size_t j = i + 1; j < entries.size();)
+                    {
+                        if (entries[j].BaseId != entries[i].BaseId || entries[j].Count == 0)
+                        {
+                            ++j;
+                            continue;
+                        }
+
+                        if (entries[i].IsWorn() || entries[j].IsWorn())
+                            entries.erase(entries.begin() + j);
+                        else
+                        {
+                            entries[i].Count += entries[j].Count;
+                            entries.erase(entries.begin() + j);
+                        }
+                    }
+                }
+            }
+
             spdlog::info("[NakedFix] owner self-heal: reapplying inventory for local actor {:X} (base {:X})",
                          apActor->formID, aBaseFormId);
             // SetActorInventory re-dresses the NPC by equipping each worn item through
@@ -1872,6 +1913,16 @@ void CharacterService::ApplyCachedSelfHeals(const UpdateEvent& acUpdateEvent) co
 
         // Stages 1-2: gentle re-dress. OwnerSelfHealDress self-dedups on the body-piece check, so
         // this is a cheap no-op once the biped is actually wearing its body armor.
+        // Issue #5: ownership may have flipped since this retry was scheduled. Never escalate
+        // a remote actor -- drop the entry instead of risking a DisableImpl 3D rebuild on
+        // another client's NPC.
+        if (pActor->GetExtension()->IsRemote())
+        {
+            spdlog::info("[NakedFix] self-heal retry: actor {:X} became remote, dropping", pActor->formID);
+            toRemove.push_back(cId);
+            continue;
+        }
+
         const bool wornBefore = HasWornBodyPiece(pActor->GetEquipment());
         const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
         OwnerSelfHealDress(pActor, baseFormId);

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -214,6 +214,8 @@ bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acS
     {
         const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
         OwnerSelfHealDress(pActor, baseFormId);
+        // The biped may not be ready yet at claim-time; schedule a deferred retry (2 passes).
+        m_selfHealRetries[pActor->formID] = {};
     }
 
     return true;
@@ -300,6 +302,7 @@ void CharacterService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
     RunRemoteUpdates();
     RunExperienceUpdates();
     ApplyCachedWeaponDraws(acUpdateEvent);
+    ApplyCachedSelfHeals(acUpdateEvent);
 }
 
 void CharacterService::OnConnected(const ConnectedEvent& acConnectedEvent) const noexcept
@@ -411,6 +414,8 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         {
             const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
             OwnerSelfHealDress(pActor, baseFormId);
+            // The biped may not be ready yet at assign-time; schedule a deferred retry (2 passes).
+            m_selfHealRetries[pActor->formID] = {};
         }
     }
     else
@@ -1785,4 +1790,48 @@ void CharacterService::ApplyCachedWeaponDraws(const UpdateEvent& acUpdateEvent) 
 
     for (uint32_t id : toRemove)
         m_weaponDrawUpdates.erase(id);
+}
+
+void CharacterService::ApplyCachedSelfHeals(const UpdateEvent& acUpdateEvent) const noexcept
+{
+    std::vector<uint32_t> toRemove{};
+
+    for (auto& [cId, _] : m_selfHealRetries)
+    {
+        auto& data = m_selfHealRetries[cId];
+
+        data.m_timer += acUpdateEvent.Delta;
+
+        // Two passes (like weapon draws): retry ~0.5s after claim, then once more ~1.5s later,
+        // by which point the biped is reliably loaded and the worn armor attaches.
+        double maxTime = data.m_isFirstPass ? 0.5 : 1.5;
+        if (data.m_timer <= maxTime)
+            continue;
+
+        Actor* pActor = Cast<Actor>(TESForm::GetById(cId));
+        if (!pActor)
+        {
+            toRemove.push_back(cId);
+            continue;
+        }
+
+        // OwnerSelfHealDress self-dedups: it skips when the biped already reports worn armor,
+        // so a retry on an already-dressed actor is a cheap no-op.
+        const bool wornBefore = pActor->GetEquipment().HasWornItems();
+        const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
+        OwnerSelfHealDress(pActor, baseFormId);
+        const bool wornAfter = pActor->GetEquipment().HasWornItems();
+
+        spdlog::info("[NakedFix] self-heal retry (pass {}) for actor {:X} (base {:X}): wornBefore={} wornAfter={}",
+                     data.m_isFirstPass ? 1 : 2, pActor->formID, baseFormId, wornBefore, wornAfter);
+
+        // Stop early once dressed; otherwise let the second pass run, then give up.
+        if (wornAfter || !data.m_isFirstPass)
+            toRemove.push_back(cId);
+
+        data.m_isFirstPass = false;
+    }
+
+    for (uint32_t id : toRemove)
+        m_selfHealRetries.erase(id);
 }

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -285,6 +285,33 @@ void CharacterService::OnDisconnected(const DisconnectedEvent& acDisconnectedEve
     m_world.clear<WaitingForAssignmentComponent, LocalComponent, RemoteComponent>();
 }
 
+namespace
+{
+    // Owner self-heal: if a locally-owned NPC currently renders with no worn items, dress it
+    // from its base-form outfit. Idempotent — a correctly-dressed NPC is a no-op, so it never
+    // fights legitimate gameplay (a real strip sends worn entries, so HasWornItems() is true).
+    void OwnerSelfHealDress(Actor* apActor, uint32_t aBaseFormId, bool aDeferred) noexcept
+    {
+        if (apActor == nullptr || apActor->GetExtension()->IsPlayer() || apActor->IsDead())
+            return;
+        if (apActor->GetActorInventory().HasWornItems())
+            return;
+
+        Inventory derived = apActor->DeriveOutfitInventory();
+        if (derived.HasWornItems())
+        {
+            spdlog::info("[NakedFix] owner self-heal{}: dressing local actor {:X} (base {:X}) from derived outfit",
+                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
+            apActor->SetActorInventory(derived);
+        }
+        else
+        {
+            spdlog::info("[NakedFix] owner self-heal{}: no derivable outfit for local actor {:X} (base {:X})",
+                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
+        }
+    }
+}
+
 void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessage) noexcept
 {
     spdlog::info(__FUNCTION__ ": Received for cookie {:X}, server id {:X}", acMessage.Cookie, acMessage.ServerId);
@@ -348,21 +375,19 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         // owner never receives its own snapshot, so its own 3D render stays naked while the
         // network (and thus party members) is correct. Dress it from the base outfit here.
         // PART 1+2 already ensured what we UPLOAD is dressed; this corrects what we SEE.
+        // Apply immediately this frame, then re-check next tick: if the engine hiccuped and
+        // overwrote the apply, re-dress once. (Same-tick overwrite is possible because the
+        // actor's 3D/equipment may not be fully settled at assignment.)
         if (!pActor->GetExtension()->IsPlayer() && !pActor->IsDead() &&
             !pActor->GetActorInventory().HasWornItems())
         {
-            Inventory derived = pActor->DeriveOutfitInventory();
-            if (derived.HasWornItems())
-            {
-                spdlog::info("[NakedFix] owner self-heal: dressing local actor {:X} (base {:X}) from derived outfit",
-                             pActor->formID, pActor->baseForm ? pActor->baseForm->formID : 0);
-                pActor->SetActorInventory(derived);
-            }
-            else
-            {
-                spdlog::info("[NakedFix] owner self-heal: no derivable outfit for local actor {:X} (base {:X})",
-                             pActor->formID, pActor->baseForm ? pActor->baseForm->formID : 0);
-            }
+            const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
+            OwnerSelfHealDress(pActor, baseFormId, false);
+            const uint32_t actorFormId = pActor->formID;
+            m_world.GetRunner().Queue([actorFormId, baseFormId]() {
+                if (auto* pLocal = Cast<Actor>(TESForm::GetById(actorFormId)))
+                    OwnerSelfHealDress(pLocal, baseFormId, true);
+            });
         }
     }
     else

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -12,6 +12,7 @@
 #include <Games/Overrides.h>
 
 #include <Forms/TESNPC.h>
+#include <Forms/TESObjectARMO.h>
 #include <Forms/TESQuest.h>
 
 #include <BranchInfo.h>
@@ -122,6 +123,27 @@ void CharacterService::DeleteRemoteEntityComponents(entt::entity aEntity) const 
 
 namespace
 {
+    // "Naked" specifically means missing the BODY/torso slot (a cuirass or body-slot ARMO),
+    // not "wearing nothing at all". A Courier wearing only its satchel/boots/gloves passes a
+    // generic HasWornItems() check yet still renders naked. Test the worn set for a body piece
+    // (slotType & 0x4) so those partial-equip cases are still treated as naked and re-dressed.
+    bool HasWornBodyPiece(const Inventory& acInventory) noexcept
+    {
+        auto& modSystem = World::Get().GetModSystem();
+        for (const auto& entry : acInventory.Entries)
+        {
+            if (!entry.IsWorn())
+                continue;
+            const uint32_t id = modSystem.GetGameId(entry.BaseId);
+            if (TESObjectARMO* pArmor = Cast<TESObjectARMO>(TESForm::GetById(id)))
+            {
+                if (pArmor->IsBodyPiece())
+                    return true;
+            }
+        }
+        return false;
+    }
+
     // Owner self-heal: the owner never receives a network inventory snapshot for its own NPCs,
     // so unlike remotes (which get SetActorInventory from the assign/spawn payload) a locally-
     // owned NPC can be left rendering naked when the engine didn't equip its worn items onto
@@ -140,9 +162,11 @@ namespace
         if (apActor == nullptr || apActor->GetExtension()->IsPlayer() || apActor->IsDead())
             return;
 
-        // Honest signal: is the biped already wearing something? (GetEquipment reads worn items,
-        // not the logical container, so it reflects the actual render state.)
-        if (apActor->GetEquipment().HasWornItems())
+        // Honest signal: is the biped already wearing a BODY piece? (GetEquipment reads worn
+        // items, not the logical container, so it reflects the actual render state.) We test the
+        // body slot specifically, not "any worn item" -- an NPC wearing only a satchel/boots but
+        // no cuirass still renders naked and must be re-dressed.
+        if (HasWornBodyPiece(apActor->GetEquipment()))
         {
             spdlog::debug("[NakedFix] owner self-heal: local actor {:X} (base {:X}) already dressed, skipping",
                           apActor->formID, aBaseFormId);
@@ -1822,19 +1846,19 @@ void CharacterService::ApplyCachedSelfHeals(const UpdateEvent& acUpdateEvent) co
             if (pActor->IsDisabled())
                 pActor->EnableImpl();
 
-            const bool wornAfter = pActor->GetEquipment().HasWornItems();
+            const bool wornAfter = HasWornBodyPiece(pActor->GetEquipment());
             spdlog::info("[NakedFix] self-heal 3D-rebuild re-enable for actor {:X}: wornAfter={}",
                          pActor->formID, wornAfter);
             toRemove.push_back(cId);
             continue;
         }
 
-        // Stages 1-2: gentle re-dress. OwnerSelfHealDress self-dedups on HasWornItems, so this is
-        // a cheap no-op once the biped is dressed.
-        const bool wornBefore = pActor->GetEquipment().HasWornItems();
+        // Stages 1-2: gentle re-dress. OwnerSelfHealDress self-dedups on the body-piece check, so
+        // this is a cheap no-op once the biped is actually wearing its body armor.
+        const bool wornBefore = HasWornBodyPiece(pActor->GetEquipment());
         const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
         OwnerSelfHealDress(pActor, baseFormId);
-        const bool wornAfter = pActor->GetEquipment().HasWornItems();
+        const bool wornAfter = HasWornBodyPiece(pActor->GetEquipment());
 
         spdlog::info("[NakedFix] self-heal retry (pass {}) for actor {:X} (base {:X}): wornBefore={} wornAfter={}",
                      data.m_pass + 1, pActor->formID, baseFormId, wornBefore, wornAfter);
@@ -1852,18 +1876,18 @@ void CharacterService::ApplyCachedSelfHeals(const UpdateEvent& acUpdateEvent) co
         // rebuild actors whose 3D is actually present (distant/unloaded actors stay pending).
         if (data.m_pass >= 1)
         {
-            const bool containerWorn = pActor->GetActorInventory().HasWornItems();
-            if (containerWorn && pActor->loadedState && !pActor->IsDisabled())
+            const bool containerHasBody = HasWornBodyPiece(pActor->GetActorInventory());
+            if (containerHasBody && pActor->loadedState && !pActor->IsDisabled())
             {
                 spdlog::info("[NakedFix] self-heal escalating to 3D rebuild for actor {:X} (base {:X}): "
-                             "container worn but biped naked", pActor->formID, baseFormId);
+                             "container has body armor but biped naked", pActor->formID, baseFormId);
                 pActor->DisableImpl();
                 data.m_rebuildPending = true;
                 data.m_timer = 0.0;
                 continue; // re-enable next tick
             }
 
-            // Nothing more we can safely do (no container items, or 3D not loaded).
+            // Nothing more we can safely do (no body armor to derive, or 3D not loaded).
             toRemove.push_back(cId);
             continue;
         }

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -290,7 +290,9 @@ namespace
     // Owner self-heal: if a locally-owned NPC currently renders with no worn items, dress it
     // from its base-form outfit. Idempotent — a correctly-dressed NPC is a no-op, so it never
     // fights legitimate gameplay (a real strip sends worn entries, so HasWornItems() is true).
-    void OwnerSelfHealDress(Actor* apActor, uint32_t aBaseFormId, bool aDeferred) noexcept
+    // aVerbose=false suppresses the "no derivable outfit" log (used by the per-second periodic
+    // re-check, which would otherwise spam for NPCs that genuinely have no base outfit).
+    void OwnerSelfHealDress(Actor* apActor, uint32_t aBaseFormId, bool aDeferred, bool aVerbose = true) noexcept
     {
         if (apActor == nullptr || apActor->GetExtension()->IsPlayer() || apActor->IsDead())
             return;
@@ -304,7 +306,7 @@ namespace
                          aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
             apActor->SetActorInventory(derived);
         }
-        else
+        else if (aVerbose)
         {
             spdlog::info("[NakedFix] owner self-heal{}: no derivable outfit for local actor {:X} (base {:X})",
                          aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
@@ -1518,6 +1520,27 @@ void CharacterService::RunLocalUpdates() const noexcept
         return;
 
     lastSendTimePoint = now;
+
+    // Periodic owner self-heal: the engine can apply its own (naked) visual equipment to a
+    // locally-owned NPC several frames after assignment, after the 3D finishes loading --
+    // well past the single deferred re-check at assignment. Re-dress any locally-owned NPC
+    // that still renders with no worn items. Idempotent: a dressed NPC is a no-op, so this
+    // never fights legitimate gameplay. Throttled to ~1s to keep cost negligible.
+    {
+        static std::chrono::steady_clock::time_point lastNakedCheck;
+        constexpr auto cNakedCheckDelay = std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::seconds(1));
+        if (now - lastNakedCheck >= cNakedCheckDelay)
+        {
+            lastNakedCheck = now;
+            auto localView = m_world.view<LocalComponent, FormIdComponent>();
+            for (auto entity : localView)
+            {
+                auto& formIdComponent = localView.get<FormIdComponent>(entity);
+                if (auto* pActor = Cast<Actor>(TESForm::GetById(formIdComponent.Id)))
+                    OwnerSelfHealDress(pActor, pActor->baseForm ? pActor->baseForm->formID : 0, true, false);
+            }
+        }
+    }
 
     ClientReferencesMoveRequest message;
     message.Tick = m_transport.GetClock().GetCurrentTick();

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -9,6 +9,7 @@
 
 #include <Games/References.h>
 #include <Games/Misc/SubtitleManager.h>
+#include <Games/Overrides.h>
 
 #include <Forms/TESNPC.h>
 #include <Forms/TESQuest.h>
@@ -129,16 +130,36 @@ namespace
     // base outfit when the container is genuinely empty (templated/leveled spawns), and
     // SetActorInventory re-equips worn items onto the biped. This must run on the same thread
     // the remote SetActorInventory runs on (the assign/ownership handlers) -- never off-thread.
+    //
+    // Dedup: ownership flits between clients (nearest-player assignment) and re-triggers this on
+    // every re-claim, running a full RemoveAllItems + re-add + re-equip on actors that are ALREADY
+    // dressed. Skip the expensive re-apply when the biped already reports worn armor -- the
+    // genuinely-naked case (biped empty) still goes through, so naked NPCs still get fixed.
     void OwnerSelfHealDress(Actor* apActor, uint32_t aBaseFormId) noexcept
     {
         if (apActor == nullptr || apActor->GetExtension()->IsPlayer() || apActor->IsDead())
             return;
+
+        // Honest signal: is the biped already wearing something? (GetEquipment reads worn items,
+        // not the logical container, so it reflects the actual render state.)
+        if (apActor->GetEquipment().HasWornItems())
+        {
+            spdlog::debug("[NakedFix] owner self-heal: local actor {:X} (base {:X}) already dressed, skipping",
+                          apActor->formID, aBaseFormId);
+            return;
+        }
 
         Inventory current = apActor->GetActorInventory();
         if (current.HasWornItems())
         {
             spdlog::info("[NakedFix] owner self-heal: reapplying inventory for local actor {:X} (base {:X})",
                          apActor->formID, aBaseFormId);
+            // SetActorInventory re-dresses the NPC by equipping each worn item through
+            // EquipManager::Equip. For a LOCAL actor that per-item Equip would otherwise fire an
+            // OnEquipmentChangeEvent to the server for every piece (a self-heal broadcast storm).
+            // Suppress the sync: the server already has this NPC's inventory, and the owner client
+            // is only repairing its own render. The engine equip still runs, so the NPC is dressed.
+            ScopedEquipOverride equipOverride;
             apActor->SetActorInventory(current);
         }
         else

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -119,6 +119,47 @@ void CharacterService::DeleteRemoteEntityComponents(entt::entity aEntity) const 
     m_world.remove<FaceGenComponent, InterpolationComponent, RemoteAnimationComponent, RemoteComponent, CacheComponent, WaitingFor3D, PlayerComponent>(aEntity);
 }
 
+namespace
+{
+    // Owner self-heal: a locally-owned NPC can end up rendered naked even though its logical
+    // inventory reports worn armor -- the engine assigned/reloaded the actor without actually
+    // equipping the container's worn items onto the biped (templated NPCs on spawn, and after
+    // ownership changes). HasWornItems() is the wrong signal here: it reads the container flags,
+    // which say "dressed" while the render is naked. So:
+    //   1. If the container HAS worn armor, force the engine to re-equip it onto the biped
+    //      (idempotent -- re-equipping an already-worn piece is a visual no-op).
+    //   2. Only if the container has NO worn armor at all do we derive+apply a base outfit
+    //      (covers genuinely-undressed templated/leveled spawns).
+    // Runs at assignment and ownership change, so no per-frame polling is needed.
+    void OwnerSelfHealDress(Actor* apActor, uint32_t aBaseFormId, bool aDeferred, bool aVerbose = true) noexcept
+    {
+        if (apActor == nullptr || apActor->GetExtension()->IsPlayer() || apActor->IsDead())
+            return;
+
+        // Honest raw signal: does the container actually have worn armor flagged?
+        if (apActor->GetWornArmor().HasWornItems())
+        {
+            spdlog::info("[NakedFix] owner self-heal{}: force re-equipping worn armor for local actor {:X} (base {:X})",
+                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
+            apActor->ForceEquipWornArmor();
+            return;
+        }
+
+        Inventory derived = apActor->DeriveOutfitInventory();
+        if (derived.HasWornItems())
+        {
+            spdlog::info("[NakedFix] owner self-heal{}: dressing local actor {:X} (base {:X}) from derived outfit",
+                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
+            apActor->SetActorInventory(derived);
+        }
+        else if (aVerbose)
+        {
+            spdlog::info("[NakedFix] owner self-heal{}: no derivable outfit for local actor {:X} (base {:X})",
+                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
+        }
+    }
+}
+
 bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acServerId, const entt::entity acEntity) const noexcept
 {
     Actor* pActor = Cast<Actor>(TESForm::GetById(acFormId));
@@ -155,6 +196,21 @@ bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acS
     request.NewActorData = BuildActorData(pActor);
 
     m_transport.Send(request);
+
+    // Ownership change: we just became the owner of this NPC. The engine may have it rendered
+    // naked (worn in the container, empty on the biped) after the transfer. Reconcile now, and
+    // again next tick in case the equip state settles a frame late. Same signal as the spawn
+    // path -- force re-equip worn armor, else derive+apply a base outfit.
+    if (!pExtension->IsPlayer() && !pActor->IsDead())
+    {
+        const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
+        OwnerSelfHealDress(pActor, baseFormId, false);
+        const uint32_t actorFormId = pActor->formID;
+        m_world.GetRunner().Queue([actorFormId, baseFormId]() {
+            if (auto* pLocal = Cast<Actor>(TESForm::GetById(actorFormId)))
+                OwnerSelfHealDress(pLocal, baseFormId, true);
+        });
+    }
 
     return true;
 }
@@ -285,35 +341,6 @@ void CharacterService::OnDisconnected(const DisconnectedEvent& acDisconnectedEve
     m_world.clear<WaitingForAssignmentComponent, LocalComponent, RemoteComponent>();
 }
 
-namespace
-{
-    // Owner self-heal: if a locally-owned NPC currently renders with no worn items, dress it
-    // from its base-form outfit. Idempotent — a correctly-dressed NPC is a no-op, so it never
-    // fights legitimate gameplay (a real strip sends worn entries, so HasWornItems() is true).
-    // aVerbose=false suppresses the "no derivable outfit" log (used by the per-second periodic
-    // re-check, which would otherwise spam for NPCs that genuinely have no base outfit).
-    void OwnerSelfHealDress(Actor* apActor, uint32_t aBaseFormId, bool aDeferred, bool aVerbose = true) noexcept
-    {
-        if (apActor == nullptr || apActor->GetExtension()->IsPlayer() || apActor->IsDead())
-            return;
-        if (apActor->GetActorInventory().HasWornItems())
-            return;
-
-        Inventory derived = apActor->DeriveOutfitInventory();
-        if (derived.HasWornItems())
-        {
-            spdlog::info("[NakedFix] owner self-heal{}: dressing local actor {:X} (base {:X}) from derived outfit",
-                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
-            apActor->SetActorInventory(derived);
-        }
-        else if (aVerbose)
-        {
-            spdlog::info("[NakedFix] owner self-heal{}: no derivable outfit for local actor {:X} (base {:X})",
-                         aDeferred ? " (re-check)" : "", apActor->formID, aBaseFormId);
-        }
-    }
-}
-
 void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessage) noexcept
 {
     spdlog::info(__FUNCTION__ ": Received for cookie {:X}, server id {:X}", acMessage.Cookie, acMessage.ServerId);
@@ -372,16 +399,17 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         }
         m_world.remove<EarlyAnimationBufferComponent>(cEntity);
 
-        // Owner self-heal: a locally-owned NPC can spawn with no worn items (the vanilla ST
-        // naked-spawn race). PART 3 only fixes REMOTE clients that receive a snapshot; the
+        // Owner self-heal: a locally-owned NPC can render naked even though its logical
+        // inventory reports worn armor -- the engine assigned the actor without actually
+        // equipping the container's worn items onto the biped (templated NPC spawns, and
+        // ownership changes). PART 3 only fixes REMOTE clients that receive a snapshot; the
         // owner never receives its own snapshot, so its own 3D render stays naked while the
-        // network (and thus party members) is correct. Dress it from the base outfit here.
-        // PART 1+2 already ensured what we UPLOAD is dressed; this corrects what we SEE.
-        // Apply immediately this frame, then re-check next tick: if the engine hiccuped and
-        // overwrote the apply, re-dress once. (Same-tick overwrite is possible because the
-        // actor's 3D/equipment may not be fully settled at assignment.)
-        if (!pActor->GetExtension()->IsPlayer() && !pActor->IsDead() &&
-            !pActor->GetActorInventory().HasWornItems())
+        // network (and thus party members) is correct. OwnerSelfHealDress reconciles this:
+        // force re-equip worn armor if the container has any, else derive+apply a base outfit.
+        // Do NOT pre-gate on HasWornItems() here: the container reporting "worn" is precisely
+        // the desync case (worn in inventory, empty on the biped) we must repair. Apply this
+        // frame, then re-check next tick in case the engine overwrote the apply mid-settle.
+        if (!pActor->GetExtension()->IsPlayer() && !pActor->IsDead())
         {
             const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
             OwnerSelfHealDress(pActor, baseFormId, false);
@@ -1520,27 +1548,6 @@ void CharacterService::RunLocalUpdates() const noexcept
         return;
 
     lastSendTimePoint = now;
-
-    // Periodic owner self-heal: the engine can apply its own (naked) visual equipment to a
-    // locally-owned NPC several frames after assignment, after the 3D finishes loading --
-    // well past the single deferred re-check at assignment. Re-dress any locally-owned NPC
-    // that still renders with no worn items. Idempotent: a dressed NPC is a no-op, so this
-    // never fights legitimate gameplay. Throttled to ~3s to keep cost negligible.
-    {
-        static std::chrono::steady_clock::time_point lastNakedCheck;
-        constexpr auto cNakedCheckDelay = std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::seconds(3));
-        if (now - lastNakedCheck >= cNakedCheckDelay)
-        {
-            lastNakedCheck = now;
-            auto localView = m_world.view<LocalComponent, FormIdComponent>();
-            for (auto entity : localView)
-            {
-                auto& formIdComponent = localView.get<FormIdComponent>(entity);
-                if (auto* pActor = Cast<Actor>(TESForm::GetById(formIdComponent.Id)))
-                    OwnerSelfHealDress(pActor, pActor->baseForm ? pActor->baseForm->formID : 0, true, false);
-            }
-        }
-    }
 
     ClientReferencesMoveRequest message;
     message.Tick = m_transport.GetClock().GetCurrentTick();

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -3,6 +3,8 @@
 #include "Services/PapyrusService.h"
 #include <Services/PartyService.h>
 
+#include <algorithm>
+
 #include <Services/CharacterService.h>
 #include <Services/QuestService.h>
 #include <Services/TransportService.h>
@@ -200,7 +202,12 @@ namespace
 
                     for (size_t j = i + 1; j < entries.size();)
                     {
-                        if (entries[j].BaseId != entries[i].BaseId || entries[j].Count == 0)
+                        // Never collapse {0,0} entries: unmapped items all share the
+                        // sentinel and would erase distinct pieces under merge.
+                        const bool isSentinel = entries[i].BaseId.ModId == 0 &&
+                                                entries[i].BaseId.BaseId == 0;
+                        if (entries[j].BaseId != entries[i].BaseId || entries[j].Count == 0 ||
+                            isSentinel)
                         {
                             ++j;
                             continue;
@@ -1944,11 +1951,18 @@ void CharacterService::ApplyCachedSelfHeals(const UpdateEvent& acUpdateEvent) co
         // rebuild actors whose 3D is actually present (distant/unloaded actors stay pending).
         if (data.m_pass >= 1)
         {
-            const bool containerHasBody = HasWornBodyPiece(pActor->GetActorInventory());
-            if (containerHasBody && pActor->loadedState && !pActor->IsDisabled())
+            // Escalate whenever the container holds any worn armor, even a non-body
+            // piece: a boot-only container previously blocked escalation forever
+            // (city NPCs stranded with exactly one boot). The rebuild re-runs the
+            // derive path which now guarantees a body piece.
+            const bool containerHasArmor = pActor->GetActorInventory().Entries.end() !=
+                std::find_if(pActor->GetActorInventory().Entries.begin(),
+                             pActor->GetActorInventory().Entries.end(),
+                             [](const auto& entry) { return entry.IsWorn(); });
+            if (containerHasArmor && pActor->loadedState && !pActor->IsDisabled())
             {
                 spdlog::info("[NakedFix] self-heal escalating to 3D rebuild for actor {:X} (base {:X}): "
-                             "container has body armor but biped naked", pActor->formID, baseFormId);
+                             "biped naked after gentle passes", pActor->formID, baseFormId);
                 pActor->DisableImpl();
                 data.m_rebuildPending = true;
                 data.m_timer = 0.0;

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -1525,10 +1525,10 @@ void CharacterService::RunLocalUpdates() const noexcept
     // locally-owned NPC several frames after assignment, after the 3D finishes loading --
     // well past the single deferred re-check at assignment. Re-dress any locally-owned NPC
     // that still renders with no worn items. Idempotent: a dressed NPC is a no-op, so this
-    // never fights legitimate gameplay. Throttled to ~1s to keep cost negligible.
+    // never fights legitimate gameplay. Throttled to ~3s to keep cost negligible.
     {
         static std::chrono::steady_clock::time_point lastNakedCheck;
-        constexpr auto cNakedCheckDelay = std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::seconds(1));
+        constexpr auto cNakedCheckDelay = std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::seconds(3));
         if (now - lastNakedCheck >= cNakedCheckDelay)
         {
             lastNakedCheck = now;

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -142,7 +142,6 @@ bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acS
     }
 
     pExtension->SetRemote(false);
-    pExtension->SetNakedDeadline();
 
     // TODO(cosideci): this should be done differently.
     // Send an ownership claim request, and have the server broadcast the result.
@@ -371,7 +370,6 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
 
         MoveActor(pActor, acMessage.WorldSpaceId, acMessage.CellId, acMessage.Position);
     }
-    pActor->GetExtension()->SetNakedDeadline();
 }
 
 void CharacterService::OnCharacterSpawn(const CharacterSpawnRequest& acMessage) const noexcept
@@ -1370,7 +1368,6 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
             }
         }
 
-
         spdlog::info(
             __FUNCTION__ ": transferring ownership of local actor, formId: {:X}, server id: {:X}, worldspace: {:X}, cell: {:X}, position: "
                          "({}, {}, {}), name: {}",
@@ -1380,9 +1377,6 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
 
         m_world.remove<LocalAnimationComponent, LocalComponent>(aEntity);
     }
-
-    if (pActor)
-        pActor->GetExtension()->SetNakedDeadline();
 }
 
 Actor* CharacterService::CreateCharacterForEntity(entt::entity aEntity) const noexcept
@@ -1577,9 +1571,6 @@ void CharacterService::RunRemoteUpdates() noexcept
 
         if (pActor->IsVampireLord())
             pActor->FixVampireLordModel();
-
-        // (Re)start naked NPC deadline. Actor MUST be fully constructed before check clock starts.
-        pActor->GetExtension()->SetNakedDeadline();
 
         toRemove.push_back(entity);
 

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -1802,10 +1802,9 @@ void CharacterService::ApplyCachedSelfHeals(const UpdateEvent& acUpdateEvent) co
 
         data.m_timer += acUpdateEvent.Delta;
 
-        // Two passes (like weapon draws): retry ~0.5s after claim, then once more ~1.5s later,
-        // by which point the biped is reliably loaded and the worn armor attaches.
-        double maxTime = data.m_isFirstPass ? 0.5 : 1.5;
-        if (data.m_timer <= maxTime)
+        // Stage cadence: pass 0 at ~0.5s, pass 1 at ~1.5s, rebuild re-enable one tick later.
+        double maxTime = data.m_pass == 0 ? 0.5 : 1.5;
+        if (!data.m_rebuildPending && data.m_timer <= maxTime)
             continue;
 
         Actor* pActor = Cast<Actor>(TESForm::GetById(cId));
@@ -1815,21 +1814,61 @@ void CharacterService::ApplyCachedSelfHeals(const UpdateEvent& acUpdateEvent) co
             continue;
         }
 
-        // OwnerSelfHealDress self-dedups: it skips when the biped already reports worn armor,
-        // so a retry on an already-dressed actor is a cheap no-op.
+        // Stage 3: a DisableImpl() was issued last tick; re-enable to rebuild the 3D from the
+        // (intact) container. EnableImpl(false) does NOT reset inventory, so the worn armor is
+        // re-attached to the freshly built biped.
+        if (data.m_rebuildPending)
+        {
+            if (pActor->IsDisabled())
+                pActor->EnableImpl();
+
+            const bool wornAfter = pActor->GetEquipment().HasWornItems();
+            spdlog::info("[NakedFix] self-heal 3D-rebuild re-enable for actor {:X}: wornAfter={}",
+                         pActor->formID, wornAfter);
+            toRemove.push_back(cId);
+            continue;
+        }
+
+        // Stages 1-2: gentle re-dress. OwnerSelfHealDress self-dedups on HasWornItems, so this is
+        // a cheap no-op once the biped is dressed.
         const bool wornBefore = pActor->GetEquipment().HasWornItems();
         const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
         OwnerSelfHealDress(pActor, baseFormId);
         const bool wornAfter = pActor->GetEquipment().HasWornItems();
 
         spdlog::info("[NakedFix] self-heal retry (pass {}) for actor {:X} (base {:X}): wornBefore={} wornAfter={}",
-                     data.m_isFirstPass ? 1 : 2, pActor->formID, baseFormId, wornBefore, wornAfter);
+                     data.m_pass + 1, pActor->formID, baseFormId, wornBefore, wornAfter);
 
-        // Stop early once dressed; otherwise let the second pass run, then give up.
-        if (wornAfter || !data.m_isFirstPass)
+        if (wornAfter)
+        {
             toRemove.push_back(cId);
+            continue;
+        }
 
-        data.m_isFirstPass = false;
+        // Still naked after the final gentle pass. If the container claims worn items but the
+        // biped isn't wearing them (the ownership-transfer no-op case), the plain re-dress can't
+        // fix it - the container diff sees "already worn" and equips nothing. Escalate to a 3D
+        // rebuild: strip the render now, re-enable next tick. Guard on loadedState so we only
+        // rebuild actors whose 3D is actually present (distant/unloaded actors stay pending).
+        if (data.m_pass >= 1)
+        {
+            const bool containerWorn = pActor->GetActorInventory().HasWornItems();
+            if (containerWorn && pActor->loadedState && !pActor->IsDisabled())
+            {
+                spdlog::info("[NakedFix] self-heal escalating to 3D rebuild for actor {:X} (base {:X}): "
+                             "container worn but biped naked", pActor->formID, baseFormId);
+                pActor->DisableImpl();
+                data.m_rebuildPending = true;
+                data.m_timer = 0.0;
+                continue; // re-enable next tick
+            }
+
+            // Nothing more we can safely do (no container items, or 3D not loaded).
+            toRemove.push_back(cId);
+            continue;
+        }
+
+        data.m_pass++;
     }
 
     for (uint32_t id : toRemove)

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -239,7 +239,13 @@ bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acS
         const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
         OwnerSelfHealDress(pActor, baseFormId);
         // The biped may not be ready yet at claim-time; schedule a deferred retry (2 passes).
-        m_selfHealRetries[pActor->formID] = {};
+        // Don't re-arm if a self-heal is already tracked for this actor: ownership flips fire
+        // repeatedly for persistent owned NPCs (e.g. horses) and each re-arm would reset the
+        // retry timer and re-run SetInventory on every flip, churning the inventory. One active
+        // self-heal per actor is enough; a fresh TakeOwnership after the entry is removed starts a
+        // new one.
+        if (m_selfHealRetries.find(pActor->formID) == m_selfHealRetries.end())
+            m_selfHealRetries[pActor->formID] = {};
     }
 
     return true;
@@ -439,7 +445,10 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
             const uint32_t baseFormId = pActor->baseForm ? pActor->baseForm->formID : 0;
             OwnerSelfHealDress(pActor, baseFormId);
             // The biped may not be ready yet at assign-time; schedule a deferred retry (2 passes).
-            m_selfHealRetries[pActor->formID] = {};
+            // Same re-arm guard as TakeOwnership: don't reset an already-active self-heal, or
+            // persistent owned NPCs (horses) get SetInventory re-run on every flip and stack.
+            if (m_selfHealRetries.find(pActor->formID) == m_selfHealRetries.end())
+                m_selfHealRetries[pActor->formID] = {};
         }
     }
     else

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -25,6 +25,7 @@
 #include <EquipManager.h>
 #include <Games/ActorExtension.h>
 #include <Forms/TESNPC.h>
+#include <Forms/BGSOutfit.h>
 #include <DefaultObjectManager.h>
 
 InventoryService::InventoryService(World& aWorld, entt::dispatcher& aDispatcher, TransportService& aTransport) noexcept
@@ -57,10 +58,21 @@ void InventoryService::OnInventoryChangeEvent(const InventoryChangeEvent& acEven
     if (iter == std::end(view))
         return;
 
+    const bool isLeader = m_world.GetPartyService().IsLeader(); // Helps distinguish in 2-party logs
     std::optional<uint32_t> serverIdRes = Utils::GetServerId(*iter);
     if (!serverIdRes.has_value())
     {
-        spdlog::error(__FUNCTION__ ": failed to find server id, target form id: {:X}, item id: {:X}, count: {}", acEvent.FormId, acEvent.Item.BaseId.BaseId, acEvent.Item.Count);
+        spdlog::error(
+            __FUNCTION__ ": failed to find server id, target form id: {:X}, isLeader: {}, item id: {:X}, count: {}", acEvent.FormId,
+            isLeader, acEvent.Item.BaseId.LogFormat(), acEvent.Item.Count);
+        return;
+    }
+
+    if (m_world.try_get<WaitingForAssignmentComponent>(*iter))
+    {
+        spdlog::debug(
+            __FUNCTION__ ": WaitingForAssignment, don't send inventory changes actorId: {:X}, serverId {:X}, isLeader: {}, item id: {:X}",
+            acEvent.FormId, serverIdRes.value(), isLeader, acEvent.Item.BaseId.LogFormat());
         return;
     }
 
@@ -72,7 +84,7 @@ void InventoryService::OnInventoryChangeEvent(const InventoryChangeEvent& acEven
 
     m_transport.Send(request);
 
-    spdlog::info("Sending item request, item: {:X}, count: {}, target object: {:X}", acEvent.Item.BaseId.BaseId, acEvent.Item.Count, acEvent.FormId);
+    spdlog::info(__FUNCTION__ ": sending item request, item: {:X}, count: {}, target object: {:X}", acEvent.Item.BaseId.LogFormat(), acEvent.Item.Count, acEvent.FormId);
 }
 
 void InventoryService::OnEquipmentChangeEvent(const EquipmentChangeEvent& acEvent) noexcept
@@ -87,16 +99,29 @@ void InventoryService::OnEquipmentChangeEvent(const EquipmentChangeEvent& acEven
     if (iter == std::end(view))
         return;
 
-    std::optional<uint32_t> serverIdRes = Utils::GetServerId(*iter);
-    if (!serverIdRes.has_value())
-    {
-        spdlog::error(__FUNCTION__ ": failed to find server id, actor id: {:X}, item id: {:X}, isAmmo: {}, unequip: {}, slot: {:X}", acEvent.ActorId, acEvent.ItemId, acEvent.IsAmmo, acEvent.Unequip, acEvent.EquipSlotId);
-        return;
-    }
-
+    const bool isLeader = m_world.GetPartyService().IsLeader(); // Helps distinguish in 2-party logs
     Actor* pActor = Cast<Actor>(TESForm::GetById(acEvent.ActorId));
     if (!pActor)
         return;
+
+    std::optional<uint32_t> serverIdRes = Utils::GetServerId(*iter);
+    if (!serverIdRes.has_value())
+    {
+        spdlog::error(
+            __FUNCTION__ ": failed to find server id, actorId: {:X}, isLeader: {}, item id: {:X}, isAmmo: {}, unequip: {}, slot: {:X}, name: {}",
+            acEvent.ActorId, isLeader, acEvent.ItemId, acEvent.IsAmmo, acEvent.Unequip, acEvent.EquipSlotId, pActor->baseForm->GetName());
+        return;
+    }
+
+    if (m_world.try_get<WaitingForAssignmentComponent>(*iter))
+    {
+        spdlog::debug(
+            __FUNCTION__ ": WaitingForAssignment, don't send equipment changes actorId: {:X}, serverId {:X}, isLeader: {}, "
+                         "item id: {:X}, isAmmo: {}, unequip: {}, slot: {:X}, name: {}",
+            acEvent.ActorId, serverIdRes.value(), isLeader, acEvent.ItemId, acEvent.IsAmmo, acEvent.Unequip, acEvent.EquipSlotId,
+            pActor->baseForm->GetName());
+        return;
+    }
 
     auto& modSystem = World::Get().GetModSystem();
 
@@ -117,7 +142,9 @@ void InventoryService::OnEquipmentChangeEvent(const EquipmentChangeEvent& acEven
 
     m_transport.Send(request);
 
-    spdlog::info("Sending equipment request, item: {:X}, count: {}, target object: {:X}", acEvent.ItemId, acEvent.Count, acEvent.ActorId);
+    spdlog::info(
+        __FUNCTION__ ": sending equipment change, actorId: {:X}, serverId {:X}, isLeader: {}, item: {:X}, count: {}, name: {}",
+        acEvent.ActorId, request.ServerId, isLeader, acEvent.ItemId, acEvent.Count, pActor->baseForm->GetName());
 }
 
 void InventoryService::OnNotifyInventoryChanges(const NotifyInventoryChanges& acMessage) noexcept
@@ -273,6 +300,8 @@ void InventoryService::RunNakedNPCBugChecks() noexcept
 
     static std::chrono::steady_clock::time_point lastSendTimePoint;
     constexpr auto cDelayBetweenUpdates = 1000ms;
+    constexpr auto cDelayAfterAssignment = 3s;
+    constexpr auto cNoDeadline = std::chrono::steady_clock::time_point{};
 
     const auto now = std::chrono::steady_clock::now();
     if (now - lastSendTimePoint < cDelayBetweenUpdates)
@@ -292,20 +321,48 @@ void InventoryService::RunNakedNPCBugChecks() noexcept
         if (pActor->GetExtension()->IsPlayer())
             continue;
 
-        if (pActor->IsDead())
+        if (pActor->GetExtension()->nakedDeadline == cNoDeadline)
             continue;
 
-        if (pActor->IsWearingBodyPiece())
+        if (pActor->IsDead() || !pActor->ShouldWearBodyPiece())
+        {
+            pActor->GetExtension()->nakedDeadline = cNoDeadline;
+            spdlog::debug(__FUNCTION__ ": actorId {:X} naked check is irrelevant {}", pActor->formID, pActor->baseForm->GetName());
+            continue; 
+        }
+
+        if (now < pActor->GetExtension()->nakedDeadline + cDelayAfterAssignment)
+        {
+            spdlog::debug(__FUNCTION__ ": actorId {:X} with naked check deadline {}", pActor->formID, pActor->baseForm->GetName());
+            continue; 
+        }
+
+        else
+        {
+            spdlog::debug(__FUNCTION__ ": actorId {:X} naked check deadline expires {}", pActor->formID, pActor->baseForm->GetName());
+            if (m_world.try_get<WaitingForAssignmentComponent>(entity))
+            {
+                spdlog::debug(__FUNCTION__ ": but still WaitingForAssignment", pActor->formID, pActor->baseForm->GetName());
+                pActor->GetExtension()->SetNakedDeadline();
+                continue;
+            }
+
+            pActor->GetExtension()->nakedDeadline = cNoDeadline;   
+        }
+
+        if (pActor->GetExtension()->IsRemote())
+        {
+            spdlog::debug(__FUNCTION__ ": actorId {:X} naked check canceled, IsRemote(), {}", pActor->formID, pActor->baseForm->GetName());
             continue;
+        }
 
-        if (!pActor->ShouldWearBodyPiece())
-            continue;
-
-        // Don't broadcast changes, it'll just make things messier.
-        // If all clients have this problem, they'll all fix it individually.
-        ScopedEquipOverride seo;
-        ScopedInventoryOverride sio;
-
-        pActor->ResetInventory(false);
+        // If somehow inventory was damaged despite fixes, dress actor. Belt and suspenders.
+        // Note if the outfit items have been removed from inventory, they aren't regenerated.
+        TESNPC* pBase = Cast<TESNPC>(pActor->baseForm);
+        if (!pActor->IsWearingBodyPiece() && pBase)
+        {
+            spdlog::warn(__FUNCTION__ ": actorId {:X} naked check fires {}", pActor->formID, pActor->baseForm->GetName());
+            pActor->EquipOutfit();
+        }
     }
 }

--- a/Code/client/Services/Generic/InventoryService.cpp
+++ b/Code/client/Services/Generic/InventoryService.cpp
@@ -25,7 +25,6 @@
 #include <EquipManager.h>
 #include <Games/ActorExtension.h>
 #include <Forms/TESNPC.h>
-#include <Forms/BGSOutfit.h>
 #include <DefaultObjectManager.h>
 
 InventoryService::InventoryService(World& aWorld, entt::dispatcher& aDispatcher, TransportService& aTransport) noexcept
@@ -43,7 +42,6 @@ InventoryService::InventoryService(World& aWorld, entt::dispatcher& aDispatcher,
 void InventoryService::OnUpdate(const UpdateEvent& acUpdateEvent) noexcept
 {
     RunWeaponStateUpdates();
-    RunNakedNPCBugChecks();
 }
 
 void InventoryService::OnInventoryChangeEvent(const InventoryChangeEvent& acEvent) noexcept
@@ -289,80 +287,6 @@ void InventoryService::RunWeaponStateUpdates() noexcept
             request.IsWeaponDrawn = isWeaponDrawn;
 
             m_transport.Send(request);
-        }
-    }
-}
-
-void InventoryService::RunNakedNPCBugChecks() noexcept
-{
-    if (!m_transport.IsConnected())
-        return;
-
-    static std::chrono::steady_clock::time_point lastSendTimePoint;
-    constexpr auto cDelayBetweenUpdates = 1000ms;
-    constexpr auto cDelayAfterAssignment = 3s;
-    constexpr auto cNoDeadline = std::chrono::steady_clock::time_point{};
-
-    const auto now = std::chrono::steady_clock::now();
-    if (now - lastSendTimePoint < cDelayBetweenUpdates)
-        return;
-
-    lastSendTimePoint = now;
-
-    auto view = m_world.view<FormIdComponent>();
-
-    for (auto entity : view)
-    {
-        const auto& formIdComponent = view.get<FormIdComponent>(entity);
-        Actor* pActor = Cast<Actor>(TESForm::GetById(formIdComponent.Id));
-        if (!pActor)
-            continue;
-
-        if (pActor->GetExtension()->IsPlayer())
-            continue;
-
-        if (pActor->GetExtension()->nakedDeadline == cNoDeadline)
-            continue;
-
-        if (pActor->IsDead() || !pActor->ShouldWearBodyPiece())
-        {
-            pActor->GetExtension()->nakedDeadline = cNoDeadline;
-            spdlog::debug(__FUNCTION__ ": actorId {:X} naked check is irrelevant {}", pActor->formID, pActor->baseForm->GetName());
-            continue; 
-        }
-
-        if (now < pActor->GetExtension()->nakedDeadline + cDelayAfterAssignment)
-        {
-            spdlog::debug(__FUNCTION__ ": actorId {:X} with naked check deadline {}", pActor->formID, pActor->baseForm->GetName());
-            continue; 
-        }
-
-        else
-        {
-            spdlog::debug(__FUNCTION__ ": actorId {:X} naked check deadline expires {}", pActor->formID, pActor->baseForm->GetName());
-            if (m_world.try_get<WaitingForAssignmentComponent>(entity))
-            {
-                spdlog::debug(__FUNCTION__ ": but still WaitingForAssignment", pActor->formID, pActor->baseForm->GetName());
-                pActor->GetExtension()->SetNakedDeadline();
-                continue;
-            }
-
-            pActor->GetExtension()->nakedDeadline = cNoDeadline;   
-        }
-
-        if (pActor->GetExtension()->IsRemote())
-        {
-            spdlog::debug(__FUNCTION__ ": actorId {:X} naked check canceled, IsRemote(), {}", pActor->formID, pActor->baseForm->GetName());
-            continue;
-        }
-
-        // If somehow inventory was damaged despite fixes, dress actor. Belt and suspenders.
-        // Note if the outfit items have been removed from inventory, they aren't regenerated.
-        TESNPC* pBase = Cast<TESNPC>(pActor->baseForm);
-        if (!pActor->IsWearingBodyPiece() && pBase)
-        {
-            spdlog::warn(__FUNCTION__ ": actorId {:X} naked check fires {}", pActor->formID, pActor->baseForm->GetName());
-            pActor->EquipOutfit();
         }
     }
 }

--- a/Code/client/Services/InventoryService.h
+++ b/Code/client/Services/InventoryService.h
@@ -60,7 +60,6 @@ private:
     * Checks whether an NPC's (local or remote) equipment is bugged (i.e. naked NPCS)
     * and resets their inventory.
     */
-    void RunNakedNPCBugChecks() noexcept;
 
     World& m_world;
     entt::dispatcher& m_dispatcher;

--- a/Code/encoding/Structs/Inventory.cpp
+++ b/Code/encoding/Structs/Inventory.cpp
@@ -203,3 +203,25 @@ bool Inventory::ContainsQuestItems() const noexcept
     }
     return false;
 }
+
+bool Inventory::IsFullyNaked() const noexcept
+{
+    for (const auto& entry : Entries)
+    {
+        if (entry.IsWorn())
+            return false;
+    }
+
+    return true;
+}
+
+bool Inventory::HasWornItems() const noexcept
+{
+    for (const auto& entry : Entries)
+    {
+        if (entry.IsWorn())
+            return true;
+    }
+
+    return false;
+}

--- a/Code/encoding/Structs/Inventory.h
+++ b/Code/encoding/Structs/Inventory.h
@@ -85,6 +85,12 @@ struct Inventory
     void UpdateEquipment(const Inventory& acNewInventory) noexcept;
     bool ContainsQuestItems() const noexcept;
 
+    // True when no entry is currently worn. A wholesale InitialInventory snapshot that is fully
+    // naked while the authoritative Content still has worn items is the transient "owner just
+    // reloaded and the engine hasn't re-dressed the actor yet" state that races across clients.
+    bool IsFullyNaked() const noexcept;
+    bool HasWornItems() const noexcept;
+
     Vector<Entry> Entries{};
     MagicEquipment CurrentMagicEquipment{};
 };

--- a/Code/server/Services/CharacterService.cpp
+++ b/Code/server/Services/CharacterService.cpp
@@ -731,7 +731,38 @@ void CharacterService::ApplyActorData(const entt::entity acEntity, const ActorDa
         const auto& incoming = acActorData.InitialInventory;
         const bool isDestructiveNaked = incoming.IsFullyNaked() && pInventoryComponent->Content.HasWornItems() && !acActorData.IsDead;
         if (!isDestructiveNaked)
+        {
             pInventoryComponent->Content = incoming;
+
+            // Normalize duplicate BaseId entries (issue #5): ownership fights used to
+            // commit stacked outfit copies into authoritative Content, where nothing
+            // ever merged them again. Collapse same-BaseId runs here so a bad snapshot
+            // cannot persist; worn entries keep the first copy, non-worn counts sum.
+            auto& entries = pInventoryComponent->Content.Entries;
+            for (size_t i = 0; i < entries.size(); ++i)
+            {
+                if (entries[i].Count == 0)
+                    continue;
+
+                for (size_t j = i + 1; j < entries.size();)
+                {
+                    if (entries[j].BaseId != entries[i].BaseId || entries[j].Count == 0)
+                    {
+                        ++j;
+                        continue;
+                    }
+
+                    // Worn items: one physical copy per actor -- drop extras entirely.
+                    if (entries[i].IsWorn() || entries[j].IsWorn())
+                        entries.erase(entries.begin() + j);
+                    else
+                    {
+                        entries[i].Count += entries[j].Count;
+                        entries.erase(entries.begin() + j);
+                    }
+                }
+            }
+        }
     }
 
     auto* pCharacterComponent = m_world.try_get<CharacterComponent>(acEntity);

--- a/Code/server/Services/CharacterService.cpp
+++ b/Code/server/Services/CharacterService.cpp
@@ -719,7 +719,19 @@ void CharacterService::ApplyActorData(const entt::entity acEntity, const ActorDa
     auto* pInventoryComponent = m_world.try_get<InventoryComponent>(acEntity);
     if (pInventoryComponent)
     {
-        pInventoryComponent->Content = acActorData.InitialInventory;
+        // Guard against a destructive fully-naked overwrite racing in from a transient owner state
+        // (e.g. the owner just reloaded the cell and the engine hasn't re-dressed the NPC yet).
+        // If the authoritative Content is still dressed but the incoming snapshot is fully naked,
+        // ignore the bad update instead of stripping the NPC. A later real inventory interaction
+        // (server InventoryService incremental change) will send correct data, so there is no need
+        // to mix in the stale naked snapshot.
+        // The only legitimate fully-empty cases are: a player steals all items from a living NPC
+        // (pickpocket, which syncs incrementally and empties Content first) or loots all items
+        // from a dead NPC. So a dead NPC's naked overwrite is allowed through.
+        const auto& incoming = acActorData.InitialInventory;
+        const bool isDestructiveNaked = incoming.IsFullyNaked() && pInventoryComponent->Content.HasWornItems() && !acActorData.IsDead;
+        if (!isDestructiveNaked)
+            pInventoryComponent->Content = incoming;
     }
 
     auto* pCharacterComponent = m_world.try_get<CharacterComponent>(acEntity);

--- a/Code/server/Services/CharacterService.cpp
+++ b/Code/server/Services/CharacterService.cpp
@@ -746,19 +746,25 @@ void CharacterService::ApplyActorData(const entt::entity acEntity, const ActorDa
 
                 for (size_t j = i + 1; j < entries.size();)
                 {
-                    if (entries[j].BaseId != entries[i].BaseId || entries[j].Count == 0)
+                    // Never collapse {0,0} entries: an unmapped mod item shares that
+                    // sentinel with every other unmapped item, so merging would erase
+                    // distinct pieces (observed as NPCs reduced to a single boot).
+                    if (entries[j].BaseId == entries[i].BaseId &&
+                        (entries[j].BaseId.ModId != 0 || entries[j].BaseId.BaseId != 0) &&
+                        entries[j].Count != 0)
                     {
-                        ++j;
-                        continue;
+                        // Worn items: one physical copy per actor -- drop extras entirely.
+                        if (entries[i].IsWorn() || entries[j].IsWorn())
+                            entries.erase(entries.begin() + j);
+                        else
+                        {
+                            entries[i].Count += entries[j].Count;
+                            entries.erase(entries.begin() + j);
+                        }
                     }
-
-                    // Worn items: one physical copy per actor -- drop extras entirely.
-                    if (entries[i].IsWorn() || entries[j].IsWorn())
-                        entries.erase(entries.begin() + j);
                     else
                     {
-                        entries[i].Count += entries[j].Count;
-                        entries.erase(entries.begin() + j);
+                        ++j;
                     }
                 }
             }


### PR DESCRIPTION
Long story short, rfortier discovered that the original RunNakedNPCBugChecks() didn't solve the issue. Checked every 3s.

What I discovered when testing the PR code, was that there were still cases where NPC were naked during ownership flip.

On some players, this ownership flip left local characters in a RemoveAllItems state, as inventory or equip calls sent empty.

What my commits since then have been trying to do is the following:
1. Make sure empty garbage equip/inventory states are not allowed to propagate, and not allowed to RemoveAllItems on ai.
2. Make sure local NPC actors do not send too much networking data when there's fighting for ownership. Tested in modlist.
3. Clean out old diagnostics and remove the RunNakedNPCBugChecks() code. Newer code runs on spawn + ownership flips.
4. Previously, there were reports that pickpocketing equipped garments from NPC would reset them back to a normal outfit.
5. I checked this after making all these commits, and verified that new code lets Party leader stealing worn items sync online.
6. For the final issue, players who wore no body armor or body garment, had invisible equipped hands and feet on remotes.
7. To fix this, i looked up a garment that shows an undressed torso, but counts as a body torso armor, so all gear show again.

When comparing before and after https://github.com/absol89/TiltedEvolutionScriptFixes/commit/ed7ed1ec3af5c4c9d0a42d0d1e47349f611732d3 , the previous commit's code isRemote() revealed NPC with bad worn state. That gave them the vampire lord's armor as proof that this was what was going on. Now, I changed the final commit to only give isRemotePlayer() the vampire lord armor to make sure their other limbs and helmets would render when they travel shirtless. Hopefully this fixes 3 issues in one swoop, and I am submitting it as a separate PR than 860 so there's possibility to review separately.

Video of npc not being naked after fixes. You can watch it without sound, it is just a 11 minute stress test https://www.youtube.com/watch?v=mCgSCQRPPiQ 

Video of pickpocket sync working (leader did it). Watch with sound https://www.youtube.com/watch?v=tFoMUSwnAZo

Picture of an NPC being fully equipless by player pickpocket. It was important that this didn't trigger outfit reset, seems ok.
<img width="2277" height="979" alt="image" src="https://github.com/user-attachments/assets/f774361d-aece-47b3-b3d3-2ab652ef3f5f" />

Picture of how player's look when not wearing torso item, and wearing helmet, gloves and boots on vanilla STR 1.8.0 (live).
<img width="3217" height="1071" alt="image" src="https://github.com/user-attachments/assets/bc3d6a89-9741-46fa-bdbd-a8c42450ebc9" />

Video of fix to limb rendering when player is not wearing torso items (gets armor 02011a85). https://youtu.be/EfgXv9WK8fE