### PR TITLE
Fix quest progression, scene dialogue, and object lifecycle synchronization

### DIFF
--- a/Code/client/Games/Skyrim/Actor.cpp
+++ b/Code/client/Games/Skyrim/Actor.cpp
@@ -843,6 +843,18 @@ bool Actor::IsVampireLord() const noexcept
     return race && race->formID == 0x200283A;
 }
 
+bool Actor::IsInScene() const noexcept
+{
+    return (flags1 & ActorBoolBits::HAS_SCENE_EXTRA) != 0;
+}
+
+bool Actor::IsInDialogueWithPlayer() noexcept
+{
+    using ObjectReference = TESObjectREFR;
+    PAPYRUS_FUNCTION(bool, ObjectReference, IsInDialogueWithPlayer);
+    return s_pIsInDialogueWithPlayer(this);
+}
+
 extern thread_local bool g_forceAnimation;
 
 void Actor::FixVampireLordModel() noexcept

--- a/Code/client/Games/Skyrim/Actor.h
+++ b/Code/client/Games/Skyrim/Actor.h
@@ -208,6 +208,8 @@ struct Actor : TESObjectREFR
     [[nodiscard]] bool HasPerk(uint32_t aPerkFormId) const noexcept;
     [[nodiscard]] uint8_t GetPerkRank(uint32_t aPerkFormId) const noexcept;
     [[nodiscard]] bool IsVampireLord() const noexcept;
+    [[nodiscard]] bool IsInScene() const noexcept;
+    [[nodiscard]] bool IsInDialogueWithPlayer() noexcept;
 
     // Setters
     void SetSpeed(float aSpeed) noexcept;
@@ -249,6 +251,12 @@ struct Actor : TESObjectREFR
     bool PlayIdle(TESIdleForm* apIdle) noexcept;
     void FixVampireLordModel() noexcept;
     bool RemoveSpell(MagicItem* apSpell) noexcept;
+
+    // Bits of `flags1` (Actor::boolBits in CommonLibSSE).
+    enum ActorBoolBits : uint32_t
+    {
+        HAS_SCENE_EXTRA = 1 << 3,
+    };
 
     enum ActorFlags
     {

--- a/Code/client/Games/Skyrim/Forms/TESQuest.cpp
+++ b/Code/client/Games/Skyrim/Forms/TESQuest.cpp
@@ -97,7 +97,7 @@ bool TESQuest::SetStage(uint16_t newStage)
     return SetStage(this, newStage);
 }
 
-void TESQuest::ScriptSetStage(uint16_t stageIndex, boolean bForce)
+void TESQuest::ScriptSetStage(uint16_t stageIndex, bool bForce)
 {
     if ((currentStage == stageIndex || IsStageDone(stageIndex)) && !bForce)
         return;

--- a/Code/client/Games/Skyrim/Forms/TESQuest.cpp
+++ b/Code/client/Games/Skyrim/Forms/TESQuest.cpp
@@ -97,9 +97,9 @@ bool TESQuest::SetStage(uint16_t newStage)
     return SetStage(this, newStage);
 }
 
-void TESQuest::ScriptSetStage(uint16_t stageIndex)
+void TESQuest::ScriptSetStage(uint16_t stageIndex, boolean bForce)
 {
-    if (currentStage == stageIndex || IsStageDone(stageIndex))
+    if ((currentStage == stageIndex || IsStageDone(stageIndex)) && !bForce)
         return;
 
     using Quest = TESQuest;

--- a/Code/client/Games/Skyrim/Forms/TESQuest.cpp
+++ b/Code/client/Games/Skyrim/Forms/TESQuest.cpp
@@ -54,13 +54,15 @@ void TESQuest::SetActive(bool toggle)
 
 bool TESQuest::IsStageDone(uint16_t stageIndex)
 {
-    for (Stage* it : stages)
-    {
-        if (it->stageIndex == stageIndex)
-            return it->IsDone();
-    }
-
-    return false;
+    // Ask the game instead of walking `stages`: that field is really the pair of
+    // (executed stages, waiting stages) list heads (see the commented-out layout in
+    // TESQuest.h), so iterating it as a single GameList<Stage> only ever sees the
+    // first executed stage. Every other completed stage reported "not done", which
+    // let a remote stage update re-run the fragments of a stage this client had
+    // already played (scene restarts, duplicated quest side effects).
+    using Quest = TESQuest;
+    PAPYRUS_FUNCTION(bool, Quest, IsStageDone, int);
+    return s_pIsStageDone(this, stageIndex);
 }
 
 bool TESQuest::Kill()

--- a/Code/client/Games/Skyrim/Forms/TESQuest.h
+++ b/Code/client/Games/Skyrim/Forms/TESQuest.h
@@ -127,7 +127,7 @@ struct TESQuest : BGSStoryManagerTreeForm
     bool EnsureQuestStarted(bool& succeded, bool force);
 
     bool SetStage(uint16_t stage);
-    void ScriptSetStage(uint16_t stage);
+    void ScriptSetStage(uint16_t stage, boolean bForce = false);
     void SetStopped();
 };
 

--- a/Code/client/Games/Skyrim/Forms/TESQuest.h
+++ b/Code/client/Games/Skyrim/Forms/TESQuest.h
@@ -127,7 +127,7 @@ struct TESQuest : BGSStoryManagerTreeForm
     bool EnsureQuestStarted(bool& succeded, bool force);
 
     bool SetStage(uint16_t stage);
-    void ScriptSetStage(uint16_t stage, boolean bForce = false);
+    void ScriptSetStage(uint16_t stage, bool bForce = false);
     void SetStopped();
 };
 

--- a/Code/client/Services/Debug/Views/QuestDebugView.cpp
+++ b/Code/client/Services/Debug/Views/QuestDebugView.cpp
@@ -61,7 +61,7 @@ void DebugService::DrawQuestDebugView()
                     sprintf_s(setStage, std::size(setStage), "Set stage (%d)", pStage->stageIndex);
 
                     if (ImGui::Button(setStage))
-                        pQuest->ScriptSetStage(pStage->stageIndex);
+                        pQuest->ScriptSetStage(pStage->stageIndex, true);
                 }
             }
 

--- a/Code/client/Services/Generic/CharacterService.cpp
+++ b/Code/client/Services/Generic/CharacterService.cpp
@@ -1015,6 +1015,24 @@ void CharacterService::OnNotifySyncExperience(const NotifySyncExperience& acMess
     pPlayer->AddSkillExperience(PlayerCharacter::LastUsedCombatSkill, acMessage.Experience);
 }
 
