### PR TITLE
Fix stale replication bindings for doors and containers

### DIFF
--- a/Code/client/Services/Generic/ObjectService.cpp
+++ b/Code/client/Services/Generic/ObjectService.cpp
@@ -1,4 +1,5 @@
 #include <Services/ObjectService.h>
+#include <Systems/ObjectSystem.h>
 
 #include <World.h>
 #include <Events/DisconnectedEvent.h>
@@ -16,6 +17,7 @@
 #include <Messages/NotifyLockChange.h>
 #include <Messages/ScriptAnimationRequest.h>
 #include <Messages/NotifyScriptAnimation.h>
+#include <Messages/NotifyRemoveObjects.h>
 
 #include <PlayerCharacter.h>
 #include <Forms/TESObjectCELL.h>
@@ -35,6 +37,7 @@ ObjectService::ObjectService(World& aWorld, entt::dispatcher& aDispatcher, Trans
     m_lockChangeConnection = aDispatcher.sink<LockChangeEvent>().connect<&ObjectService::OnLockChange>(this);
     m_lockChangeNotifyConnection = aDispatcher.sink<NotifyLockChange>().connect<&ObjectService::OnLockChangeNotify>(this);
     m_assignObjectConnection = aDispatcher.sink<AssignObjectsResponse>().connect<&ObjectService::OnAssignObjectsResponse>(this);
+    m_removeObjectsConnection = aDispatcher.sink<NotifyRemoveObjects>().connect<&ObjectService::OnRemoveObjects>(this);
     m_scriptAnimationConnection = aDispatcher.sink<ScriptAnimationEvent>().connect<&ObjectService::OnScriptAnimationEvent>(this);
     m_scriptAnimationNotifyConnection = aDispatcher.sink<NotifyScriptAnimation>().connect<&ObjectService::OnNotifyScriptAnimation>(this);
 
@@ -78,7 +81,7 @@ bool ShouldSyncObject(const TESObjectREFR* apObject) noexcept
 
 void ObjectService::OnDisconnected(const DisconnectedEvent&) noexcept
 {
-    // TODO(cosideci): clear object components
+    ObjectSystem::Clear(m_world);
 }
 
 void ObjectService::OnCellChange(const CellChangeEvent& acEvent) noexcept
@@ -196,22 +199,16 @@ void ObjectService::OnAssignObjectsResponse(const AssignObjectsResponse& acMessa
     }
 }
 
+void ObjectService::OnRemoveObjects(const NotifyRemoveObjects& acMessage) noexcept
+{
+    // Only remove ECS bindings; the corresponding Skyrim references still exist.
+    ObjectSystem::Remove(m_world, acMessage.ServerIds);
+}
+
 entt::entity ObjectService::CreateObjectEntity(const uint32_t acFormId, const uint32_t acServerId) noexcept
 {
-    const auto view = m_world.view<FormIdComponent, ObjectComponent>();
-
-    auto it = std::find_if(view.begin(), view.end(), [acServerId, view](entt::entity entity) { return view.get<ObjectComponent>(entity).Id == acServerId; });
-
-    if (it != view.end())
-        return *it;
-
-    entt::entity entity = m_world.create();
-    spdlog::info("Created object entity, server id: {:X}, form id {:X}", acServerId, acFormId);
-
-    m_world.emplace<FormIdComponent>(entity, acFormId);
-    m_world.emplace<ObjectComponent>(entity, acServerId);
-
-    return entity;
+    spdlog::debug("Assigning object form id {:X} to server id {:X}", acFormId, acServerId);
+    return ObjectSystem::Setup(m_world, acFormId, acServerId);
 }
 
 void ObjectService::OnActivate(const ActivateEvent& acEvent) noexcept

--- a/Code/client/Services/ObjectService.h
+++ b/Code/client/Services/ObjectService.h
@@ -15,6 +15,7 @@ struct CellChangeEvent;
 struct ScriptAnimationEvent;
 struct AssignObjectsResponse;
 struct NotifyScriptAnimation;
