### PR TITLE
Exclude faction jail containers from object sync (#700)

### DIFF
--- a/Code/client/Games/Skyrim/Forms/TESFaction.h
+++ b/Code/client/Games/Skyrim/Forms/TESFaction.h
@@ -3,7 +3,43 @@
 #include <Forms/TESForm.h>
 #include <Components/TESFullName.h>
 
+struct TESObjectREFR;
+struct BGSListForm;
+struct BGSOutfit;
+
+struct TESReactionForm : BaseFormComponent
+{
+    void* reactionListHead; // BSSimpleList<GROUP_REACTION*>
+    void* reactionListNext;
+    uint8_t groupFormType;
+    uint8_t pad19[7];
+};
+
+static_assert(sizeof(TESReactionForm) == 0x20);
+
 struct TESFaction : TESForm
 {
+    // Where the game sends the player's belongings when they are arrested by this faction.
+    struct CrimeData
+    {
+        TESObjectREFR* jailMarker;               // JAIL
+        TESObjectREFR* waitMarker;               // WAIT
+        TESObjectREFR* stolenGoodsContainer;     // STOL: stolen items taken on arrest
+        TESObjectREFR* playerInventoryContainer; // PLCN: the rest of the player's inventory, returned on release
+        BGSListForm* crimeGroup;                 // CRGR
+        BGSOutfit* jailOutfit;                   // JOUT
+        uint8_t crimeValues[0x18];               // CRVA
+    };
+
     TESFullName fullname;
+    TESReactionForm reactionForm;
+    uint8_t crimeGoldMap[0x30]; // BSTHashMap<const TESNPC*, uint32_t>
+    uint32_t factionFlags;      // DATA
+    uint32_t pad84;
+    CrimeData crimeData;
 };
+
+static_assert(offsetof(TESFaction, fullname) == 0x20);
+static_assert(offsetof(TESFaction, crimeData) == 0x88);
+static_assert(offsetof(TESFaction, crimeData.stolenGoodsContainer) == 0x98);
+static_assert(offsetof(TESFaction, crimeData.playerInventoryContainer) == 0xA0);

--- a/Code/client/Games/TES.h
+++ b/Code/client/Games/TES.h
@@ -5,6 +5,7 @@ struct TESObjectCELL;
 struct TESWorldSpace;
 struct NiPoint3;
 struct TESForm;
+struct TESFaction;
 struct Actor;
 struct ImageSpaceModifierInstance;
 
@@ -109,12 +110,17 @@ struct ModManager
     Mod* GetByName(const char* acpName) const noexcept;
     TESObjectCELL* GetCellFromCoordinates(int32_t aX, int32_t aY, TESWorldSpace* aWorldSpace, bool aSpawnCell) noexcept;
 
-    uint8_t pad0[0x748];
+    // Form arrays start at 0x10 and are indexed by FormType, 0x18 bytes each.
+    uint8_t pad0[0x118];
+    GameArray<TESFaction*> factions;
+    uint8_t pad130[0x748 - 0x130];
     GameArray<TESQuest*> quests;
     uint8_t pad760[0xD60 - 0x760];
     GameList<Mod> mods;
 };
 
+static_assert(offsetof(ModManager, factions) == 0x118);
+static_assert(offsetof(ModManager, quests) == 0x748);
 static_assert(offsetof(ModManager, mods) == 0xD60);
 
 struct Setting

--- a/Code/client/Services/Generic/ObjectService.cpp
+++ b/Code/client/Services/Generic/ObjectService.cpp
@@ -21,6 +21,8 @@
 #include <Forms/TESObjectCELL.h>
 #include <Forms/TESWorldSpace.h>
 #include <Forms/BGSEncounterZone.h>
+#include <Forms/TESFaction.h>
+#include <Games/TES.h>
 
 #include <inttypes.h>
 
@@ -60,11 +62,44 @@ bool IsPlayerHome(const TESObjectCELL* pCell) noexcept
     return false;
 }
 
