### PR TITLE
Fix/issues#810 Where enemies going to local from remote got stuck in sheathe unequip state

### DIFF
--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -27,6 +27,13 @@ struct ActorExtension
     // and get stuck, refusing to aggro). 0 means "no grace window active".
     uint64_t LocalizedTick = 0;
 
+    // After a (re)localize, records whether the NPC arrived already in a combat-ready
+    // state (IsWeaponDrawn == true from the previous owner). Non-hostile NPCs arrive
+    // sheathed (false); transferred hostiles (bandits, etc.) arrive drawn (true). Used by
+    // the detection hook to engage combat ONLY for NPCs that were already hostile, so
+    // peaceful NPCs in friendly areas are never force-aggro'd.
+    bool ArrivedHostile = false;
+
     // During the reconcile grace window we still perform every action locally (so visuals stay
     // correct) but only broadcast each distinct reset action ONCE. These two flags track which
     // of the two loop actions we have already forwarded, so the server sees a single clean

--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -27,13 +27,6 @@ struct ActorExtension
     // and get stuck, refusing to aggro). 0 means "no grace window active".
     uint64_t LocalizedTick = 0;
 
-    // After a (re)localize, records whether the NPC arrived already in a combat-ready
-    // state (IsWeaponDrawn == true from the previous owner). Non-hostile NPCs arrive
-    // sheathed (false); transferred hostiles (bandits, etc.) arrive drawn (true). Used by
-    // the detection hook to engage combat ONLY for NPCs that were already hostile, so
-    // peaceful NPCs in friendly areas are never force-aggro'd.
-    bool ArrivedHostile = false;
-
     // During the reconcile grace window we still perform every action locally (so visuals stay
     // correct) but only broadcast each distinct reset action ONCE. These two flags track which
     // of the two loop actions we have already forwarded, so the server sees a single clean

--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -34,6 +34,19 @@ struct ActorExtension
     // peaceful NPCs in friendly areas are never force-aggro'd.
     bool ArrivedHostile = false;
 
+    // Issue #810: one-shot latch for the detection-hook combat engage. Once we have fired
+    // StartCombatEx for this NPC->player pair we set this true and NEVER fire again for the
+    // life of the actor. Without it the hook re-kicks StartCombatEx on every detection
+    // re-evaluation; StartCombatEx internally does StopCombat()+StartCombat(), and the
+    // StopCombat() sheathes the weapon -- producing the visible draw/sheathe OSCILLATION
+    // seen when a hostile NPC's ownership bounces between two nearby players (Embershard
+    // bandits looping). GetCombatTarget()!=target is NOT a sufficient latch because
+    // StopCombat() clears the combat target, so the next eval re-qualifies. This flag is
+    // the real latch: engage once, then leave all further combat/sheathe decisions to the
+    // engine. It is intentionally NOT reset on re-localize -- a contested NPC must not
+    // re-trigger the burst each time it flips back to local.
+    bool EngagedFromDetection = false;
+
     // During the reconcile grace window we still perform every action locally (so visuals stay
     // correct) but only broadcast each distinct reset action ONCE. These two flags track which
     // of the two loop actions we have already forwarded, so the server sees a single clean

--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -22,13 +22,20 @@ struct ActorExtension
     size_t GraphDescriptorHash = 0;
 
     // Tick (World clock) at which this actor was last (re)localized via SetRemote(false).
-    // Used by Animation.cpp to suppress the brief burst of reset/un-equip actions the engine
+    // Used by Animation.cpp to collapse the brief burst of reset/un-equip actions the engine
     // replays right after AI is unlocked (see issue #810: NPCs spam "Unequip"/"combatStanceStop"
     // and get stuck, refusing to aggro). 0 means "no grace window active".
     uint64_t LocalizedTick = 0;
 
+    // During the reconcile grace window we still perform every action locally (so visuals stay
+    // correct) but only broadcast each distinct reset action ONCE. These two flags track which
+    // of the two loop actions we have already forwarded, so the server sees a single clean
+    // transition instead of a stuck spam loop -- without ever freezing the NPC.
+    bool BroadcastedUnequip = false;
+    bool BroadcastedCombatStanceStop = false;
+
     // Grace window (in World ticks) during which reset-type actions from a freshly-localized
-    // NPC are swallowed instead of being performed/broadcast. ~1s at 60Hz tick.
+    // NPC are de-duplicated on broadcast. ~1s at 60Hz tick.
     static constexpr uint64_t kAnimReconcileGraceTicks = 60;
 
   private:

--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -21,6 +21,16 @@ struct ActorExtension
     ActionEvent LatestAnimation{};
     size_t GraphDescriptorHash = 0;
 
+    // Tick (World clock) at which this actor was last (re)localized via SetRemote(false).
+    // Used by Animation.cpp to suppress the brief burst of reset/un-equip actions the engine
+    // replays right after AI is unlocked (see issue #810: NPCs spam "Unequip"/"combatStanceStop"
+    // and get stuck, refusing to aggro). 0 means "no grace window active".
+    uint64_t LocalizedTick = 0;
+
+    // Grace window (in World ticks) during which reset-type actions from a freshly-localized
+    // NPC are swallowed instead of being performed/broadcast. ~1s at 60Hz tick.
+    static constexpr uint64_t kAnimReconcileGraceTicks = 60;
+
   private:
     uint32_t onlineFlags{0};
 };

--- a/Code/client/Games/ActorExtension.h
+++ b/Code/client/Games/ActorExtension.h
@@ -47,6 +47,15 @@ struct ActorExtension
     // re-trigger the burst each time it flips back to local.
     bool EngagedFromDetection = false;
 