+struct NotifyRemoveObjects;
 
 /**
  * @brief Handles objects in the environment.
@@ -28,6 +29,7 @@ private:
     void OnDisconnected(const DisconnectedEvent&) noexcept;
     void OnCellChange(const CellChangeEvent&) noexcept;
     void OnAssignObjectsResponse(const AssignObjectsResponse&) noexcept;
+    void OnRemoveObjects(const NotifyRemoveObjects&) noexcept;
     void OnActivate(const ActivateEvent&) noexcept;
     void OnActivateNotify(const NotifyActivate&) noexcept;
     void OnLockChange(const LockChangeEvent&) noexcept;
@@ -49,6 +51,7 @@ private:
     entt::scoped_connection m_lockChangeConnection;
     entt::scoped_connection m_lockChangeNotifyConnection;
     entt::scoped_connection m_assignObjectConnection;
+    entt::scoped_connection m_removeObjectsConnection;
     entt::scoped_connection m_scriptAnimationConnection;
     entt::scoped_connection m_scriptAnimationNotifyConnection;
 };

--- a/Code/client/Systems/ObjectSystem.cpp
+++ b/Code/client/Systems/ObjectSystem.cpp
@@ -1,0 +1,71 @@
+#include <TiltedCore/Stl.hpp>
+#include <TiltedCore/Buffer.hpp>
+#include <TiltedCore/Serialization.hpp>
+#include <TiltedCore/Outcome.hpp>
+#include <glm/glm.hpp>
+#include <entt/entt.hpp>
+#include <optional>
+
+using TiltedPhoques::List;
+using TiltedPhoques::Outcome;
+using TiltedPhoques::Set;
+using TiltedPhoques::Vector;
+
+#include <Components.h>
+#include <Systems/ObjectSystem.h>
+
+entt::entity ObjectSystem::Setup(entt::registry& aRegistry, const uint32_t aFormId, const uint32_t aServerId) noexcept
+{
+    const auto view = aRegistry.view<FormIdComponent, ObjectComponent>();
+    entt::entity existingEntity = entt::null;
+    Vector<entt::entity> staleEntities;
+
+    for (const auto entity : view)
+    {
+        const auto& formIdComponent = view.get<FormIdComponent>(entity);
+        const auto& objectComponent = view.get<ObjectComponent>(entity);
+
+        if (formIdComponent.Id == aFormId && existingEntity == entt::null)
+            existingEntity = entity;
+        else if (formIdComponent.Id == aFormId || objectComponent.Id == aServerId)
+            staleEntities.push_back(entity);
+    }
+
+    for (const auto entity : staleEntities)
+        aRegistry.destroy(entity);
+
+    if (existingEntity != entt::null)
+    {
+        aRegistry.get<ObjectComponent>(existingEntity).Id = aServerId;
+        return existingEntity;
+    }
+
+    const entt::entity entity = aRegistry.create();
+    aRegistry.emplace<FormIdComponent>(entity, aFormId);
+    aRegistry.emplace<ObjectComponent>(entity, aServerId);
+    return entity;
+}
+
+void ObjectSystem::Remove(entt::registry& aRegistry, const std::span<const uint32_t> aServerIds) noexcept
+{
+    const Set<uint32_t> serverIds(aServerIds.begin(), aServerIds.end());
+    const auto view = aRegistry.view<ObjectComponent>();
+    Vector<entt::entity> entities;
+
+    for (const auto entity : view)
+    {
+        if (serverIds.count(view.get<ObjectComponent>(entity).Id))
+            entities.push_back(entity);
+    }
+
+    for (const auto entity : entities)
+        aRegistry.destroy(entity);
+}
+
+void ObjectSystem::Clear(entt::registry& aRegistry) noexcept
+{
+    const auto view = aRegistry.view<ObjectComponent>();
+    const Vector<entt::entity> entities(view.begin(), view.end());
+    for (const auto entity : entities)
+        aRegistry.destroy(entity);
+}

--- a/Code/client/Systems/ObjectSystem.h
+++ b/Code/client/Systems/ObjectSystem.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <entt/fwd.hpp>
+
+/**
+ * @brief Manages object replication bindings without changing game references.
+ */
+struct ObjectSystem
+{
+    static entt::entity Setup(entt::registry& aRegistry, uint32_t aFormId, uint32_t aServerId) noexcept;
+    static void Remove(entt::registry& aRegistry, std::span<const uint32_t> aServerIds) noexcept;
+    static void Clear(entt::registry& aRegistry) noexcept;
+};