-bool ShouldSyncObject(const TESObjectREFR* apObject) noexcept
+// Containers where the game stashes an arrested player's belongings, taken from the crime data of every
+// loaded faction. Sending a player to jail moves their whole inventory into the faction's player inventory
+// container (stolen goods go to the stolen goods container) and hands it back on release, so these are
+// per-player storage: if they were synced, the first player to enter the jail cell would overwrite the
+// stash of everyone who follows, and the others would walk out with the wrong inventory (#700).
+// Only pointers are compared here; the crime data itself is never dereferenced.
+Set<const TESObjectREFR*> GetPlayerStashContainers() noexcept
+{
+    Set<const TESObjectREFR*> containers{};
+
+    ModManager* pModManager = ModManager::Get();
+    if (!pModManager)
+        return containers;
+
+    for (const TESFaction* pFaction : pModManager->factions)
+    {
+        if (!pFaction)
+            continue;
+
+        if (pFaction->crimeData.playerInventoryContainer)
+            containers.insert(pFaction->crimeData.playerInventoryContainer);
+
+        if (pFaction->crimeData.stolenGoodsContainer)
+            containers.insert(pFaction->crimeData.stolenGoodsContainer);
+    }
+
+    return containers;
+}
+
+bool ShouldSyncObject(const TESObjectREFR* apObject, const Set<const TESObjectREFR*>& acPlayerStashContainers) noexcept
 {
     if (!apObject)
         return false;
 
+    if (acPlayerStashContainers.contains(apObject))
+        return false;
+
+    // Quest chests that take the player's whole inventory without going through faction crime data.
     switch (apObject->formID)
     {
     case 0x39CF1: // Don't sync the chest in the "Diplomatic Immunity" quest
@@ -117,9 +152,11 @@ void ObjectService::OnCellChange(const CellChangeEvent& acEvent) noexcept
 
     AssignObjectsRequest request{};
 
+    const Set<const TESObjectREFR*> playerStashContainers = GetPlayerStashContainers();
+
     for (TESObjectREFR* pObject : objects)
     {
-        if (!ShouldSyncObject(pObject))
+        if (!ShouldSyncObject(pObject, playerStashContainers))
         {
             spdlog::warn("Excluding sync for {:X}", pObject->formID);
             continue;


### PR DESCRIPTION
Fixes #700

## What was wrong

When a player is sent to jail, the game moves their whole inventory into the jail's prisoner belongings container (stolen goods go to the evidence chest) and hands it back when the sentence is served. Both are regular world containers, so `ObjectService::OnCellChange` registered them on the server with the first player's stash as their inventory. When a second party member entered the same jail cell, the server answered with that inventory and `OnAssignObjectsResponse` replaced the second player's local chest contents with the leader's items. On release, the game gave the second player the leader's belongings and their own were gone.

Example: leader and member both get arrested in Whiterun and serve their time. Before this change, the member walks out with the leader's inventory (except worn items). After it, each player gets their own items back.

Two quest chests (`0x39CF1` in Diplomatic Immunity and `0x3EF03` in No One Escapes Cidhna Mine) were already excluded by hard-coded form ID for the same reason. As noted in the issue, that does not scale: every hold has its own jail chests, and mods add more.

## What changes

Every faction that can arrest the player stores, in its crime data, the container that receives the player's inventory (`PLCN`) and the one that receives stolen goods (`STOL`). On cell change the client now walks the loaded factions (`TESDataHandler` faction array) and excludes those containers from object sync, so each client keeps its own copy and the game returns each player's own items. The check compares pointers only and never dereferences the crime data, so a layout mismatch cannot crash the client; it would just fall back to the previous behaviour for that faction.

The two hard-coded quest chests stay excluded because they are quest-owned containers, not faction jail containers.

- `Code/client/Games/Skyrim/Forms/TESFaction.h`: crime data layout.
- `Code/client/Games/TES.h`: faction form array in the data handler, with offset asserts.
- `Code/client/Services/Generic/ObjectService.cpp`: collect the containers and exclude them in `ShouldSyncObject`.

## How it was checked

- `SkyrimTogetherClient` builds and `TPTests` pass on this branch (based on `dev`).
- In-game verification with two arrested party members is still pending. Expected result: each player gets their own inventory back, and the client log shows `Excluding sync for <chest id>` for the prisoner belongings and evidence chests when entering the jail cell, while other containers in the cell keep syncing.

Limited to object sync exclusion; no changes to actor inventories, ownership transfer, protocol or quest logic.