+// Scenes (BGSScene) run on every client that has the owning quest at the right stage, so
+// each client already plays the lines of a scene locally, including those of actors it
+// does not own. Broadcasting the owner's copy of those lines makes the receivers call
+// StopCurrentDialogue() on their own copy of the actor mid-scene, which ends the scene's
+// dialogue action early, lets their scene phase race ahead of the owner's, and can hang
+// the scene for everyone. Lines said to the local player (dialogue menu) are not played
+// elsewhere, so those still need to be synced even inside a scene.
+static bool ShouldSyncSpeech(Actor* apActor) noexcept
+{
+    if (!apActor)
+        return false;
+
+    if (!apActor->IsInScene())
+        return true;
+
+    return apActor->IsInDialogueWithPlayer();
+}
+
 void CharacterService::OnDialogueEvent(const DialogueEvent& acEvent) noexcept
 {
     if (!m_transport.IsConnected())
@@ -1030,6 +1048,12 @@ void CharacterService::OnDialogueEvent(const DialogueEvent& acEvent) noexcept
     if (!serverIdRes)
     {
         spdlog::error("{}: server id not found for form id {:X}", __FUNCTION__, acEvent.ActorID);
+        return;
+    }
+
+    if (!ShouldSyncSpeech(Cast<Actor>(TESForm::GetById(acEvent.ActorID))))
+    {
+        spdlog::debug("{}: not syncing scene line of actor {:X}: {}", __FUNCTION__, acEvent.ActorID, acEvent.VoiceFile.c_str());
         return;
     }
 
@@ -1077,6 +1101,12 @@ void CharacterService::OnSubtitleEvent(const SubtitleEvent& acEvent) noexcept
     if (!serverIdRes)
     {
         spdlog::error("{}: server id not found for form id {:X}", __FUNCTION__, acEvent.SpeakerID);
+        return;
+    }
+
+    if (!ShouldSyncSpeech(Cast<Actor>(TESForm::GetById(acEvent.SpeakerID))))
+    {
+        spdlog::debug("{}: not syncing scene subtitle of actor {:X}: {}", __FUNCTION__, acEvent.SpeakerID, acEvent.Text.c_str());
         return;
     }
 

--- a/Code/client/Services/Generic/ObjectService.cpp
+++ b/Code/client/Services/Generic/ObjectService.cpp
@@ -1,4 +1,5 @@
 #include <Services/ObjectService.h>
+#include <Systems/ObjectSystem.h>
 
 #include <World.h>
 #include <Events/DisconnectedEvent.h>
@@ -16,6 +17,7 @@
 #include <Messages/NotifyLockChange.h>
 #include <Messages/ScriptAnimationRequest.h>
 #include <Messages/NotifyScriptAnimation.h>
+#include <Messages/NotifyRemoveObjects.h>
 
 #include <PlayerCharacter.h>
 #include <Forms/TESObjectCELL.h>
@@ -35,6 +37,7 @@ ObjectService::ObjectService(World& aWorld, entt::dispatcher& aDispatcher, Trans
     m_lockChangeConnection = aDispatcher.sink<LockChangeEvent>().connect<&ObjectService::OnLockChange>(this);
     m_lockChangeNotifyConnection = aDispatcher.sink<NotifyLockChange>().connect<&ObjectService::OnLockChangeNotify>(this);
     m_assignObjectConnection = aDispatcher.sink<AssignObjectsResponse>().connect<&ObjectService::OnAssignObjectsResponse>(this);
+    m_removeObjectsConnection = aDispatcher.sink<NotifyRemoveObjects>().connect<&ObjectService::OnRemoveObjects>(this);
     m_scriptAnimationConnection = aDispatcher.sink<ScriptAnimationEvent>().connect<&ObjectService::OnScriptAnimationEvent>(this);
     m_scriptAnimationNotifyConnection = aDispatcher.sink<NotifyScriptAnimation>().connect<&ObjectService::OnNotifyScriptAnimation>(this);
 
@@ -78,7 +81,7 @@ bool ShouldSyncObject(const TESObjectREFR* apObject) noexcept
 
 void ObjectService::OnDisconnected(const DisconnectedEvent&) noexcept
 {
-    // TODO(cosideci): clear object components
+    ObjectSystem::Clear(m_world);
 }
 
 void ObjectService::OnCellChange(const CellChangeEvent& acEvent) noexcept
@@ -196,22 +199,16 @@ void ObjectService::OnAssignObjectsResponse(const AssignObjectsResponse& acMessa
     }
 }
 
+void ObjectService::OnRemoveObjects(const NotifyRemoveObjects& acMessage) noexcept
+{
+    // Only remove ECS bindings; the corresponding Skyrim references still exist.
+    ObjectSystem::Remove(m_world, acMessage.ServerIds);
+}
+
 entt::entity ObjectService::CreateObjectEntity(const uint32_t acFormId, const uint32_t acServerId) noexcept
 {
-    const auto view = m_world.view<FormIdComponent, ObjectComponent>();
-
-    auto it = std::find_if(view.begin(), view.end(), [acServerId, view](entt::entity entity) { return view.get<ObjectComponent>(entity).Id == acServerId; });
-
-    if (it != view.end())
-        return *it;
-
-    entt::entity entity = m_world.create();
-    spdlog::info("Created object entity, server id: {:X}, form id {:X}", acServerId, acFormId);
-
-    m_world.emplace<FormIdComponent>(entity, acFormId);
-    m_world.emplace<ObjectComponent>(entity, acServerId);
-
-    return entity;
+    spdlog::debug("Assigning object form id {:X} to server id {:X}", acFormId, acServerId);
+    return ObjectSystem::Setup(m_world, acFormId, acServerId);
 }
 
 void ObjectService::OnActivate(const ActivateEvent& acEvent) noexcept

--- a/Code/client/Services/Generic/QuestService.cpp
+++ b/Code/client/Services/Generic/QuestService.cpp
@@ -57,7 +57,7 @@ BSTEventResult QuestService::OnEvent(const TESQuestStartStopEvent* apEvent, cons
     if (ScopedQuestOverride::IsOverriden() || !m_world.Get().GetPartyService().IsInParty())
         return BSTEventResult::kOk;
 
-    spdlog::info("Quest start/stop event: {:X}", apEvent->formId);
+    spdlog::info(__FUNCTION__ ": quest start/stop event formId: {:X}", apEvent->formId);
 
     if (TESQuest* pQuest = Cast<TESQuest>(TESForm::GetById(apEvent->formId)))
     {
@@ -105,7 +105,7 @@ BSTEventResult QuestService::OnEvent(const TESQuestStageEvent* apEvent, const Ev
     if (ScopedQuestOverride::IsOverriden() || !m_world.Get().GetPartyService().IsInParty())
         return BSTEventResult::kOk;
 
-    spdlog::info("Quest stage event: {:X}, stage: {}", apEvent->formId, apEvent->stageId);
+    spdlog::info(__FUNCTION__ ": quest stage formId: {:X}, stage: {}", apEvent->formId, apEvent->stageId);
 
     // there is no reason to even fetch the quest object, since the event provides everything already....
     if (TESQuest* pQuest = Cast<TESQuest>(TESForm::GetById(apEvent->formId)))
@@ -157,13 +157,13 @@ void QuestService::OnQuestUpdate(const NotifyQuestUpdate& aUpdate) noexcept
     TESQuest* pQuest = Cast<TESQuest>(TESForm::GetById(formId));
     if (!pQuest)
     {
-        spdlog::error("Failed to find quest, base id: {:X}, mod id: {:X}", aUpdate.Id.BaseId, aUpdate.Id.ModId);
+        spdlog::error(__FUNCTION__ ": failed to find quest, gameId: {:X}, stage: {}", aUpdate.Id.LogFormat(), aUpdate.Stage);
         return;
     }
 
     if (pQuest->type == TESQuest::Type::None || pQuest->type == TESQuest::Type::Miscellaneous)
     {
-        spdlog::info(__FUNCTION__ ": receiving type none/misc quest update gameId {:X} questStage {} questStatus {} questType {} formId {:X} name {}",
+        spdlog::info(__FUNCTION__ ": receiving type none/misc quest update gameId: {:X}, questStage: {}, questStatus: {}, questType: {}, formId: {:X}, name: {}",
                      aUpdate.Id.LogFormat(), aUpdate.Stage, aUpdate.Status,
                      aUpdate.ClientQuestType, formId, pQuest->fullName.value.AsAscii());
     }
@@ -172,27 +172,46 @@ void QuestService::OnQuestUpdate(const NotifyQuestUpdate& aUpdate) noexcept
     switch (aUpdate.Status)
     {
     case NotifyQuestUpdate::Started:
-    {
-        pQuest->ScriptSetStage(aUpdate.Stage);
-        pQuest->SetActive(true);
+        if (pQuest->getState() == TESQuest::State::Running) // Supress duplicate or loopback quest starts
+        {
+            spdlog::info(__FUNCTION__ ": suppressing duplicate quest start gameId: {:X}, questStage: {}, questStatus: {}, questType: {}, formId: {:X}, name: {}",
+                         aUpdate.Id.LogFormat(), aUpdate.Stage, aUpdate.Status, aUpdate.ClientQuestType, formId, pQuest->fullName.value.AsAscii());
+        }
+        else
+        {
+            pQuest->ScriptSetStage(aUpdate.Stage);
+            pQuest->SetActive(true);
+            spdlog::info(__FUNCTION__ ": remote quest started gameId: {:X}, questStage: {}, questStatus: {}, questType: {}, formId: {:X}, name: {}",
+                         aUpdate.Id.LogFormat(), aUpdate.Stage, aUpdate.Status, aUpdate.ClientQuestType, formId, pQuest->fullName.value.AsAscii());
+        }
         bResult = true;
-        spdlog::info("Remote quest started: {:X}, stage: {}", formId, aUpdate.Stage);
         break;
-    }
     case NotifyQuestUpdate::StageUpdate:
         pQuest->ScriptSetStage(aUpdate.Stage);
         bResult = true;
-        spdlog::info("Remote quest updated: {:X}, stage: {}", formId, aUpdate.Stage);
+        spdlog::info(__FUNCTION__ ": remote quest updated gameId: {:X}, questStage: {}, questStatus: {}, questType: {}, formId: {:X}, name: {}",
+                     aUpdate.Id.LogFormat(), aUpdate.Stage, aUpdate.Status, aUpdate.ClientQuestType, formId, pQuest->fullName.value.AsAscii());
         break;
     case NotifyQuestUpdate::Stopped:
-        bResult = StopQuest(formId);
-        spdlog::info("Remote quest stopped: {:X}, stage: {}", formId, aUpdate.Stage);
+        if (pQuest->getState() == TESQuest::State::Stopped) // Supress duplicate or loopback quest stop
+        {
+            spdlog::info(__FUNCTION__ ": suppressing duplicate quest stop gameId: {:X}, questStage: {}, questStatus: {}, questType: {}, formId: {:X}, name: {}",
+                         aUpdate.Id.LogFormat(), aUpdate.Stage, aUpdate.Status, aUpdate.ClientQuestType, formId, pQuest->fullName.value.AsAscii());
+        }
+        else
+        {
+            bResult = StopQuest(formId);
+            spdlog::info(__FUNCTION__ ": remote quest stopped gameId: {:X}, questStage: {}, questStatus: {}, questType: {}, formId: {:X}, name: {}",
+                         aUpdate.Id.LogFormat(), aUpdate.Stage, aUpdate.Status, aUpdate.ClientQuestType, formId, pQuest->fullName.value.AsAscii());
+        }
+        bResult = true;
         break;
     default: break;
     }
 
     if (!bResult)
-        spdlog::error("Failed to update the client quest state, quest: {:X}, stage: {}, status: {}", formId, aUpdate.Stage, aUpdate.Status);
+        spdlog::error(__FUNCTION__ ": failed to update the client quest state gameId: {:X}, questStage: {}, questStatus: {}, questType: {}, formId: {:X}, name: {}",
+                      aUpdate.Id.LogFormat(), aUpdate.Stage, aUpdate.Status, aUpdate.ClientQuestType, formId, pQuest->fullName.value.AsAscii());
 }
 
 bool QuestService::StopQuest(uint32_t aformId)
@@ -200,8 +219,17 @@ bool QuestService::StopQuest(uint32_t aformId)
     TESQuest* pQuest = Cast<TESQuest>(TESForm::GetById(aformId));
     if (pQuest)
     {
-        pQuest->SetActive(false);
-        pQuest->SetStopped();
+        if (pQuest->getState() == TESQuest::State::Stopped) // Supress duplicate or loopback quest stop
+        {
+            spdlog::info(__FUNCTION__ ": suppressing duplicate quest stop formId: {:X}, questStage: {}, questFlags: {:X}, questType: {}, formId: {:X}, name: {}",
+                         aformId, pQuest->currentStage, static_cast<uint8_t>(pQuest->flags), static_cast<uint16_t>(pQuest->type), aformId, pQuest->fullName.value.AsAscii());
+        }
+        else
+        {
+            pQuest->SetActive(false);
+            pQuest->SetStopped();
+        }
+
         return true;
     }
 

--- a/Code/client/Services/ObjectService.h
+++ b/Code/client/Services/ObjectService.h
@@ -15,6 +15,7 @@ struct CellChangeEvent;
 struct ScriptAnimationEvent;
 struct AssignObjectsResponse;
 struct NotifyScriptAnimation;
+struct NotifyRemoveObjects;
 
 /**
  * @brief Handles objects in the environment.
@@ -28,6 +29,7 @@ private:
     void OnDisconnected(const DisconnectedEvent&) noexcept;
     void OnCellChange(const CellChangeEvent&) noexcept;
     void OnAssignObjectsResponse(const AssignObjectsResponse&) noexcept;
+    void OnRemoveObjects(const NotifyRemoveObjects&) noexcept;
     void OnActivate(const ActivateEvent&) noexcept;
     void OnActivateNotify(const NotifyActivate&) noexcept;
     void OnLockChange(const LockChangeEvent&) noexcept;
@@ -49,6 +51,7 @@ private:
     entt::scoped_connection m_lockChangeConnection;
     entt::scoped_connection m_lockChangeNotifyConnection;
     entt::scoped_connection m_assignObjectConnection;
+    entt::scoped_connection m_removeObjectsConnection;
     entt::scoped_connection m_scriptAnimationConnection;
     entt::scoped_connection m_scriptAnimationNotifyConnection;
 };

--- a/Code/client/Systems/ObjectSystem.cpp
+++ b/Code/client/Systems/ObjectSystem.cpp
@@ -1,0 +1,71 @@
+#include <TiltedCore/Stl.hpp>
+#include <TiltedCore/Buffer.hpp>
+#include <TiltedCore/Serialization.hpp>
+#include <TiltedCore/Outcome.hpp>
+#include <glm/glm.hpp>
+#include <entt/entt.hpp>
+#include <optional>
+
+using TiltedPhoques::List;
+using TiltedPhoques::Outcome;
+using TiltedPhoques::Set;
+using TiltedPhoques::Vector;
+
+#include <Components.h>
+#include <Systems/ObjectSystem.h>
+
+entt::entity ObjectSystem::Setup(entt::registry& aRegistry, const uint32_t aFormId, const uint32_t aServerId) noexcept
+{
+    const auto view = aRegistry.view<FormIdComponent, ObjectComponent>();
+    entt::entity existingEntity = entt::null;
+    Vector<entt::entity> staleEntities;
+
+    for (const auto entity : view)
+    {
+        const auto& formIdComponent = view.get<FormIdComponent>(entity);
+        const auto& objectComponent = view.get<ObjectComponent>(entity);
+
+        if (formIdComponent.Id == aFormId && existingEntity == entt::null)
+            existingEntity = entity;
+        else if (formIdComponent.Id == aFormId || objectComponent.Id == aServerId)
+            staleEntities.push_back(entity);
+    }
+
+    for (const auto entity : staleEntities)
+        aRegistry.destroy(entity);
+
+    if (existingEntity != entt::null)
+    {
+        aRegistry.get<ObjectComponent>(existingEntity).Id = aServerId;
+        return existingEntity;
+    }
+
+    const entt::entity entity = aRegistry.create();
+    aRegistry.emplace<FormIdComponent>(entity, aFormId);
+    aRegistry.emplace<ObjectComponent>(entity, aServerId);
+    return entity;
+}
+
+void ObjectSystem::Remove(entt::registry& aRegistry, const std::span<const uint32_t> aServerIds) noexcept
+{
+    const Set<uint32_t> serverIds(aServerIds.begin(), aServerIds.end());
+    const auto view = aRegistry.view<ObjectComponent>();
+    Vector<entt::entity> entities;
+
+    for (const auto entity : view)
+    {
+        if (serverIds.count(view.get<ObjectComponent>(entity).Id))
+            entities.push_back(entity);
+    }
+
+    for (const auto entity : entities)
+        aRegistry.destroy(entity);
+}
+
+void ObjectSystem::Clear(entt::registry& aRegistry) noexcept
+{
+    const auto view = aRegistry.view<ObjectComponent>();
+    const Vector<entt::entity> entities(view.begin(), view.end());
+    for (const auto entity : entities)
+        aRegistry.destroy(entity);
+}

--- a/Code/client/Systems/ObjectSystem.h
+++ b/Code/client/Systems/ObjectSystem.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <entt/fwd.hpp>
+
+/**
+ * @brief Manages object replication bindings without changing game references.
+ */
+struct ObjectSystem
+{
+    static entt::entity Setup(entt::registry& aRegistry, uint32_t aFormId, uint32_t aServerId) noexcept;
+    static void Remove(entt::registry& aRegistry, std::span<const uint32_t> aServerIds) noexcept;
+    static void Clear(entt::registry& aRegistry) noexcept;
+};

--- a/Code/encoding/Messages/NotifyRemoveObjects.cpp
+++ b/Code/encoding/Messages/NotifyRemoveObjects.cpp
@@ -1,0 +1,18 @@
+#include <Messages/NotifyRemoveObjects.h>
+
+void NotifyRemoveObjects::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept
+{
+    Serialization::WriteVarInt(aWriter, ServerIds.size());
+    for (const uint32_t serverId : ServerIds)
+        Serialization::WriteVarInt(aWriter, serverId);
+}
+
+void NotifyRemoveObjects::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
+{
+    ServerMessage::DeserializeRaw(aReader);
+
+    const auto count = Serialization::ReadVarInt(aReader);
+    ServerIds.resize(count);
+    for (auto& serverId : ServerIds)
+        serverId = Serialization::ReadVarInt(aReader) & 0xFFFFFFFF;
+}

--- a/Code/encoding/Messages/NotifyRemoveObjects.h
+++ b/Code/encoding/Messages/NotifyRemoveObjects.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Message.h"
+
+struct NotifyRemoveObjects final : ServerMessage
+{
+    static constexpr ServerOpcode Opcode = kNotifyRemoveObjects;
+
+    NotifyRemoveObjects()
+        : ServerMessage(Opcode)
+    {
+    }
+
+    void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
+    void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
+
+    bool operator==(const NotifyRemoveObjects& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && ServerIds == acRhs.ServerIds; }
+
+    TiltedPhoques::Vector<uint32_t> ServerIds{};
+};

--- a/Code/encoding/Messages/ServerMessageFactory.h
+++ b/Code/encoding/Messages/ServerMessageFactory.h
@@ -58,6 +58,7 @@
 #include <Messages/NotifySetWaypoint.h>
 #include <Messages/NotifyRemoveWaypoint.h>
 #include <Messages/NotifySetTimeResult.h>
+#include <Messages/NotifyRemoveObjects.h>
 
 using TiltedPhoques::UniquePtr;
 
@@ -68,11 +69,14 @@ struct ServerMessageFactory
     template <class T> static auto Visit(T&& func)
     {
         auto s_visitor = CreateMessageVisitor<
-            AuthenticationResponse, AssignCharacterResponse, ServerReferencesMoveRequest, ServerTimeSettings, CharacterSpawnRequest, NotifyInventoryChanges, StringCacheUpdate, NotifyFactionsChanges, NotifyRemoveCharacter, NotifyQuestUpdate, NotifyPlayerList, NotifyPartyInfo, NotifyPartyInvite,
-            NotifyActorValueChanges, NotifyPartyJoined, NotifyPartyLeft, NotifyActorMaxValueChanges, NotifyHealthChangeBroadcast, NotifyActivate, NotifyLockChange, AssignObjectsResponse, NotifyDeathStateChange, NotifyOwnershipTransfer, NotifyObjectInventoryChanges, NotifySpellCast,
-            NotifyProjectileLaunch, NotifyInterruptCast, NotifyAddTarget, NotifyScriptAnimation, NotifyDrawWeapon, NotifyMount, NotifyNewPackage, NotifyRespawn, NotifySyncExperience, NotifyEquipmentChanges, NotifyChatMessageBroadcast, TeleportCommandResponse, NotifyPlayerRespawn, NotifyDialogue,
-            NotifySubtitle, NotifyPlayerDialogue, NotifyActorTeleport, NotifyPlayerLeft, NotifyPlayerJoined, NotifyDialogue, NotifySubtitle, NotifyPlayerDialogue, NotifyPlayerLevel, NotifyPlayerCellChanged, NotifyTeleport, NotifyPlayerHealthUpdate, NotifySettingsChange,
-            NotifyWeatherChange, NotifySetWaypoint, NotifyRemoveWaypoint, NotifySetTimeResult, NotifyRemoveSpell>;
+            AuthenticationResponse, AssignCharacterResponse, ServerReferencesMoveRequest, ServerTimeSettings, CharacterSpawnRequest, NotifyInventoryChanges, StringCacheUpdate,
+            NotifyFactionsChanges, NotifyRemoveCharacter, NotifyQuestUpdate, NotifyPlayerList, NotifyPartyInfo, NotifyPartyInvite, NotifyActorValueChanges, NotifyPartyJoined,
+            NotifyPartyLeft, NotifyActorMaxValueChanges, NotifyHealthChangeBroadcast, NotifyActivate, NotifyLockChange, AssignObjectsResponse, NotifyDeathStateChange,
+            NotifyOwnershipTransfer, NotifyObjectInventoryChanges, NotifySpellCast, NotifyProjectileLaunch, NotifyInterruptCast, NotifyAddTarget, NotifyScriptAnimation,
+            NotifyDrawWeapon, NotifyMount, NotifyNewPackage, NotifyRespawn, NotifySyncExperience, NotifyEquipmentChanges, NotifyChatMessageBroadcast, TeleportCommandResponse,
+            NotifyPlayerRespawn, NotifyDialogue, NotifySubtitle, NotifyPlayerDialogue, NotifyActorTeleport, NotifyPlayerLeft, NotifyPlayerJoined, NotifyDialogue, NotifySubtitle,
+            NotifyPlayerDialogue, NotifyPlayerLevel, NotifyPlayerCellChanged, NotifyTeleport, NotifyPlayerHealthUpdate, NotifySettingsChange, NotifyWeatherChange,
+            NotifySetWaypoint, NotifyRemoveWaypoint, NotifySetTimeResult, NotifyRemoveSpell, NotifyRemoveObjects>;
 
         return s_visitor(std::forward<T>(func));
     }

--- a/Code/encoding/Opcodes.h
+++ b/Code/encoding/Opcodes.h
@@ -112,5 +112,6 @@ enum ServerOpcode : unsigned char
     kNotifySetWaypoint,
     kNotifyRemoveWaypoint,
     kNotifySetTimeResult,
+    kNotifyRemoveObjects,
     kServerOpcodeMax
 };

--- a/Code/immersive_launcher/loader/MemoryLayout.cpp
+++ b/Code/immersive_launcher/loader/MemoryLayout.cpp
@@ -32,7 +32,10 @@ namespace
 {
 extern "C" const IMAGE_DOS_HEADER __ImageBase;
 
-constinit const uint8_t* pBasePtr = reinterpret_cast<const uint8_t*>(&__ImageBase);
+// Not `constinit`: MSVC 14.51+ (VS 18) rejects a reinterpret_cast of &__ImageBase as a constant
+// initializer (C2127). The linker still resolves it as an ADDR64 relocation to __ImageBase with no
+// dynamic initializer, so behaviour is unchanged for older toolsets.
+const uint8_t* pBasePtr = reinterpret_cast<const uint8_t*>(&__ImageBase);
 const uint8_t* kpImageEnd{pBasePtr + ((PIMAGE_NT_HEADERS)(pBasePtr + __ImageBase.e_lfanew))->OptionalHeader.SizeOfImage};
 
 bool InRange(const uint8_t* apObj, const uint8_t* apLo, const uint8_t* apHi)

--- a/Code/server/Services/ObjectLifecycle.cpp
+++ b/Code/server/Services/ObjectLifecycle.cpp
@@ -1,0 +1,36 @@
+#include <Services/ObjectLifecycle.h>
+
+#include <Components.h>
+#include <Messages/NotifyRemoveObjects.h>
+
+#include <algorithm>
+
+namespace ObjectLifecycle
+{
+void RetireCell(entt::registry& aRegistry, const GameId& acCell, std::span<const GameId> aPlayerCells, const SendRemoval& aSendRemoval) noexcept
+{
+    // Preserve the existing policy: occupied current cells are retained.
+    // Tracking all loaded exterior cells remains a separate concern.
+    if (std::find(aPlayerCells.begin(), aPlayerCells.end(), acCell) != aPlayerCells.end())
+        return;
+
+    const auto objectView = aRegistry.view<ObjectComponent, CellIdComponent>();
+    Vector<entt::entity> toDestroy;
+    NotifyRemoveObjects notify{};
+
+    for (const auto entity : objectView)
+    {
+        if (objectView.get<CellIdComponent>(entity).Cell != acCell)
+            continue;
+
+        toDestroy.push_back(entity);
+        notify.ServerIds.push_back(entt::to_integral(entity));
+    }
+
+    if (!notify.ServerIds.empty())
+        aSendRemoval(notify);
+
+    for (const auto entity : toDestroy)
+        aRegistry.destroy(entity);
+}
+} // namespace ObjectLifecycle

--- a/Code/server/Services/ObjectLifecycle.h
+++ b/Code/server/Services/ObjectLifecycle.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <entt/entity/registry.hpp>
+#include <functional>
+#include <span>
+
+struct GameId;
+struct NotifyRemoveObjects;
+
+namespace ObjectLifecycle
+{
+using SendRemoval = std::function<void(const NotifyRemoveObjects&)>;
+
+// aPlayerCells contains the players' current cells after the departure.
+// aSendRemoval must broadcast synchronously before entity identifiers can be reused.
+void RetireCell(entt::registry& aRegistry, const GameId& acCell, std::span<const GameId> aPlayerCells, const SendRemoval& aSendRemoval) noexcept;
+} // namespace ObjectLifecycle

--- a/Code/server/Services/ObjectService.cpp
+++ b/Code/server/Services/ObjectService.cpp
@@ -1,4 +1,5 @@
 #include <Services/ObjectService.h>
+#include <Services/ObjectLifecycle.h>
 
 #include <GameServer.h>
 #include <World.h>
@@ -26,39 +27,16 @@ ObjectService::ObjectService(World& aWorld, entt::dispatcher& aDispatcher)
     m_scriptAnimationConnection = aDispatcher.sink<PacketEvent<ScriptAnimationRequest>>().connect<&ObjectService::OnScriptAnimationRequest>(this);
 }
 
-// TODO: Account for loaded exterior grids, not only players' current cells.
 void ObjectService::OnPlayerLeaveCellEvent(const PlayerLeaveCellEvent& acEvent) noexcept
 {
+    Vector<GameId> playerCells;
+    playerCells.reserve(m_world.GetPlayerManager().Count());
     for (Player* pPlayer : m_world.GetPlayerManager())
-    {
-        if (pPlayer->GetCellComponent().Cell == acEvent.OldCell)
-            return;
-    }
-
-    auto objectView = m_world.view<ObjectComponent, CellIdComponent>();
-    Vector<entt::entity> toDestroy;
-    NotifyRemoveObjects notify{};
-
-    for (auto entity : objectView)
-    {
-        const auto& cellIdComponent = objectView.get<CellIdComponent>(entity);
-
-        if (cellIdComponent.Cell != acEvent.OldCell)
-            continue;
-
-        toDestroy.push_back(entity);
-        notify.ServerIds.push_back(World::ToInteger(entity));
-    }
+        playerCells.push_back(pPlayer->GetCellComponent().Cell);
 
     // Clients retain object bindings after leaving a cell. Retire those bindings
     // everywhere before the server entity identifiers can be reused.
-    if (!notify.ServerIds.empty())
-        GameServer::Get()->SendToPlayers(notify);
-
-    for (auto& entity : toDestroy)
-    {
-        m_world.destroy(entity);
-    }
+    ObjectLifecycle::RetireCell(m_world, acEvent.OldCell, playerCells, [](const NotifyRemoveObjects& acNotify) { GameServer::Get()->SendToPlayers(acNotify); });
 }
 
 // NOTE: this whole system kinda relies on all objects in a cell being static.

--- a/Code/server/Services/ObjectService.cpp
+++ b/Code/server/Services/ObjectService.cpp
@@ -14,6 +14,7 @@
 #include <Messages/AssignObjectsResponse.h>
 #include <Messages/ScriptAnimationRequest.h>
 #include <Messages/NotifyScriptAnimation.h>
+#include <Messages/NotifyRemoveObjects.h>
 
 ObjectService::ObjectService(World& aWorld, entt::dispatcher& aDispatcher)
     : m_world(aWorld)
@@ -25,9 +26,7 @@ ObjectService::ObjectService(World& aWorld, entt::dispatcher& aDispatcher)
     m_scriptAnimationConnection = aDispatcher.sink<PacketEvent<ScriptAnimationRequest>>().connect<&ObjectService::OnScriptAnimationRequest>(this);
 }
 
-// TODO(cosideci): the cell handling of objects need to be revamped.
-// We already store the location and worldspace of the mod through CellIdComponent.
-// Clients need a message saying the entity was destroyed.
+// TODO: Account for loaded exterior grids, not only players' current cells.
 void ObjectService::OnPlayerLeaveCellEvent(const PlayerLeaveCellEvent& acEvent) noexcept
 {
     for (Player* pPlayer : m_world.GetPlayerManager())
@@ -38,6 +37,7 @@ void ObjectService::OnPlayerLeaveCellEvent(const PlayerLeaveCellEvent& acEvent) 
 
     auto objectView = m_world.view<ObjectComponent, CellIdComponent>();
     Vector<entt::entity> toDestroy;
+    NotifyRemoveObjects notify{};
 
     for (auto entity : objectView)
     {
@@ -47,7 +47,13 @@ void ObjectService::OnPlayerLeaveCellEvent(const PlayerLeaveCellEvent& acEvent) 
             continue;
 
         toDestroy.push_back(entity);
+        notify.ServerIds.push_back(World::ToInteger(entity));
     }
+
+    // Clients retain object bindings after leaving a cell. Retire those bindings
+    // everywhere before the server entity identifiers can be reused.
+    if (!notify.ServerIds.empty())
+        GameServer::Get()->SendToPlayers(notify);
 
     for (auto& entity : toDestroy)
     {

--- a/Code/server/Services/QuestService.cpp
+++ b/Code/server/Services/QuestService.cpp
@@ -41,7 +41,7 @@ void QuestService::OnQuestChanges(const PacketEvent<RequestQuestUpdate>& acMessa
     {
         if (!bEnableMiscQuestSync)
             return;
-        spdlog::info("{}: syncing type none/misc quest to party, gameId {:X} questStage {} questStatus {} questType {}",
+        spdlog::info("{}: syncing type none/misc quest to party, gameId: {:X}, questStage: {}, questStatus: {}; questType: {}",
                      __FUNCTION__, notify.Id.LogFormat(), notify.Stage, notify.Status, notify.ClientQuestType);
     }
 
@@ -58,7 +58,7 @@ void QuestService::OnQuestChanges(const PacketEvent<RequestQuestUpdate>& acMessa
 
             if (message.Status == RequestQuestUpdate::Started)
             {
-                spdlog::debug("Started quest: {:X} stage: {}", message.Id.LogFormat(), message.Stage);
+                spdlog::info("{}: started quest: {:X}, stage: {}", __FUNCTION__, message.Id.LogFormat(), message.Stage);
 
                 notify.Status = NotifyQuestUpdate::Started;
             }
@@ -69,7 +69,7 @@ void QuestService::OnQuestChanges(const PacketEvent<RequestQuestUpdate>& acMessa
         }
         else
         {
-            spdlog::debug("Updated quest: {:X}, stage: {}", message.Id.LogFormat(), message.Id.BaseId, message.Stage);
+            spdlog::info("{}: updated quest: {:X}, stage: {}", __FUNCTION__, message.Id.LogFormat(), message.Stage);
 
             auto& record = *questIt;
             record.Id = message.Id;
@@ -80,12 +80,12 @@ void QuestService::OnQuestChanges(const PacketEvent<RequestQuestUpdate>& acMessa
     }
     else if (message.Status == RequestQuestUpdate::Stopped)
     {
-        spdlog::debug("Stopped quest: {:X}, stage: {}", message.Id.LogFormat(), message.Id.BaseId, message.Stage);
+        spdlog::info("{}: stopped quest: {:X}, stage: {}", __FUNCTION__, message.Id.LogFormat(), message.Stage);
 
         if (questIt != entries.end())
             entries.erase(questIt);
         else
-            spdlog::warn("Unable to delete quest object {:X}", message.Id.LogFormat(), message.Id.BaseId);
+            spdlog::warn("{}: unable to delete quest object {:X}", __FUNCTION__, message.Id.LogFormat());
 
         notify.Status = NotifyQuestUpdate::Stopped;
     }

--- a/Code/server/Services/QuestService.cpp
+++ b/Code/server/Services/QuestService.cpp
@@ -11,6 +11,8 @@
 namespace
 {
 Console::Setting bEnableMiscQuestSync{"Gameplay:bEnableMiscQuestSync", "(Experimental) Syncs miscellaneous quests when possible", false};
+Console::Setting bPartyMembersCanStopQuests{
+    "Gameplay:bPartyMembersCanStopQuests", "Whether quest stop events from party members (non-leaders) are forwarded to the rest of the party", false};
 
 }
 
@@ -93,6 +95,18 @@ void QuestService::OnQuestChanges(const PacketEvent<RequestQuestUpdate>& acMessa
     const auto& partyComponent = acMessage.pPlayer->GetParty();
     if (!partyComponent.JoinedPartyId.has_value())
         return;
+
+    // A quest normally ends on every client through the synced stage that completes it,
+    // so a stop event from a member carries no new information in the common case.
+    // When it does (a member's local scripts decided the quest failed, e.g. misjudging
+    // the outcome of a brawl in "Trouble in Whiterun"), forwarding it would stop the
+    // leader's copy of the quest and corrupt the party's progress. Keep the member's
+    // own quest log up to date (done above), but don't broadcast the stop.
+    if (message.Status == RequestQuestUpdate::Stopped && !bPartyMembersCanStopQuests && !m_world.GetPartyService().IsPlayerLeader(pPlayer))
+    {
+        spdlog::info("{}: not forwarding quest stop from party member {:X}, quest: {:X}, stage: {}", __FUNCTION__, pPlayer->GetId(), message.Id.LogFormat(), message.Stage);
+        return;
+    }
 
     GameServer::Get()->SendToParty(notify, partyComponent, acMessage.GetSender());
 }

--- a/Code/tests/object_encoding.cpp
+++ b/Code/tests/object_encoding.cpp
@@ -1,0 +1,47 @@
+#include <TiltedCore/Stl.hpp>
+#include <TiltedCore/Allocator.hpp>
+#include <TiltedCore/Buffer.hpp>
+#include <TiltedCore/Serialization.hpp>
+#include <optional>
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <Messages/NotifyRemoveObjects.h>
+#include <Messages/ServerMessageFactory.h>
+
+using namespace TiltedPhoques;
+
+TEST_CASE("Object removal notifications preserve server entity identifiers", "[encoding.objects]")
+{
+    NotifyRemoveObjects sent;
+
+    SECTION("Empty notification")
+    {
+    }
+
+    SECTION("Entity indices and generation bits")
+    {
+        sent.ServerIds = {0, 1, 0x100000, 0xABC12345, 0xFFFFFFFE};
+    }
+
+    SECTION("A cell containing many objects")
+    {
+        for (uint32_t i = 0; i < 1024; ++i)
+            sent.ServerIds.push_back(0xABC00000 + i);
+    }
+
+    Buffer buffer(16384);
+    Buffer::Writer writer(&buffer);
+    sent.Serialize(writer);
+
+    Buffer::Reader reader(&buffer);
+    const ServerMessageFactory factory;
+    auto message = factory.Extract(reader);
+
+    REQUIRE(message);
+    REQUIRE(message->GetOpcode() == NotifyRemoveObjects::Opcode);
+    auto received = CastUnique<NotifyRemoveObjects>(std::move(message));
+    REQUIRE(*received == sent);
+}

--- a/Code/tests/object_lifecycle.cpp
+++ b/Code/tests/object_lifecycle.cpp
@@ -1,0 +1,103 @@
+#include <TiltedCore/Stl.hpp>
+#include <TiltedCore/Buffer.hpp>
+#include <TiltedCore/Serialization.hpp>
+#include <TiltedCore/Outcome.hpp>
+#include <glm/glm.hpp>
+#include <entt/entt.hpp>
+#include <catch2/catch.hpp>
+#include <array>
+#include <optional>
+
+using TiltedPhoques::List;
+using TiltedPhoques::Outcome;
+using TiltedPhoques::Vector;
+
+#include <Components.h>
+#include <Systems/ObjectSystem.h>
+
+TEST_CASE("Object bindings follow reassignment without duplicating forms", "[objects]")
+{
+    entt::registry registry;
+    const auto object = ObjectSystem::Setup(registry, 0x1234, 17);
+
+    SECTION("Repeated assignment keeps the same entity")
+    {
+        REQUIRE(ObjectSystem::Setup(registry, 0x1234, 17) == object);
+        REQUIRE(registry.view<ObjectComponent>().size() == 1);
+    }
+
+    SECTION("Returning to a retired cell changes the server id")
+    {
+        REQUIRE(ObjectSystem::Setup(registry, 0x1234, 0x100011) == object);
+        REQUIRE(registry.get<ObjectComponent>(object).Id == 0x100011);
+        REQUIRE(registry.view<ObjectComponent>().size() == 1);
+
+        // A late or duplicate removal of the old incarnation must not erase the new one.
+        ObjectSystem::Remove(registry, std::array<uint32_t, 1>{17});
+        REQUIRE(registry.valid(object));
+        REQUIRE(registry.get<ObjectComponent>(object).Id == 0x100011);
+    }
+
+    SECTION("A server id reused for another form retires the previous binding")
+    {
+        const auto replacement = ObjectSystem::Setup(registry, 0x5678, 17);
+        REQUIRE_FALSE(registry.valid(object));
+        REQUIRE(registry.get<FormIdComponent>(replacement).Id == 0x5678);
+        REQUIRE(registry.view<ObjectComponent>().size() == 1);
+    }
+
+    SECTION("Legacy duplicates are collapsed on reassignment")
+    {
+        const auto duplicate = registry.create();
+        registry.emplace<FormIdComponent>(duplicate, 0x1234u);
+        registry.emplace<ObjectComponent>(duplicate, 99);
+
+        const auto assigned = ObjectSystem::Setup(registry, 0x1234, 42);
+        REQUIRE(registry.valid(assigned));
+        REQUIRE(registry.get<ObjectComponent>(assigned).Id == 42);
+        REQUIRE(registry.view<ObjectComponent>().size() == 1);
+    }
+}
+
+TEST_CASE("Object removal preserves unrelated entities and tolerates repeated messages", "[objects]")
+{
+    entt::registry registry;
+    const auto first = ObjectSystem::Setup(registry, 0x1234, 17);
+    const auto second = ObjectSystem::Setup(registry, 0x5678, 18);
+    const auto actor = registry.create();
+    registry.emplace<FormIdComponent>(actor, 0x14u);
+    registry.emplace<PlayerComponent>(actor, 17);
+
+    ObjectSystem::Remove(registry, std::array<uint32_t, 3>{17, 17, 999});
+    REQUIRE_FALSE(registry.valid(first));
+    REQUIRE(registry.valid(second));
+    REQUIRE(registry.valid(actor));
+    REQUIRE(registry.view<ObjectComponent>().size() == 1);
+
+    ObjectSystem::Remove(registry, std::array<uint32_t, 1>{17});
+    ObjectSystem::Remove(registry, {});
+    REQUIRE(registry.valid(second));
+    REQUIRE(registry.valid(actor));
+}
+
+TEST_CASE("Disconnect clears both sides of object bindings before reconnect", "[objects]")
+{
+    entt::registry registry;
+    const auto first = ObjectSystem::Setup(registry, 0x1234, 17);
+    const auto second = ObjectSystem::Setup(registry, 0x5678, 18);
+    const auto actor = registry.create();
+    registry.emplace<FormIdComponent>(actor, 0x14u);
+
+    ObjectSystem::Clear(registry);
+    REQUIRE_FALSE(registry.valid(first));
+    REQUIRE_FALSE(registry.valid(second));
+    REQUIRE(registry.valid(actor));
+    REQUIRE(registry.view<ObjectComponent>().empty());
+    REQUIRE(registry.view<FormIdComponent>().size() == 1);
+
+    ObjectSystem::Clear(registry);
+    const auto reconnected = ObjectSystem::Setup(registry, 0x5678, 17);
+    REQUIRE(registry.get<FormIdComponent>(reconnected).Id == 0x5678);
+    REQUIRE(registry.get<ObjectComponent>(reconnected).Id == 17);
+    REQUIRE(registry.view<ObjectComponent>().size() == 1);
+}

--- a/Code/tests/server/object_lifecycle.cpp
+++ b/Code/tests/server/object_lifecycle.cpp
@@ -1,0 +1,149 @@
+#include <catch2/catch.hpp>
+
+#include <Components.h>
+#include <Messages/NotifyRemoveObjects.h>
+#include <Services/ObjectLifecycle.h>
+
+#include <algorithm>
+#include <array>
+
+namespace
+{
+entt::entity CreateObject(entt::registry& aRegistry, const GameId& acCell)
+{
+    const auto entity = aRegistry.create();
+    aRegistry.emplace<ObjectComponent>(entity, nullptr);
+    aRegistry.emplace<CellIdComponent>(entity, acCell);
+    return entity;
+}
+
+struct RetirementRecorder
+{
+    explicit RetirementRecorder(entt::registry& aRegistry)
+        : Registry(aRegistry)
+    {
+    }
+
+    void operator()(const NotifyRemoveObjects& acMessage)
+    {
+        for (const auto id : acMessage.ServerIds)
+        {
+            const auto entity = static_cast<entt::entity>(id);
+            ObjectsAliveAtSend &= Registry.valid(entity) && Registry.all_of<ObjectComponent, CellIdComponent>(entity);
+        }
+
+        Messages.push_back(acMessage);
+    }
+
+    entt::registry& Registry;
+    Vector<NotifyRemoveObjects> Messages;
+    bool ObjectsAliveAtSend{true};
+};
+} // namespace
+
+TEST_CASE("An occupied cell retains server objects and their lock state", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto object = CreateObject(registry, cell);
+    auto& lock = registry.get<ObjectComponent>(object).CurrentLockData;
+    lock.IsLocked = true;
+    lock.LockLevel = 75;
+
+    RetirementRecorder sent(registry);
+    const std::array<GameId, 3> playerCells{GameId{1, 0x200}, GameId{1, 0x300}, cell};
+    ObjectLifecycle::RetireCell(registry, cell, playerCells, std::ref(sent));
+
+    REQUIRE(sent.Messages.empty());
+    REQUIRE(registry.valid(object));
+    REQUIRE(registry.get<ObjectComponent>(object).CurrentLockData.IsLocked);
+    REQUIRE(registry.get<ObjectComponent>(object).CurrentLockData.LockLevel == 75);
+}
+
+TEST_CASE("The last departure retires only objects belonging to the complete cell id", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto first = CreateObject(registry, cell);
+    const auto second = CreateObject(registry, cell);
+    const auto otherCell = CreateObject(registry, GameId{1, 0x200});
+    const auto otherMod = CreateObject(registry, GameId{2, 0x100});
+    const auto actor = registry.create();
+    registry.emplace<CellIdComponent>(actor, cell);
+    const auto noCell = registry.create();
+    registry.emplace<ObjectComponent>(noCell, nullptr);
+
+    // Former visitors are now outside this cell, including one with the same
+    // base cell id in a different mod. They must not prevent its retirement.
+    const std::array<GameId, 2> playerCells{GameId{1, 0x200}, GameId{2, 0x100}};
+    RetirementRecorder sent(registry);
+    ObjectLifecycle::RetireCell(registry, cell, playerCells, std::ref(sent));
+
+    REQUIRE(sent.Messages.size() == 1);
+    auto actual = sent.Messages.front().ServerIds;
+    std::sort(actual.begin(), actual.end());
+    Vector<uint32_t> expected{entt::to_integral(first), entt::to_integral(second)};
+    std::sort(expected.begin(), expected.end());
+    REQUIRE(actual == expected);
+    REQUIRE(sent.ObjectsAliveAtSend);
+    REQUIRE_FALSE(registry.valid(first));
+    REQUIRE_FALSE(registry.valid(second));
+    REQUIRE(registry.valid(otherCell));
+    REQUIRE(registry.valid(otherMod));
+    REQUIRE(registry.valid(actor));
+    REQUIRE(registry.valid(noCell));
+}
+
+TEST_CASE("An empty cell does not broadcast an empty retirement", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto other = CreateObject(registry, GameId{1, 0x200});
+    RetirementRecorder sent(registry);
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+
+    REQUIRE(sent.Messages.empty());
+    REQUIRE(registry.valid(other));
+}
+
+TEST_CASE("Repeated departure events are harmless after all players disconnect", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto object = CreateObject(registry, cell);
+    RetirementRecorder sent(registry);
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+    REQUIRE(sent.Messages.size() == 1);
+    REQUIRE(sent.Messages.front().ServerIds == Vector<uint32_t>{entt::to_integral(object)});
+    REQUIRE(sent.ObjectsAliveAtSend);
+    REQUIRE_FALSE(registry.valid(object));
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+    REQUIRE(sent.Messages.size() == 1);
+}
+
+TEST_CASE("Server retirement preserves entity generation bits after reentry", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto original = CreateObject(registry, cell);
+    RetirementRecorder sent(registry);
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+    const auto replacement = CreateObject(registry, cell);
+    REQUIRE(entt::to_entity(original) == entt::to_entity(replacement));
+    REQUIRE(entt::to_integral(original) != entt::to_integral(replacement));
+
+    const std::array<GameId, 1> playerCells{cell};
+    ObjectLifecycle::RetireCell(registry, cell, playerCells, std::ref(sent));
+    REQUIRE(registry.valid(replacement));
+    REQUIRE(sent.Messages.size() == 1);
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+    REQUIRE(sent.Messages.size() == 2);
+    REQUIRE(sent.Messages.back().ServerIds == Vector<uint32_t>{entt::to_integral(replacement)});
+    REQUIRE(sent.ObjectsAliveAtSend);
+    REQUIRE_FALSE(registry.valid(replacement));
+}

--- a/Code/tests/server/xmake.lua
+++ b/Code/tests/server/xmake.lua
@@ -1,0 +1,17 @@
+target("TPServerTests")
+    set_kind("binary")
+    set_group("Tests")
+    add_includedirs("../../server", "../../../Libraries")
+    set_pcxxheader("../../server/Pch.h")
+    add_files("../main.cpp", "*.cpp", "../../server/Services/ObjectLifecycle.cpp")
+    add_deps("SkyrimEncoding", "CommonLib", "Console", "TiltedConnect")
+    add_packages(
+        "tiltedcore",
+        "hopscotch-map",
+        "catch2",
+        "glm",
+        "entt",
+        "spdlog",
+        "gamenetworkingsockets",
+        "lua",
+        "sol2")

--- a/Code/tests/xmake.lua
+++ b/Code/tests/xmake.lua
@@ -15,3 +15,13 @@ target("TPTests")
         "mimalloc",
         "glm",
         "entt")
+
+option("server_tests")
+    set_default(false)
+    set_showmenu(true)
+    set_description("Build isolated server object lifecycle tests")
+option_end()
+
+if has_config("server_tests") then
+    includes("server")
+end

--- a/Code/tests/xmake.lua
+++ b/Code/tests/xmake.lua
@@ -3,13 +3,15 @@ target("TPTests")
     set_kind("binary")
     set_group("Tests")
     add_includedirs(
-        ".", "../encoding")
+        ".", "../encoding", "../client")
     add_headerfiles("**.h")
     add_files("*.cpp")
+    add_files("../client/Systems/ObjectSystem.cpp")
     add_deps("SkyrimEncoding")
     add_packages(
         "tiltedcore",
         "hopscotch-map",
         "catch2",
         "mimalloc",
-        "glm")
+        "glm",
+        "entt")


### PR DESCRIPTION
Prevent repeated remote quest execution, redundant scene dialogue broadcasts,
and stale door/container bindings during cooperative play.

Changes:
- Suppress duplicate quest starts/stops and use the game's IsStageDone
  function to avoid re-running completed quest stages.
- Prevent party members from stopping other players' quests by default,
  configurable through Gameplay:bPartyMembersCanStopQuests.
- Filter scene dialogue and subtitle broadcasts while preserving dialogue
  addressed to the local player.
- Refresh and deduplicate object bindings, clear them on disconnect, and
  notify all clients before retiring server object entities.
- Add regression tests for message encoding, client object bindings, and
  server cell retirement.
- Fix launcher compilation with MSVC 14.51.

Validation:
- Client, server, server runner, and launcher build and link successfully.
- TPTests: 63 assertions across 9 test cases passed.
- TPServerTests: 28 assertions across 5 test cases passed.
- Two-client smoke testing covered connections, chests/doors, and dungeon
  transitions on the integrated gameplay build.

Compatible client/server builds are required for the new server opcode.
Full story and long-scene testing remain pending. The follower transition
issue is deferred.