--- a/Code/encoding/Messages/NotifyRemoveObjects.cpp
+++ b/Code/encoding/Messages/NotifyRemoveObjects.cpp
@@ -1,0 +1,18 @@
+#include <Messages/NotifyRemoveObjects.h>
+
+void NotifyRemoveObjects::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept
+{
+    Serialization::WriteVarInt(aWriter, ServerIds.size());
+    for (const uint32_t serverId : ServerIds)
+        Serialization::WriteVarInt(aWriter, serverId);
+}
+
+void NotifyRemoveObjects::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
+{
+    ServerMessage::DeserializeRaw(aReader);
+
+    const auto count = Serialization::ReadVarInt(aReader);
+    ServerIds.resize(count);
+    for (auto& serverId : ServerIds)
+        serverId = Serialization::ReadVarInt(aReader) & 0xFFFFFFFF;
+}

--- a/Code/encoding/Messages/NotifyRemoveObjects.h
+++ b/Code/encoding/Messages/NotifyRemoveObjects.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Message.h"
+
+struct NotifyRemoveObjects final : ServerMessage
+{
+    static constexpr ServerOpcode Opcode = kNotifyRemoveObjects;
+
+    NotifyRemoveObjects()
+        : ServerMessage(Opcode)
+    {
+    }
+
+    void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
+    void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
+
+    bool operator==(const NotifyRemoveObjects& acRhs) const noexcept { return GetOpcode() == acRhs.GetOpcode() && ServerIds == acRhs.ServerIds; }
+
+    TiltedPhoques::Vector<uint32_t> ServerIds{};
+};

--- a/Code/encoding/Messages/ServerMessageFactory.h
+++ b/Code/encoding/Messages/ServerMessageFactory.h
@@ -58,6 +58,7 @@
 #include <Messages/NotifySetWaypoint.h>
 #include <Messages/NotifyRemoveWaypoint.h>
 #include <Messages/NotifySetTimeResult.h>
+#include <Messages/NotifyRemoveObjects.h>
 
 using TiltedPhoques::UniquePtr;
 
@@ -68,11 +69,14 @@ struct ServerMessageFactory
     template <class T> static auto Visit(T&& func)
     {
         auto s_visitor = CreateMessageVisitor<
-            AuthenticationResponse, AssignCharacterResponse, ServerReferencesMoveRequest, ServerTimeSettings, CharacterSpawnRequest, NotifyInventoryChanges, StringCacheUpdate, NotifyFactionsChanges, NotifyRemoveCharacter, NotifyQuestUpdate, NotifyPlayerList, NotifyPartyInfo, NotifyPartyInvite,
-            NotifyActorValueChanges, NotifyPartyJoined, NotifyPartyLeft, NotifyActorMaxValueChanges, NotifyHealthChangeBroadcast, NotifyActivate, NotifyLockChange, AssignObjectsResponse, NotifyDeathStateChange, NotifyOwnershipTransfer, NotifyObjectInventoryChanges, NotifySpellCast,
-            NotifyProjectileLaunch, NotifyInterruptCast, NotifyAddTarget, NotifyScriptAnimation, NotifyDrawWeapon, NotifyMount, NotifyNewPackage, NotifyRespawn, NotifySyncExperience, NotifyEquipmentChanges, NotifyChatMessageBroadcast, TeleportCommandResponse, NotifyPlayerRespawn, NotifyDialogue,
-            NotifySubtitle, NotifyPlayerDialogue, NotifyActorTeleport, NotifyPlayerLeft, NotifyPlayerJoined, NotifyDialogue, NotifySubtitle, NotifyPlayerDialogue, NotifyPlayerLevel, NotifyPlayerCellChanged, NotifyTeleport, NotifyPlayerHealthUpdate, NotifySettingsChange,
-            NotifyWeatherChange, NotifySetWaypoint, NotifyRemoveWaypoint, NotifySetTimeResult, NotifyRemoveSpell>;
+            AuthenticationResponse, AssignCharacterResponse, ServerReferencesMoveRequest, ServerTimeSettings, CharacterSpawnRequest, NotifyInventoryChanges, StringCacheUpdate,
+            NotifyFactionsChanges, NotifyRemoveCharacter, NotifyQuestUpdate, NotifyPlayerList, NotifyPartyInfo, NotifyPartyInvite, NotifyActorValueChanges, NotifyPartyJoined,
+            NotifyPartyLeft, NotifyActorMaxValueChanges, NotifyHealthChangeBroadcast, NotifyActivate, NotifyLockChange, AssignObjectsResponse, NotifyDeathStateChange,
+            NotifyOwnershipTransfer, NotifyObjectInventoryChanges, NotifySpellCast, NotifyProjectileLaunch, NotifyInterruptCast, NotifyAddTarget, NotifyScriptAnimation,
+            NotifyDrawWeapon, NotifyMount, NotifyNewPackage, NotifyRespawn, NotifySyncExperience, NotifyEquipmentChanges, NotifyChatMessageBroadcast, TeleportCommandResponse,
+            NotifyPlayerRespawn, NotifyDialogue, NotifySubtitle, NotifyPlayerDialogue, NotifyActorTeleport, NotifyPlayerLeft, NotifyPlayerJoined, NotifyDialogue, NotifySubtitle,
+            NotifyPlayerDialogue, NotifyPlayerLevel, NotifyPlayerCellChanged, NotifyTeleport, NotifyPlayerHealthUpdate, NotifySettingsChange, NotifyWeatherChange,
+            NotifySetWaypoint, NotifyRemoveWaypoint, NotifySetTimeResult, NotifyRemoveSpell, NotifyRemoveObjects>;
 
         return s_visitor(std::forward<T>(func));
     }