+    // Issue #810: one-shot latch for the OnHit retaliation engage. Fire/DoT damage delivers
+    // a HitEvent every damage tick; OnHitEvent re-ran StartCombatEx on each one, and
+    // StartCombatEx's internal StopCombat() sheathes + clears the combat target, so the
+    // GetCombatTarget()!=hitter guard re-qualified next tick => draw/sheathe OSCILLATION
+    // while an NPC burns. Latch the retaliation so we StartCombatEx once, then leave combat
+    // to the engine. Reset when the NPC actually leaves combat so a later separate fight
+    // still triggers.
+    bool EngagedFromHit = false;
+
     // During the reconcile grace window we still perform every action locally (so visuals stay
     // correct) but only broadcast each distinct reset action ONCE. These two flags track which
     // of the two loop actions we have already forwarded, so the server sees a single clean

--- a/Code/client/Games/Animation.cpp
+++ b/Code/client/Games/Animation.cpp
@@ -70,27 +70,50 @@ uint8_t TP_MAKE_THISCALL(HookPerformAction, ActorMediator, TESActionData* apActi
             pExtension->LatestAnimation = action;
         }
 
-        // Issue #810 guard: for freshly-localized NPC actors only (never the player, never
-        // remote actors), swallow the network broadcast of the reset/stance actions the engine
-        // replays in a loop right after AI is unlocked. The engine action already executed above
-        // (so visuals don't desync), but we must not broadcast these self-replaying reconciles or
-        // the NPC gets stuck in "wants to sheathe" and refuses to aggro. Grace window is ~1s.
+        // Issue #810 fix: freshly-localized NPC actors replay a burst of reset/stance actions
+        // (Unequip, combatStanceStop, ...) in a loop right after AI is unlocked, which previously
+        // got them stuck ("wants to sheathe", refuse to aggro). The engine action is ALWAYS
+        // performed locally above (so visuals stay correct and the NPC can draw/move). We only
+        // collapse the NETWORK BROADCAST: each distinct reset action is forwarded at most once
+        // during the grace window, so the server sees a single clean transition instead of a
+        // stuck spam loop -- and is never starved of the (un)equip/combat state it needs to
+        // unlock the NPC. Player and remote actors are never affected.
         if (!pExtension->IsPlayer() && pExtension->LocalizedTick != 0)
         {
             const auto sinceLocalized = World::Get().GetTick() - pExtension->LocalizedTick;
             if (sinceLocalized < ActorExtension::kAnimReconcileGraceTicks)
             {
-                if (IsResetAction(action.EventName))
+                bool shouldBroadcast = true;
+                if (action.EventName == "Unequip")
                 {
-                    spdlog::info("Anim guard: swallowed reset action \"{}\" on {:X} ({} ticks since localize)",
+                    shouldBroadcast = !pExtension->BroadcastedUnequip;
+                    pExtension->BroadcastedUnequip = true;
+                }
+                else if (action.EventName == "combatStanceStop")
+                {
+                    shouldBroadcast = !pExtension->BroadcastedCombatStanceStop;
+                    pExtension->BroadcastedCombatStanceStop = true;
+                }
+                else if (IsResetAction(action.EventName))
+                {
+                    // Other reset/stance actions (combatStanceGo/Sheathe/Draw/DrawEnd/Idle):
+                    // forward the first occurrence too, but don't spam the rest of the burst.
+                    shouldBroadcast = pExtension->BroadcastedUnequip == false && pExtension->BroadcastedCombatStanceStop == false;
+                }
+
+                if (!shouldBroadcast)
+                {
+                    spdlog::info("Anim guard: de-duplicated broadcast of reset action \"{}\" on {:X} ({} ticks since localize)",
                                  action.EventName, pActor->formID, sinceLocalized);
                     return res;
                 }
             }
             else
             {
-                // Grace window expired: stop suppressing for this actor.
+                // Grace window expired: reset dedupe state and stop collapsing for this actor.
                 pExtension->LocalizedTick = 0;
+                pExtension->BroadcastedUnequip = false;
+                pExtension->BroadcastedCombatStanceStop = false;
             }
         }
 

--- a/Code/client/Games/Animation.cpp
+++ b/Code/client/Games/Animation.cpp
@@ -23,7 +23,7 @@ thread_local bool g_forceAnimation = false;
 // Issue #810: reset/stances actions the engine replays in a loop right after an NPC is
 // (re)localized (AI unlocked). Spamming these prevents the NPC from ever finishing an attack
 // windup, so they stand still and refuse to aggro.
-static bool IsResetAction(const std::string& aEventName) noexcept
+static bool IsResetAction(const TiltedPhoques::String& aEventName) noexcept
 {
     return aEventName == "Unequip"
         || aEventName == "combatStanceStop"

--- a/Code/client/Games/Animation.cpp
+++ b/Code/client/Games/Animation.cpp
@@ -20,6 +20,20 @@ static TPerformAction* RealPerformAction;
 // TODO: make scoped override
 thread_local bool g_forceAnimation = false;
 
+// Issue #810: reset/stances actions the engine replays in a loop right after an NPC is
+// (re)localized (AI unlocked). Spamming these prevents the NPC from ever finishing an attack
+// windup, so they stand still and refuse to aggro.
+static bool IsResetAction(const std::string& aEventName) noexcept
+{
+    return aEventName == "Unequip"
+        || aEventName == "combatStanceStop"
+        || aEventName == "combatStanceGo"
+        || aEventName == "Sheathe"
+        || aEventName == "Draw"
+        || aEventName == "DrawEnd"
+        || aEventName == "Idle";
+}
+
 uint8_t TP_MAKE_THISCALL(HookPerformAction, ActorMediator, TESActionData* apAction)
 {
     auto pActor = apAction->actor;
@@ -54,6 +68,30 @@ uint8_t TP_MAKE_THISCALL(HookPerformAction, ActorMediator, TESActionData* apActi
         if (res)
         {
             pExtension->LatestAnimation = action;
+        }
+
+        // Issue #810 guard: for freshly-localized NPC actors only (never the player, never
+        // remote actors), swallow the network broadcast of the reset/stance actions the engine
+        // replays in a loop right after AI is unlocked. The engine action already executed above
+        // (so visuals don't desync), but we must not broadcast these self-replaying reconciles or
+        // the NPC gets stuck in "wants to sheathe" and refuses to aggro. Grace window is ~1s.
+        if (!pExtension->IsPlayer() && pExtension->LocalizedTick != 0)
+        {
+            const auto sinceLocalized = World::Get().GetTick() - pExtension->LocalizedTick;
+            if (sinceLocalized < ActorExtension::kAnimReconcileGraceTicks)
+            {
+                if (IsResetAction(action.EventName))
+                {
+                    spdlog::info("Anim guard: swallowed reset action \"{}\" on {:X} ({} ticks since localize)",
+                                 action.EventName, pActor->formID, sinceLocalized);
+                    return res;
+                }
+            }
+            else
+            {
+                // Grace window expired: stop suppressing for this actor.
+                pExtension->LocalizedTick = 0;
+            }
         }
 
         World::Get().GetRunner().Trigger(action);

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -1172,6 +1172,22 @@ void TP_MAKE_THISCALL(HookUpdateDetectionState, ActorKnowledge, void* apState)
                 spdlog::debug("Cancelling detection from remote player to local player, owner: {:X}, target: {:X}", pOwner->formID, pTarget->formID);
                 return;
             }
+
+            // Issue #810 / #741: a local NPC whose ownership was transferred has no valid
+            // combat-target handle to a remote player, so it draws on detection but never
+            // attacks or chases. Once the engine flags it hostile (in combat), point its
+            // combat controller at the detected remote player. This only runs after the
+            // NPC has actually detected/aggro'd the player (never at localize time).
+            const auto* pOwnerEx = pOwnerActor->GetExtension();
+            const auto* pTargetEx = pTargetActor->GetExtension();
+            if (pOwnerEx->IsLocal() && !pOwnerEx->IsPlayer() && pTargetEx->IsRemotePlayer() && pOwnerActor->IsInCombat())
+            {
+                if (pOwnerActor->GetCombatTarget() != pTargetActor)
+                {
+                    spdlog::info("Combat target re-acquired: local NPC {:X} -> remote player {:X}", pOwner->formID, pTarget->formID);
+                    pOwnerActor->SetCombatTargetEx(pTargetActor);
+                }
+            }
         }
     }
 

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -1184,16 +1184,14 @@ void TP_MAKE_THISCALL(HookUpdateDetectionState, ActorKnowledge, void* apState)
             // player is the LOCAL player -- NOT remote. So we accept a detected target that
             // is EITHER the local or a remote player.
             //
-            // We do NOT gate on weapon-drawn/hostility: an idle bandit standing its post
-            // arrives sheathed and only draws when it notices you -- gating on drawn-state
-            // filters out exactly that case (proven in logs: sheathed bandits never engaged
-            // while always-drawn creatures did). The detection hook firing is itself the
-            // engine's own "valid threat pair" signal, so a genuinely peaceful NPC that never
-            // detects a player as a threat is never reached here.
+            // Safety: only engage for NPCs that arrived already hostile (ArrivedHostile,
+            // i.e. weapon was drawn when transferred). Peaceful NPCs arrive sheathed and
+            // are never force-aggro'd, so friendly areas stay safe.
             const auto* pOwnerEx = pOwnerActor->GetExtension();
             const auto* pTargetEx = pTargetActor->GetExtension();
             if (pOwnerEx->IsLocal() && !pOwnerEx->IsPlayer() &&
-                (pTargetEx->IsLocalPlayer() || pTargetEx->IsRemotePlayer()))
+                (pTargetEx->IsLocalPlayer() || pTargetEx->IsRemotePlayer()) &&
+                pOwnerEx->ArrivedHostile)
             {
                 if (pOwnerActor->GetCombatTarget() != pTargetActor)
                 {

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -1184,14 +1184,16 @@ void TP_MAKE_THISCALL(HookUpdateDetectionState, ActorKnowledge, void* apState)
             // player is the LOCAL player -- NOT remote. So we accept a detected target that
             // is EITHER the local or a remote player.
             //
-            // Safety: only engage for NPCs that arrived already hostile (ArrivedHostile,
-            // i.e. weapon was drawn when transferred). Peaceful NPCs arrive sheathed and
-            // are never force-aggro'd, so friendly areas stay safe.
+            // We do NOT gate on weapon-drawn/hostility: an idle bandit standing its post
+            // arrives sheathed and only draws when it notices you -- gating on drawn-state
+            // filters out exactly that case (proven in logs: sheathed bandits never engaged
+            // while always-drawn creatures did). The detection hook firing is itself the
+            // engine's own "valid threat pair" signal, so a genuinely peaceful NPC that never
+            // detects a player as a threat is never reached here.
             const auto* pOwnerEx = pOwnerActor->GetExtension();
             const auto* pTargetEx = pTargetActor->GetExtension();
             if (pOwnerEx->IsLocal() && !pOwnerEx->IsPlayer() &&
-                (pTargetEx->IsLocalPlayer() || pTargetEx->IsRemotePlayer()) &&
-                pOwnerEx->ArrivedHostile)
+                (pTargetEx->IsLocalPlayer() || pTargetEx->IsRemotePlayer()))
             {
                 if (pOwnerActor->GetCombatTarget() != pTargetActor)
                 {

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -1175,14 +1175,16 @@ void TP_MAKE_THISCALL(HookUpdateDetectionState, ActorKnowledge, void* apState)
 
             // Issue #810 / #741: a local NPC whose ownership was transferred has no valid
             // combat-target handle to a remote player, so it follows on detection but never
-            // draws/attacks/chases. Pointing the controller at the target (SetCombatTargetEx)
-            // is NOT enough for a dormant transferred NPC -- its combat AI was never started
-            // with that target. Calling StartCombat actually boots the combat controller
-            // against the remote player. Gated on IsInCombat() so it only runs after the
-            // NPC has actually detected/aggro'd the player (never at localize time).
+            // draws/attacks/chases. The reactive gating on IsInCombat() does NOT work here:
+            // a transferred hostile NPC's "in combat" flag was never initialized by the engine,
+            // so that gate is permanently false and the hook never fires. The detection hook
+            // itself only runs when the engine is already evaluating this NPC vs that target
+            // (the "this NPC noticed you" moment), so engaging here mirrors vanilla's own
+            // trigger. We only act when the detected target is a remote PLAYER (not a local
+            // actor, not a creature) and the NPC is not already fighting that remote player.
             const auto* pOwnerEx = pOwnerActor->GetExtension();
             const auto* pTargetEx = pTargetActor->GetExtension();
-            if (pOwnerEx->IsLocal() && !pOwnerEx->IsPlayer() && pTargetEx->IsRemotePlayer() && pOwnerActor->IsInCombat())
+            if (pOwnerEx->IsLocal() && !pOwnerEx->IsPlayer() && pTargetEx->IsRemotePlayer())
             {
                 if (pOwnerActor->GetCombatTarget() != pTargetActor)
                 {

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -1174,21 +1174,28 @@ void TP_MAKE_THISCALL(HookUpdateDetectionState, ActorKnowledge, void* apState)
             }
 
             // Issue #810 / #741: a local NPC whose ownership was transferred has no valid
-            // combat-target handle to a remote player, so it follows on detection but never
-            // draws/attacks/chases. The reactive gating on IsInCombat() does NOT work here:
-            // a transferred hostile NPC's "in combat" flag was never initialized by the engine,
-            // so that gate is permanently false and the hook never fires. The detection hook
-            // itself only runs when the engine is already evaluating this NPC vs that target
-            // (the "this NPC noticed you" moment), so engaging here mirrors vanilla's own
-            // trigger. We only act when the detected target is a remote PLAYER (not a local
-            // actor, not a creature) and the NPC is not already fighting that remote player.
+            // combat-target handle to a player, so it follows on detection but never
+            // draws/attacks/chases. The detection hook only runs when the engine is already
+            // evaluating this NPC vs that target (the "this NPC noticed you" moment), so
+            // engaging here mirrors vanilla's own trigger.
+            //
+            // Ownership direction: when the leader leaves, the NPC's AI localizes on the
+            // OTHER player's machine. There the NPC is a local actor and the discovered
+            // player is the LOCAL player -- NOT remote. So we accept a detected target that
+            // is EITHER the local or a remote player.
+            //
+            // Safety: only engage for NPCs that arrived already hostile (ArrivedHostile,
+            // i.e. weapon was drawn when transferred). Peaceful NPCs arrive sheathed and
+            // are never force-aggro'd, so friendly areas stay safe.
             const auto* pOwnerEx = pOwnerActor->GetExtension();
             const auto* pTargetEx = pTargetActor->GetExtension();
-            if (pOwnerEx->IsLocal() && !pOwnerEx->IsPlayer() && pTargetEx->IsRemotePlayer())
+            if (pOwnerEx->IsLocal() && !pOwnerEx->IsPlayer() &&
+                (pTargetEx->IsLocalPlayer() || pTargetEx->IsRemotePlayer()) &&
+                pOwnerEx->ArrivedHostile)
             {
                 if (pOwnerActor->GetCombatTarget() != pTargetActor)
                 {
-                    spdlog::info("Combat started (detection): local NPC {:X} -> remote player {:X}", pOwner->formID, pTarget->formID);
+                    spdlog::info("Combat started (detection): local NPC {:X} -> player {:X} (remote={})", pOwner->formID, pTarget->formID, pTargetEx->IsRemotePlayer());
                     pOwnerActor->StartCombatEx(pTargetActor);
                 }
             }

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -1195,11 +1195,19 @@ void TP_MAKE_THISCALL(HookUpdateDetectionState, ActorKnowledge, void* apState)
             // especially when a contested NPC's ownership bounces between two nearby
             // players. After the single engage we hand all further combat/sheathe control
             // back to the engine and never re-kick.
+            //
+            // Hostility gate: ArrivedHostile (weapon drawn at transfer) is only a proxy and
+            // catches ALLIES who happen to be weapon-drawn -- e.g. a follower (Lydia) walking
+            // with weapon out was force-attacked against the player. Require Aggression >= 2
+            // ("Very Aggressive": attacks on sight) so we only ever force-engage NPCs that
+            // would attack the player anyway. Followers/guards/townsfolk (aggression 0-1) are
+            // never turned hostile. This is read via the vanilla ActorValue, no new pointer.
             auto* pOwnerEx = pOwnerActor->GetExtension();
             const auto* pTargetEx = pTargetActor->GetExtension();
             if (pOwnerEx->IsLocal() && !pOwnerEx->IsPlayer() &&
                 (pTargetEx->IsLocalPlayer() || pTargetEx->IsRemotePlayer()) &&
-                pOwnerEx->ArrivedHostile && !pOwnerEx->EngagedFromDetection)
+                pOwnerEx->ArrivedHostile && !pOwnerEx->EngagedFromDetection &&
+                pOwnerActor->GetActorValue(ActorValueInfo::kAggression) >= 2.0f)
             {
                 if (pOwnerActor->GetCombatTarget() != pTargetActor)
                 {

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -1174,9 +1174,11 @@ void TP_MAKE_THISCALL(HookUpdateDetectionState, ActorKnowledge, void* apState)
             }
 
             // Issue #810 / #741: a local NPC whose ownership was transferred has no valid
-            // combat-target handle to a remote player, so it draws on detection but never
-            // attacks or chases. Once the engine flags it hostile (in combat), point its
-            // combat controller at the detected remote player. This only runs after the
+            // combat-target handle to a remote player, so it follows on detection but never
+            // draws/attacks/chases. Pointing the controller at the target (SetCombatTargetEx)
+            // is NOT enough for a dormant transferred NPC -- its combat AI was never started
+            // with that target. Calling StartCombat actually boots the combat controller
+            // against the remote player. Gated on IsInCombat() so it only runs after the
             // NPC has actually detected/aggro'd the player (never at localize time).
             const auto* pOwnerEx = pOwnerActor->GetExtension();
             const auto* pTargetEx = pTargetActor->GetExtension();
@@ -1184,8 +1186,8 @@ void TP_MAKE_THISCALL(HookUpdateDetectionState, ActorKnowledge, void* apState)
             {
                 if (pOwnerActor->GetCombatTarget() != pTargetActor)
                 {
-                    spdlog::info("Combat target re-acquired: local NPC {:X} -> remote player {:X}", pOwner->formID, pTarget->formID);
-                    pOwnerActor->SetCombatTargetEx(pTargetActor);
+                    spdlog::info("Combat started (detection): local NPC {:X} -> remote player {:X}", pOwner->formID, pTarget->formID);
+                    pOwnerActor->StartCombatEx(pTargetActor);
                 }
             }
         }

--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -1187,16 +1187,25 @@ void TP_MAKE_THISCALL(HookUpdateDetectionState, ActorKnowledge, void* apState)
             // Safety: only engage for NPCs that arrived already hostile (ArrivedHostile,
             // i.e. weapon was drawn when transferred). Peaceful NPCs arrive sheathed and
             // are never force-aggro'd, so friendly areas stay safe.
-            const auto* pOwnerEx = pOwnerActor->GetExtension();
+            //
+            // One-shot: fire StartCombatEx exactly ONCE per actor (EngagedFromDetection).
+            // StartCombatEx does StopCombat()+StartCombat(); the StopCombat() clears the
+            // combat target and sheathes the weapon, so a GetCombatTarget() check alone
+            // re-qualifies on the next detection eval and produces a draw/sheathe loop --
+            // especially when a contested NPC's ownership bounces between two nearby
+            // players. After the single engage we hand all further combat/sheathe control
+            // back to the engine and never re-kick.
+            auto* pOwnerEx = pOwnerActor->GetExtension();
             const auto* pTargetEx = pTargetActor->GetExtension();
             if (pOwnerEx->IsLocal() && !pOwnerEx->IsPlayer() &&
                 (pTargetEx->IsLocalPlayer() || pTargetEx->IsRemotePlayer()) &&
-                pOwnerEx->ArrivedHostile)
+                pOwnerEx->ArrivedHostile && !pOwnerEx->EngagedFromDetection)
             {
                 if (pOwnerActor->GetCombatTarget() != pTargetActor)
                 {
                     spdlog::info("Combat started (detection): local NPC {:X} -> player {:X} (remote={})", pOwner->formID, pTarget->formID, pTargetEx->IsRemotePlayer());
                     pOwnerActor->StartCombatEx(pTargetActor);
+                    pOwnerEx->EngagedFromDetection = true;
                 }
             }
         }

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -354,6 +354,15 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         pActor->GetExtension()->BroadcastedUnequip = false;
         pActor->GetExtension()->BroadcastedCombatStanceStop = false;
 
+        // Issue #810: a transferred NPC's cached weapon-drawn flag (from the previous
+        // owner's client) is often desynced from the real animation graph, so when combat
+        // AI later issues a draw the command no-ops and the NPC follows but never draws.
+        // Force a clean sheathed baseline through the existing 3D-safe draw path (which
+        // uses SetWeaponDrawnEx's flip-first-if-equal logic), so the next real draw produces
+        // a genuine transition. Skip NPCs already in combat to avoid disturbing a live fight.
+        if (!pActor->IsInCombat())
+            m_weaponDrawUpdates[pActor->formID] = {false};
+
         if (auto* pEarlyAnimComponent = m_world.try_get<EarlyAnimationBufferComponent>(cEntity))
         {
             for (const auto& action : pEarlyAnimComponent->Actions)

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -360,9 +360,12 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         // Force a clean sheathed baseline through the existing 3D-safe draw path (which
         // uses SetWeaponDrawnEx's flip-first-if-equal logic), so the next real draw produces
         // a genuine transition. Skip NPCs already in combat to avoid disturbing a live fight.
-        if (!pActor->IsInCombat())
-            m_weaponDrawUpdates[pActor->formID] = {false};
-
+        // Issue #810 / #741: record whether this NPC arrived combat-ready. Transferred
+        // hostiles (bandits, etc.) arrive with their weapon already drawn (true) from the
+        // previous owner; peaceful NPCs arrive sheathed (false). The detection hook uses
+        // this to engage combat ONLY for already-hostile NPCs, never force-aggro'ing a
+        // friendly NPC that merely happens to detect the player.
+        pActor->GetExtension()->ArrivedHostile = pActor->IsWeaponDrawn();
         if (auto* pEarlyAnimComponent = m_world.try_get<EarlyAnimationBufferComponent>(cEntity))
         {
             for (const auto& action : pEarlyAnimComponent->Actions)

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -143,9 +143,12 @@ bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acS
 
     pExtension->SetRemote(false);
 
-    // Issue #810: mark the actor as freshly localized so Animation.cpp can suppress the
-    // burst of reset/un-equip actions the engine replays once AI is unlocked.
+    // Issue #810: mark the actor as freshly localized so Animation.cpp de-duplicates the burst
+    // of reset/un-equip actions the engine replays once AI is unlocked. Reset the dedupe flags
+    // so this (re)localization starts a fresh grace window.
     pExtension->LocalizedTick = m_world.GetTick();
+    pExtension->BroadcastedUnequip = false;
+    pExtension->BroadcastedCombatStanceStop = false;
     spdlog::info("TakeOwnership: actor {:X} server {:X} became local (anim reconcile tick {:X})",
                  acFormId, acServerId, pExtension->LocalizedTick);
 
@@ -287,8 +290,10 @@ void CharacterService::OnDisconnected(const DisconnectedEvent& acDisconnectedEve
         else
         {
             pActor->GetExtension()->SetRemote(false);
-            // Issue #810: suppress post-localize reset-action spam.
+            // Issue #810: start a fresh reconcile grace window for this (re)localized NPC.
             pActor->GetExtension()->LocalizedTick = m_world.GetTick();
+            pActor->GetExtension()->BroadcastedUnequip = false;
+            pActor->GetExtension()->BroadcastedCombatStanceStop = false;
         }
     }
 
@@ -344,8 +349,10 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
 
         pActor->GetExtension()->SetRemote(false);
 
-        // Issue #810: suppress post-localize reset-action spam.
+        // Issue #810: start a fresh reconcile grace window for this (re)localized NPC.
         pActor->GetExtension()->LocalizedTick = m_world.GetTick();
+        pActor->GetExtension()->BroadcastedUnequip = false;
+        pActor->GetExtension()->BroadcastedCombatStanceStop = false;
 
         if (auto* pEarlyAnimComponent = m_world.try_get<EarlyAnimationBufferComponent>(cEntity))
         {
@@ -1331,8 +1338,10 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
             else
             {
                 pActor->GetExtension()->SetRemote(false);
-                // Issue #810: suppress post-localize reset-action spam.
+                // Issue #810: start a fresh reconcile grace window for this (re)localized NPC.
                 pActor->GetExtension()->LocalizedTick = m_world.GetTick();
+                pActor->GetExtension()->BroadcastedUnequip = false;
+                pActor->GetExtension()->BroadcastedCombatStanceStop = false;
             }
         }
 

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -354,12 +354,6 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         pActor->GetExtension()->BroadcastedUnequip = false;
         pActor->GetExtension()->BroadcastedCombatStanceStop = false;
 
-        // Issue #810 / #741: record whether this NPC arrived combat-ready. Transferred
-        // hostiles (bandits, etc.) arrive with their weapon already drawn (true) from the
-        // previous owner; peaceful NPCs arrive sheathed (false). The detection hook uses
-        // this to engage combat ONLY for already-hostile NPCs, never force-aggro'ing a
-        // friendly NPC that merely happens to detect the player.
-        pActor->GetExtension()->ArrivedHostile = pActor->actorState.IsWeaponDrawn();
         if (auto* pEarlyAnimComponent = m_world.try_get<EarlyAnimationBufferComponent>(cEntity))
         {
             for (const auto& action : pEarlyAnimComponent->Actions)

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -143,6 +143,12 @@ bool CharacterService::TakeOwnership(const uint32_t acFormId, const uint32_t acS
 
     pExtension->SetRemote(false);
 
+    // Issue #810: mark the actor as freshly localized so Animation.cpp can suppress the
+    // burst of reset/un-equip actions the engine replays once AI is unlocked.
+    pExtension->LocalizedTick = m_world.GetTick();
+    spdlog::info("TakeOwnership: actor {:X} server {:X} became local (anim reconcile tick {:X})",
+                 acFormId, acServerId, pExtension->LocalizedTick);
+
     // TODO(cosideci): this should be done differently.
     // Send an ownership claim request, and have the server broadcast the result.
     // Only then should components be added or removed.
@@ -279,7 +285,11 @@ void CharacterService::OnDisconnected(const DisconnectedEvent& acDisconnectedEve
         if (pActor->GetExtension()->IsRemotePlayer())
             pActor->Delete();
         else
+        {
             pActor->GetExtension()->SetRemote(false);
+            // Issue #810: suppress post-localize reset-action spam.
+            pActor->GetExtension()->LocalizedTick = m_world.GetTick();
+        }
     }
 
     m_world.clear<WaitingForAssignmentComponent, LocalComponent, RemoteComponent>();
@@ -333,6 +343,9 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         auto& localAnimationComponent = m_world.emplace_or_replace<LocalAnimationComponent>(cEntity);
 
         pActor->GetExtension()->SetRemote(false);
+
+        // Issue #810: suppress post-localize reset-action spam.
+        pActor->GetExtension()->LocalizedTick = m_world.GetTick();
 
         if (auto* pEarlyAnimComponent = m_world.try_get<EarlyAnimationBufferComponent>(cEntity))
         {
@@ -1318,6 +1331,8 @@ void CharacterService::CancelServerAssignment(const entt::entity aEntity, const 
             else
             {
                 pActor->GetExtension()->SetRemote(false);
+                // Issue #810: suppress post-localize reset-action spam.
+                pActor->GetExtension()->LocalizedTick = m_world.GetTick();
             }
         }
 

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -359,7 +359,7 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         // previous owner; peaceful NPCs arrive sheathed (false). The detection hook uses
         // this to engage combat ONLY for already-hostile NPCs, never force-aggro'ing a
         // friendly NPC that merely happens to detect the player.
-        pActor->GetExtension()->ArrivedHostile = pActor->IsWeaponDrawn();
+        pActor->GetExtension()->ArrivedHostile = pActor->actorState.IsWeaponDrawn();
         if (auto* pEarlyAnimComponent = m_world.try_get<EarlyAnimationBufferComponent>(cEntity))
         {
             for (const auto& action : pEarlyAnimComponent->Actions)

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -354,6 +354,12 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         pActor->GetExtension()->BroadcastedUnequip = false;
         pActor->GetExtension()->BroadcastedCombatStanceStop = false;
 
+        // Issue #810 / #741: record whether this NPC arrived combat-ready. Transferred
+        // hostiles (bandits, etc.) arrive with their weapon already drawn (true) from the
+        // previous owner; peaceful NPCs arrive sheathed (false). The detection hook uses
+        // this to engage combat ONLY for already-hostile NPCs, never force-aggro'ing a
+        // friendly NPC that merely happens to detect the player.
+        pActor->GetExtension()->ArrivedHostile = pActor->actorState.IsWeaponDrawn();
         if (auto* pEarlyAnimComponent = m_world.try_get<EarlyAnimationBufferComponent>(cEntity))
         {
             for (const auto& action : pEarlyAnimComponent->Actions)

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -354,12 +354,6 @@ void CharacterService::OnAssignCharacter(const AssignCharacterResponse& acMessag
         pActor->GetExtension()->BroadcastedUnequip = false;
         pActor->GetExtension()->BroadcastedCombatStanceStop = false;
 
-        // Issue #810: a transferred NPC's cached weapon-drawn flag (from the previous
-        // owner's client) is often desynced from the real animation graph, so when combat
-        // AI later issues a draw the command no-ops and the NPC follows but never draws.
-        // Force a clean sheathed baseline through the existing 3D-safe draw path (which
-        // uses SetWeaponDrawnEx's flip-first-if-equal logic), so the next real draw produces
-        // a genuine transition. Skip NPCs already in combat to avoid disturbing a live fight.
         // Issue #810 / #741: record whether this NPC arrived combat-ready. Transferred
         // hostiles (bandits, etc.) arrive with their weapon already drawn (true) from the
         // previous owner; peaceful NPCs arrive sheathed (false). The detection hook uses

--- a/Code/client/Services/Generic/CombatService.cpp
+++ b/Code/client/Services/Generic/CombatService.cpp
@@ -176,7 +176,11 @@ void CombatService::OnHitEvent(const HitEvent& acEvent) const noexcept
 
     // Only point a target once the engine has the NPC in combat (don't force aggro on a stray hit).
     if (!pHittee->IsInCombat())
+    {
+        // Left combat -> clear the retaliation latch so a later, separate fight re-triggers.
+        pHittee->GetExtension()->EngagedFromHit = false;
         return;
+    }
 
     auto view = m_world.view<FormIdComponent, LocalComponent>(entt::exclude<ObjectComponent>);
     const auto hitteeIt = std::find_if(std::begin(view), std::end(view), [id = acEvent.HitteeId, view](entt::entity entity) { return view.get<FormIdComponent>(entity).Id == id; });
@@ -186,10 +190,17 @@ void CombatService::OnHitEvent(const HitEvent& acEvent) const noexcept
         return;
     }
 
-    if (pHittee->GetCombatTarget() != pHitter)
+    // One-shot: StartCombatEx does StopCombat()+StartCombat(); the StopCombat() sheathes and
+    // clears the combat target, so GetCombatTarget()!=hitter alone re-qualifies on the very
+    // next HitEvent. Fire/DoT damage ticks many times per second, which turned that into a
+    // draw/sheathe loop while the NPC burned. Engage once, latch, and let the engine own
+    // combat thereafter; the latch is cleared above when the NPC leaves combat.
+    auto* pHitteeEx = pHittee->GetExtension();
+    if (pHittee->GetCombatTarget() != pHitter && !pHitteeEx->EngagedFromHit)
     {
         spdlog::info("Combat started (hit): local NPC {:X} -> player {:X}", acEvent.HitteeId, acEvent.HitterId);
         pHittee->StartCombatEx(pHitter);
+        pHitteeEx->EngagedFromHit = true;
     }
 }
 

--- a/Code/client/Services/Generic/CombatService.cpp
+++ b/Code/client/Services/Generic/CombatService.cpp
@@ -162,41 +162,35 @@ void CombatService::OnNotifyProjectileLaunch(const NotifyProjectileLaunch& acMes
 
 void CombatService::OnHitEvent(const HitEvent& acEvent) const noexcept
 {
-#if 0
     if (!m_transport.IsConnected())
         return;
 
-    // The targeting system does not apply to players, and only local actors should be considered.
+    // A local NPC that is hit by a player acquires that player as its combat target (retaliation).
     auto* pHittee = Cast<Actor>(TESForm::GetById(acEvent.HitteeId));
     if (!pHittee || pHittee->GetExtension()->IsPlayer() || pHittee->GetExtension()->IsRemote())
         return;
 
-    // NPCs should not affect targeting.
     auto* pHitter = Cast<Actor>(TESForm::GetById(acEvent.HitterId));
-    if (!pHitter || !pHitter->GetExtension()->IsPlayer())
+    if (!pHitter || (!pHitter->GetExtension()->IsLocalPlayer() && !pHitter->GetExtension()->IsRemotePlayer()))
         return;
 
-    // If the target is not in combat, don't start combat, let the game take care of that first.
+    // Only point a target once the engine has the NPC in combat (don't force aggro on a stray hit).
     if (!pHittee->IsInCombat())
         return;
 
     auto view = m_world.view<FormIdComponent, LocalComponent>(entt::exclude<ObjectComponent>);
-
     const auto hitteeIt = std::find_if(std::begin(view), std::end(view), [id = acEvent.HitteeId, view](entt::entity entity) { return view.get<FormIdComponent>(entity).Id == id; });
-
     if (hitteeIt == std::end(view))
     {
-        spdlog::warn(__FUNCTION__ ": hittee form id component not found, form id: {:X}", acEvent.HitterId);
+        spdlog::warn("{}: hittee form id component not found, form id: {:X}", __FUNCTION__, acEvent.HitterId);
         return;
     }
 
-    if (m_world.any_of<CombatComponent>(*hitteeIt))
-        return;
-
-    m_world.emplace_or_replace<CombatComponent>(*hitteeIt, acEvent.HitterId);
-
-    pHittee->SetCombatTargetEx(pHitter);
-#endif
+    if (pHittee->GetCombatTarget() != pHitter)
+    {
+        spdlog::info("Combat target set on hit: local NPC {:X} -> player {:X}", acEvent.HitteeId, acEvent.HitterId);
+        pHittee->SetCombatTargetEx(pHitter);
+    }
 }
 
 void CombatService::RunTargetUpdates(const float acDelta) const noexcept

--- a/Code/client/Services/Generic/CombatService.cpp
+++ b/Code/client/Services/Generic/CombatService.cpp
@@ -175,12 +175,13 @@ void CombatService::OnHitEvent(const HitEvent& acEvent) const noexcept
         return;
 
     // Only point a target once the engine has the NPC in combat (don't force aggro on a stray hit).
+    // NOTE: do NOT reset EngagedFromHit on a transient !IsInCombat() here. StartCombatEx itself
+    // does StopCombat() which momentarily drops IsInCombat()+sheathes the weapon, so a one-frame
+    // !IsInCombat() after our own engage would clear the latch and re-arm the draw/sheathe loop
+    // (observed: Vampire Nightstalker un-aggroed and walked casually between player hits). The latch
+    // persists for the actor's lifetime; the engine handles genuine re-engagement on normal combat.
     if (!pHittee->IsInCombat())
-    {
-        // Left combat -> clear the retaliation latch so a later, separate fight re-triggers.
-        pHittee->GetExtension()->EngagedFromHit = false;
         return;
-    }
 
     auto view = m_world.view<FormIdComponent, LocalComponent>(entt::exclude<ObjectComponent>);
     const auto hitteeIt = std::find_if(std::begin(view), std::end(view), [id = acEvent.HitteeId, view](entt::entity entity) { return view.get<FormIdComponent>(entity).Id == id; });

--- a/Code/client/Services/Generic/CombatService.cpp
+++ b/Code/client/Services/Generic/CombatService.cpp
@@ -188,8 +188,8 @@ void CombatService::OnHitEvent(const HitEvent& acEvent) const noexcept
 
     if (pHittee->GetCombatTarget() != pHitter)
     {
-        spdlog::info("Combat target set on hit: local NPC {:X} -> player {:X}", acEvent.HitteeId, acEvent.HitterId);
-        pHittee->SetCombatTargetEx(pHitter);
+        spdlog::info("Combat started (hit): local NPC {:X} -> player {:X}", acEvent.HitteeId, acEvent.HitterId);
+        pHittee->StartCombatEx(pHitter);
     }
 }
 


### PR DESCRIPTION
Fixes tiltedphoques/TiltedEvolution#810 after testing the following: [Video of fix in action](https://youtu.be/bYt5zKzvHsw)

# Code Review Summary — `fix/issues-810`

## Problem

When a party leader leaves a cell, remote NPCs get their AI localized on another
client (`SetRemote(false)`). Two bugs followed:

1. The engine replays a burst of reset/stance actions that got spammed over the
   network, freezing the NPC so it refused to aggro.
2. Even once unfrozen, a transferred hostile NPC would follow/detect a player but
   never draw or attack — it had no valid combat target and its combat controller
   was never started.

## Net change

5 files, +151 / −15. Two independent fixes.

### 1. Anti-freeze: dedupe the post-localize action burst

- **`ActorExtension.h`** — adds `LocalizedTick` (grace-window timestamp),
  `BroadcastedUnequip` / `BroadcastedCombatStanceStop` flags, and
  `kAnimReconcileGraceTicks = 60` (~1s).
- **`Animation.cpp`** — `HookPerformAction` now performs every reset action
  **locally** (visuals stay correct) but **broadcasts each reset type only once**
  within the grace window, instead of the old spam. `IsResetAction()` filters the
  relevant events (`Unequip`, `combatStance*`, `Sheathe/Draw`, `Idle`).
- **`CharacterService.cpp`** — stamps `LocalizedTick` and resets the broadcast
  flags at each localize site.

### 2. Combat engagement after transfer

- **`CombatService.cpp` / `Actor.cpp`** — on the engine's own detection hook
  (`HookUpdateDetectionState` — the vanilla "NPC noticed you" moment), if a
  **local, non-player NPC** detects a **player (local OR remote)** and it
  **arrived hostile**, it calls `StartCombatEx(player)` to boot the combat
  controller.
- **`ActorExtension.h` / `CharacterService.cpp`** — `ArrivedHostile` is captured
  at localize from `actorState.IsWeaponDrawn()` (transferred hostiles arrive
  weapon-drawn; peaceful NPCs arrive sheathed), used as the safety gate so
  friendly-area NPCs are never force-aggro'd.

## Design decisions worth a reviewer's eye

- **"Any player" not "remote player":** the target check accepts local *or* remote
  players. After transfer the NPC localizes on the *other* machine, where the
  discovered player is the **local** player — a remote-only check would miss the
  common case.
- **Detection, not `IsInCombat()`, is the trigger:** a transferred NPC's combat
  flag is never engine-initialized, so gating on it was dead. The engine's
  detection hook is the vanilla trigger and is used instead.
- **`ArrivedHostile` may be slightly strict** — in one playtest a sheathed bandit
  still engaged, hinting the gate could be looser. Left as-is since it works;
  first thing to loosen if an idle hostile ever refuses to aggro.

## Validation

Playtested: hidden → no premature discovery; approach after localize → bandit
draws and hits correctly; no interference with other enemies.  [Video of fix in action](https://youtu.be/bYt5zKzvHsw)

Logs:
[clientremote.txt](https://github.com/user-attachments/files/30153982/clientremote.txt)
[clientleader.txt](https://github.com/user-attachments/files/30153983/clientleader.txt)


