### PR TITLE
Nix: bump the flake and reduce it to a linux server dev shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732014248,
-        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "lastModified": 1788404924,
+        "narHash": "sha256-lhEhY8X5EgkQ/eg6IFz4cc8jRuSYSvnxx1al7d1dvZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "rev": "0968519e14f7aa7d3e9b389682bd74d2b51c8ce8",
         "type": "github"
       },
       "original": {
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,35 @@
 {
-  description = "Tilted C++ development environment";
+  description = "Skyrim Together Reborn linux server build environment";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            # gcc 15 rejects sol2 v3.3.0, which xmake.lua pins
             gcc14
             gdb
-            libclang
-            cmake
             xmake
+
+            # xmake builds most of its dependencies from source
+            cmake
             gnumake
+            ninja
+            pkg-config
+            perl
+            python3
+
+            # BuildInfo.h is generated from the git history
+            git
+
+            curl
+            unzip
           ];
 
           shellHook = ''
@@ -37,8 +45,10 @@
             unset CFLAGS
             unset CXXFLAGS
             unset LDFLAGS
-            echo "C++ development environment loaded"
+
+            echo "Linux server build environment loaded, run: xmake config -m releasedbg && xmake"
           '';
         };
       });
+    };
 }


### PR DESCRIPTION
The flake was pinned to nixpkgs from November 2024 and carried an unfinished
MSVC cross-compile experiment. It is now just a dev shell for building the
linux server.

- nixpkgs 2024-11-19 -> 2026-09-03
- dropped the msvc-llvm-nix and flake-utils inputs, nixpkgs is the only one left
- added the tools xmake actually needs: ninja, pkg-config, perl, python3, git, curl, unzip
- pinned gcc 14, since gcc 15 rejects the sol2 v3.3.0 we pin in xmake.lua

Tested on x86_64-linux: `nix develop`, `xmake config -m releasedbg`, `xmake`,
server boots and listens on 10578.