--- a/Code/encoding/Opcodes.h
+++ b/Code/encoding/Opcodes.h
@@ -112,5 +112,6 @@ enum ServerOpcode : unsigned char
     kNotifySetWaypoint,
     kNotifyRemoveWaypoint,
     kNotifySetTimeResult,
+    kNotifyRemoveObjects,
     kServerOpcodeMax
 };

--- a/Code/server/Services/ObjectLifecycle.cpp
+++ b/Code/server/Services/ObjectLifecycle.cpp
@@ -1,0 +1,36 @@
+#include <Services/ObjectLifecycle.h>
+
+#include <Components.h>
+#include <Messages/NotifyRemoveObjects.h>
+
+#include <algorithm>
+
+namespace ObjectLifecycle
+{
+void RetireCell(entt::registry& aRegistry, const GameId& acCell, std::span<const GameId> aPlayerCells, const SendRemoval& aSendRemoval) noexcept
+{
+    // Preserve the existing policy: occupied current cells are retained.
+    // Tracking all loaded exterior cells remains a separate concern.
+    if (std::find(aPlayerCells.begin(), aPlayerCells.end(), acCell) != aPlayerCells.end())
+        return;
+
+    const auto objectView = aRegistry.view<ObjectComponent, CellIdComponent>();
+    Vector<entt::entity> toDestroy;
+    NotifyRemoveObjects notify{};
+
+    for (const auto entity : objectView)
+    {
+        if (objectView.get<CellIdComponent>(entity).Cell != acCell)
+            continue;
+
+        toDestroy.push_back(entity);
+        notify.ServerIds.push_back(entt::to_integral(entity));
+    }
+
+    if (!notify.ServerIds.empty())
+        aSendRemoval(notify);
+
+    for (const auto entity : toDestroy)
+        aRegistry.destroy(entity);
+}
+} // namespace ObjectLifecycle

--- a/Code/server/Services/ObjectLifecycle.h
+++ b/Code/server/Services/ObjectLifecycle.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <entt/entity/registry.hpp>
+#include <functional>
+#include <span>
+
+struct GameId;
+struct NotifyRemoveObjects;
+
+namespace ObjectLifecycle
+{
+using SendRemoval = std::function<void(const NotifyRemoveObjects&)>;
+
+// aPlayerCells contains the players' current cells after the departure.
+// aSendRemoval must broadcast synchronously before entity identifiers can be reused.
+void RetireCell(entt::registry& aRegistry, const GameId& acCell, std::span<const GameId> aPlayerCells, const SendRemoval& aSendRemoval) noexcept;
+} // namespace ObjectLifecycle

--- a/Code/server/Services/ObjectService.cpp
+++ b/Code/server/Services/ObjectService.cpp
@@ -1,4 +1,5 @@
 #include <Services/ObjectService.h>
+#include <Services/ObjectLifecycle.h>
 
 #include <GameServer.h>
 #include <World.h>
@@ -14,6 +15,7 @@
 #include <Messages/AssignObjectsResponse.h>
 #include <Messages/ScriptAnimationRequest.h>
 #include <Messages/NotifyScriptAnimation.h>
+#include <Messages/NotifyRemoveObjects.h>
 
 ObjectService::ObjectService(World& aWorld, entt::dispatcher& aDispatcher)
     : m_world(aWorld)
