### PR TITLE
Revert "Slow effect is player-specific, should not sync."

### DIFF
--- a/Code/client/Games/Skyrim/Magic/MagicTarget.cpp
+++ b/Code/client/Games/Skyrim/Magic/MagicTarget.cpp
@@ -68,7 +68,7 @@ bool MagicTarget::AddTargetData::IsForbiddenEffect(Actor* apTarget)
     if (apTarget != PlayerCharacter::Get())
         return false;
 
-    return pEffectItem->IsNightVisionEffect() || pEffectItem->IsSlowEffect();
+    return pEffectItem->IsNightVisionEffect();
 }
 
 Actor* MagicTarget::GetTargetAsActor()


### PR DESCRIPTION
Reverts tiltedphoques/TiltedEvolution#856

#856 (and #858 if merged) breaks the original intent behind Slow Time sync, where if one player casts the shout it applies to all nearby players