@@ -25,34 +27,16 @@ ObjectService::ObjectService(World& aWorld, entt::dispatcher& aDispatcher)
     m_scriptAnimationConnection = aDispatcher.sink<PacketEvent<ScriptAnimationRequest>>().connect<&ObjectService::OnScriptAnimationRequest>(this);
 }
 
-// TODO(cosideci): the cell handling of objects need to be revamped.
-// We already store the location and worldspace of the mod through CellIdComponent.
-// Clients need a message saying the entity was destroyed.
 void ObjectService::OnPlayerLeaveCellEvent(const PlayerLeaveCellEvent& acEvent) noexcept
 {
+    Vector<GameId> playerCells;
+    playerCells.reserve(m_world.GetPlayerManager().Count());
     for (Player* pPlayer : m_world.GetPlayerManager())
-    {
-        if (pPlayer->GetCellComponent().Cell == acEvent.OldCell)
-            return;
-    }
+        playerCells.push_back(pPlayer->GetCellComponent().Cell);
 
-    auto objectView = m_world.view<ObjectComponent, CellIdComponent>();
-    Vector<entt::entity> toDestroy;
-
-    for (auto entity : objectView)
-    {
-        const auto& cellIdComponent = objectView.get<CellIdComponent>(entity);
-
-        if (cellIdComponent.Cell != acEvent.OldCell)
-            continue;
-
-        toDestroy.push_back(entity);
-    }
-
-    for (auto& entity : toDestroy)
-    {
-        m_world.destroy(entity);
-    }
+    // Clients retain object bindings after leaving a cell. Retire those bindings
+    // everywhere before the server entity identifiers can be reused.
+    ObjectLifecycle::RetireCell(m_world, acEvent.OldCell, playerCells, [](const NotifyRemoveObjects& acNotify) { GameServer::Get()->SendToPlayers(acNotify); });
 }
 
 // NOTE: this whole system kinda relies on all objects in a cell being static.

--- a/Code/tests/object_encoding.cpp
+++ b/Code/tests/object_encoding.cpp
@@ -1,0 +1,47 @@
+#include <TiltedCore/Stl.hpp>
+#include <TiltedCore/Allocator.hpp>
+#include <TiltedCore/Buffer.hpp>
+#include <TiltedCore/Serialization.hpp>
+#include <optional>
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <Messages/NotifyRemoveObjects.h>
+#include <Messages/ServerMessageFactory.h>
+
+using namespace TiltedPhoques;
+
+TEST_CASE("Object removal notifications preserve server entity identifiers", "[encoding.objects]")
+{
+    NotifyRemoveObjects sent;
+
+    SECTION("Empty notification")
+    {
+    }
+
+    SECTION("Entity indices and generation bits")
+    {
+        sent.ServerIds = {0, 1, 0x100000, 0xABC12345, 0xFFFFFFFE};
+    }
+
+    SECTION("A cell containing many objects")
+    {
+        for (uint32_t i = 0; i < 1024; ++i)
+            sent.ServerIds.push_back(0xABC00000 + i);
+    }
+
+    Buffer buffer(16384);
+    Buffer::Writer writer(&buffer);
+    sent.Serialize(writer);
+
+    Buffer::Reader reader(&buffer);
+    const ServerMessageFactory factory;
+    auto message = factory.Extract(reader);
+
+    REQUIRE(message);
+    REQUIRE(message->GetOpcode() == NotifyRemoveObjects::Opcode);
+    auto received = CastUnique<NotifyRemoveObjects>(std::move(message));
+    REQUIRE(*received == sent);
+}

--- a/Code/tests/object_lifecycle.cpp
+++ b/Code/tests/object_lifecycle.cpp
@@ -1,0 +1,103 @@
+#include <TiltedCore/Stl.hpp>
+#include <TiltedCore/Buffer.hpp>
+#include <TiltedCore/Serialization.hpp>
+#include <TiltedCore/Outcome.hpp>
+#include <glm/glm.hpp>
+#include <entt/entt.hpp>
+#include <catch2/catch.hpp>
+#include <array>
+#include <optional>
+
+using TiltedPhoques::List;
+using TiltedPhoques::Outcome;
+using TiltedPhoques::Vector;
+
+#include <Components.h>
+#include <Systems/ObjectSystem.h>
+
+TEST_CASE("Object bindings follow reassignment without duplicating forms", "[objects]")
+{
+    entt::registry registry;
+    const auto object = ObjectSystem::Setup(registry, 0x1234, 17);
+
+    SECTION("Repeated assignment keeps the same entity")
+    {
+        REQUIRE(ObjectSystem::Setup(registry, 0x1234, 17) == object);
+        REQUIRE(registry.view<ObjectComponent>().size() == 1);
+    }
+
+    SECTION("Returning to a retired cell changes the server id")
+    {
+        REQUIRE(ObjectSystem::Setup(registry, 0x1234, 0x100011) == object);
+        REQUIRE(registry.get<ObjectComponent>(object).Id == 0x100011);
+        REQUIRE(registry.view<ObjectComponent>().size() == 1);
+
+        // A late or duplicate removal of the old incarnation must not erase the new one.
+        ObjectSystem::Remove(registry, std::array<uint32_t, 1>{17});
+        REQUIRE(registry.valid(object));
+        REQUIRE(registry.get<ObjectComponent>(object).Id == 0x100011);
+    }
+
+    SECTION("A server id reused for another form retires the previous binding")
+    {
+        const auto replacement = ObjectSystem::Setup(registry, 0x5678, 17);
+        REQUIRE_FALSE(registry.valid(object));
+        REQUIRE(registry.get<FormIdComponent>(replacement).Id == 0x5678);
+        REQUIRE(registry.view<ObjectComponent>().size() == 1);
+    }
+
+    SECTION("Legacy duplicates are collapsed on reassignment")
+    {
+        const auto duplicate = registry.create();
+        registry.emplace<FormIdComponent>(duplicate, 0x1234u);
+        registry.emplace<ObjectComponent>(duplicate, 99);
+
+        const auto assigned = ObjectSystem::Setup(registry, 0x1234, 42);
+        REQUIRE(registry.valid(assigned));
+        REQUIRE(registry.get<ObjectComponent>(assigned).Id == 42);
+        REQUIRE(registry.view<ObjectComponent>().size() == 1);
+    }
+}
+
+TEST_CASE("Object removal preserves unrelated entities and tolerates repeated messages", "[objects]")
+{
+    entt::registry registry;
+    const auto first = ObjectSystem::Setup(registry, 0x1234, 17);
+    const auto second = ObjectSystem::Setup(registry, 0x5678, 18);
+    const auto actor = registry.create();
+    registry.emplace<FormIdComponent>(actor, 0x14u);
+    registry.emplace<PlayerComponent>(actor, 17);
+
+    ObjectSystem::Remove(registry, std::array<uint32_t, 3>{17, 17, 999});
+    REQUIRE_FALSE(registry.valid(first));
+    REQUIRE(registry.valid(second));
+    REQUIRE(registry.valid(actor));
+    REQUIRE(registry.view<ObjectComponent>().size() == 1);
+
+    ObjectSystem::Remove(registry, std::array<uint32_t, 1>{17});
+    ObjectSystem::Remove(registry, {});
+    REQUIRE(registry.valid(second));
+    REQUIRE(registry.valid(actor));
+}
+
+TEST_CASE("Disconnect clears both sides of object bindings before reconnect", "[objects]")
+{
+    entt::registry registry;
+    const auto first = ObjectSystem::Setup(registry, 0x1234, 17);
+    const auto second = ObjectSystem::Setup(registry, 0x5678, 18);
+    const auto actor = registry.create();
+    registry.emplace<FormIdComponent>(actor, 0x14u);
+
+    ObjectSystem::Clear(registry);
+    REQUIRE_FALSE(registry.valid(first));
+    REQUIRE_FALSE(registry.valid(second));
+    REQUIRE(registry.valid(actor));
+    REQUIRE(registry.view<ObjectComponent>().empty());
+    REQUIRE(registry.view<FormIdComponent>().size() == 1);
+
+    ObjectSystem::Clear(registry);
+    const auto reconnected = ObjectSystem::Setup(registry, 0x5678, 17);
+    REQUIRE(registry.get<FormIdComponent>(reconnected).Id == 0x5678);
+    REQUIRE(registry.get<ObjectComponent>(reconnected).Id == 17);
+    REQUIRE(registry.view<ObjectComponent>().size() == 1);
+}

--- a/Code/tests/server/object_lifecycle.cpp
+++ b/Code/tests/server/object_lifecycle.cpp
@@ -1,0 +1,149 @@
+#include <catch2/catch.hpp>
+
+#include <Components.h>
+#include <Messages/NotifyRemoveObjects.h>
+#include <Services/ObjectLifecycle.h>
+
+#include <algorithm>
+#include <array>
+
+namespace
+{
+entt::entity CreateObject(entt::registry& aRegistry, const GameId& acCell)
+{
+    const auto entity = aRegistry.create();
+    aRegistry.emplace<ObjectComponent>(entity, nullptr);
+    aRegistry.emplace<CellIdComponent>(entity, acCell);
+    return entity;
+}
+
+struct RetirementRecorder
+{
+    explicit RetirementRecorder(entt::registry& aRegistry)
+        : Registry(aRegistry)
+    {
+    }
+
+    void operator()(const NotifyRemoveObjects& acMessage)
+    {
+        for (const auto id : acMessage.ServerIds)
+        {
+            const auto entity = static_cast<entt::entity>(id);
+            ObjectsAliveAtSend &= Registry.valid(entity) && Registry.all_of<ObjectComponent, CellIdComponent>(entity);
+        }
+
+        Messages.push_back(acMessage);
+    }
+
+    entt::registry& Registry;
+    Vector<NotifyRemoveObjects> Messages;
+    bool ObjectsAliveAtSend{true};
+};
+} // namespace
+
+TEST_CASE("An occupied cell retains server objects and their lock state", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto object = CreateObject(registry, cell);
+    auto& lock = registry.get<ObjectComponent>(object).CurrentLockData;
+    lock.IsLocked = true;
+    lock.LockLevel = 75;
+
+    RetirementRecorder sent(registry);
+    const std::array<GameId, 3> playerCells{GameId{1, 0x200}, GameId{1, 0x300}, cell};
+    ObjectLifecycle::RetireCell(registry, cell, playerCells, std::ref(sent));
+
+    REQUIRE(sent.Messages.empty());
+    REQUIRE(registry.valid(object));
+    REQUIRE(registry.get<ObjectComponent>(object).CurrentLockData.IsLocked);
+    REQUIRE(registry.get<ObjectComponent>(object).CurrentLockData.LockLevel == 75);
+}
+
+TEST_CASE("The last departure retires only objects belonging to the complete cell id", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto first = CreateObject(registry, cell);
+    const auto second = CreateObject(registry, cell);
+    const auto otherCell = CreateObject(registry, GameId{1, 0x200});
+    const auto otherMod = CreateObject(registry, GameId{2, 0x100});
+    const auto actor = registry.create();
+    registry.emplace<CellIdComponent>(actor, cell);
+    const auto noCell = registry.create();
+    registry.emplace<ObjectComponent>(noCell, nullptr);
+
+    // Former visitors are now outside this cell, including one with the same
+    // base cell id in a different mod. They must not prevent its retirement.
+    const std::array<GameId, 2> playerCells{GameId{1, 0x200}, GameId{2, 0x100}};
+    RetirementRecorder sent(registry);
+    ObjectLifecycle::RetireCell(registry, cell, playerCells, std::ref(sent));
+
+    REQUIRE(sent.Messages.size() == 1);
+    auto actual = sent.Messages.front().ServerIds;
+    std::sort(actual.begin(), actual.end());
+    Vector<uint32_t> expected{entt::to_integral(first), entt::to_integral(second)};
+    std::sort(expected.begin(), expected.end());
+    REQUIRE(actual == expected);
+    REQUIRE(sent.ObjectsAliveAtSend);
+    REQUIRE_FALSE(registry.valid(first));
+    REQUIRE_FALSE(registry.valid(second));
+    REQUIRE(registry.valid(otherCell));
+    REQUIRE(registry.valid(otherMod));
+    REQUIRE(registry.valid(actor));
+    REQUIRE(registry.valid(noCell));
+}
+
+TEST_CASE("An empty cell does not broadcast an empty retirement", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto other = CreateObject(registry, GameId{1, 0x200});
+    RetirementRecorder sent(registry);
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+
+    REQUIRE(sent.Messages.empty());
+    REQUIRE(registry.valid(other));
+}
+
+TEST_CASE("Repeated departure events are harmless after all players disconnect", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto object = CreateObject(registry, cell);
+    RetirementRecorder sent(registry);
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+    REQUIRE(sent.Messages.size() == 1);
+    REQUIRE(sent.Messages.front().ServerIds == Vector<uint32_t>{entt::to_integral(object)});
+    REQUIRE(sent.ObjectsAliveAtSend);
+    REQUIRE_FALSE(registry.valid(object));
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+    REQUIRE(sent.Messages.size() == 1);
+}
+
+TEST_CASE("Server retirement preserves entity generation bits after reentry", "[server.objects]")
+{
+    entt::registry registry;
+    const GameId cell{1, 0x100};
+    const auto original = CreateObject(registry, cell);
+    RetirementRecorder sent(registry);
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+    const auto replacement = CreateObject(registry, cell);
+    REQUIRE(entt::to_entity(original) == entt::to_entity(replacement));
+    REQUIRE(entt::to_integral(original) != entt::to_integral(replacement));
+
+    const std::array<GameId, 1> playerCells{cell};
+    ObjectLifecycle::RetireCell(registry, cell, playerCells, std::ref(sent));
+    REQUIRE(registry.valid(replacement));
+    REQUIRE(sent.Messages.size() == 1);
+
+    ObjectLifecycle::RetireCell(registry, cell, {}, std::ref(sent));
+    REQUIRE(sent.Messages.size() == 2);
+    REQUIRE(sent.Messages.back().ServerIds == Vector<uint32_t>{entt::to_integral(replacement)});
+    REQUIRE(sent.ObjectsAliveAtSend);
+    REQUIRE_FALSE(registry.valid(replacement));
+}

--- a/Code/tests/server/xmake.lua
+++ b/Code/tests/server/xmake.lua
@@ -1,0 +1,17 @@
+target("TPServerTests")
+    set_kind("binary")
+    set_group("Tests")
+    add_includedirs("../../server", "../../../Libraries")
+    set_pcxxheader("../../server/Pch.h")
+    add_files("../main.cpp", "*.cpp", "../../server/Services/ObjectLifecycle.cpp")
+    add_deps("SkyrimEncoding", "CommonLib", "Console", "TiltedConnect")
+    add_packages(
+        "tiltedcore",
+        "hopscotch-map",
+        "catch2",
+        "glm",
+        "entt",
+        "spdlog",
+        "gamenetworkingsockets",
+        "lua",
+        "sol2")

--- a/Code/tests/xmake.lua
+++ b/Code/tests/xmake.lua
@@ -3,13 +3,25 @@ target("TPTests")
     set_kind("binary")
     set_group("Tests")
     add_includedirs(
-        ".", "../encoding")
+        ".", "../encoding", "../client")
     add_headerfiles("**.h")
     add_files("*.cpp")
+    add_files("../client/Systems/ObjectSystem.cpp")
     add_deps("SkyrimEncoding")
     add_packages(
         "tiltedcore",
         "hopscotch-map",
         "catch2",
         "mimalloc",
-        "glm")
+        "glm",
+        "entt")
+
+option("server_tests")
+    set_default(false)
+    set_showmenu(true)
+    set_description("Build isolated server object lifecycle tests")
+option_end()
+
+if has_config("server_tests") then
+    includes("server")
+end


### PR DESCRIPTION
Clients can retain stale object replication bindings after the server retires a cell's objects or a connection ends. This change keeps a single binding per local door/container reference, updates reassigned server IDs, and clears object bindings on disconnect.

The server broadcasts `NotifyRemoveObjects` before destroying retired entities. Clients remove matching bindings using the full server entity ID, including generation bits. This removes replication state without deleting the underlying Skyrim references.

Includes regression tests for client binding assignment/removal, message serialization and server cell retirement. Quest progression, scenes and dialogue are outside this change.

## Validation

- Built `SkyrimTogetherClient`, `SkyrimTogetherServer` and `SkyrimServerRunner` on the object-only branch with xmake 3.1.0 and MSVC 14.51.
- `TPTests`: 63 assertions passed in 9 cases.
- `TPServerTests`: 28 assertions passed in 5 cases.
- The launcher build fails at unchanged `MemoryLayout.cpp:35`: this toolset rejects the existing `constinit` initializer containing `reinterpret_cast`. The separate compiler compatibility fix is excluded here.
- Manual container interactions and cell/interior transitions were checked with two local Skyrim clients on the earlier combined build. In-game validation of this extracted branch remains pending; the automated tests do not execute Skyrim.

Client and server must use matching builds because this adds a server message. The existing current-cell retention policy is preserved; tracking all loaded exterior cells and persistent container state are not addressed here.

Separates the object lifecycle changes previously included in #890.
